### PR TITLE
Add proposal for Intl.NumberFormat round option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ ES Intl Proposals follow [this process document](https://docs.google.com/documen
 |🚀| Proposal                                | Champion      | Stage | Notes
 |---|---------------------------------------|-------------- | ------|------
 |   | [Fix 9.2.3 LookupMatcher algorithm][] | Rafael Xavier |     0 |    
+|   | [Intl.NumberFormat round option][]    | Rafael Xavier |     0 |
 
 [Fix 9.2.3 LookupMatcher algorithm]: https://github.com/rxaviers/ecma402-fix-lookup-matcher
+[Intl.NumberFormat round option]: https://github.com/rxaviers/ecma402-number-format-round-option
 
 🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.
 


### PR DESCRIPTION
Allows to select a rounding function for NumberFormat different than round "half-even". For example: ceil, floor, or truncate.

See: https://github.com/rxaviers/ecma402-number-format-round-option