### PR TITLE
Migrate to <emu-import href="...">

### DIFF
--- a/spec/source/index.html
+++ b/spec/source/index.html
@@ -32,19 +32,19 @@
 <h3 class="orange">Standard ECMA-402</h3>
 <h3 class="orange">2<sup>nd</sup> Edition / June 2015</h3>
 
-<link rel="import" href="./copyright.html">
-<link rel="import" href="./introduction.html">
-<link rel="import" href="./scope.html">
-<link rel="import" href="./conformance.html">
-<link rel="import" href="./normative-references.html">
-<link rel="import" href="./overview.html">
-<link rel="import" href="./conventions.html">
-<link rel="import" href="./locales-currencies-tz.html">
-<link rel="import" href="./requirements.html">
-<link rel="import" href="./intl.html">
-<link rel="import" href="./negotiation.html">
-<link rel="import" href="./collator.html">
-<link rel="import" href="./numberformat.html">
-<link rel="import" href="./datetimeformat.html">
-<link rel="import" href="./locale-sensitive-functions.html">
-<link rel="import" href="./annexes.html">
+<emu-import href="./copyright.html"></emu-import>
+<emu-import href="./introduction.html"></emu-import>
+<emu-import href="./scope.html"></emu-import>
+<emu-import href="./conformance.html"></emu-import>
+<emu-import href="./normative-references.html"></emu-import>
+<emu-import href="./overview.html"></emu-import>
+<emu-import href="./conventions.html"></emu-import>
+<emu-import href="./locales-currencies-tz.html"></emu-import>
+<emu-import href="./requirements.html"></emu-import>
+<emu-import href="./intl.html"></emu-import>
+<emu-import href="./negotiation.html"></emu-import>
+<emu-import href="./collator.html"></emu-import>
+<emu-import href="./numberformat.html"></emu-import>
+<emu-import href="./datetimeformat.html"></emu-import>
+<emu-import href="./locale-sensitive-functions.html"></emu-import>
+<emu-import href="./annexes.html"></emu-import>


### PR DESCRIPTION
@caridy newer versions of ecmarkup have replaced `<link ...>` with `<emu-import ...>`. This patch updates the spec source. 