### PR TITLE
editorial fixes and alignment with ES2016 conventions

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -49,46 +49,39 @@
 
       <emu-alg>
         1. If collator has an [[initializedIntlObject]] internal slot with value *true*, throw a *TypeError* exception.
-        2. Set collator.[[initializedIntlObject]] to *true*.
-        3. Let _requestedLocales_ be CanonicalizeLocaleList(_locales_).
-        4. ReturnIfAbrupt(_requestedLocales_).
-        5. If _options_ is *undefined*, then
+        1. Set collator.[[initializedIntlObject]] to *true*.
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+        1. If _options_ is *undefined*, then
           1. Let _options_ be ObjectCreate(*%ObjectPrototype%*).
-        6. Else
-          1. Let _options_ be ToObject(_options_).
-          1. ReturnIfAbrupt(_options_).
-        7. Let _u_ be GetOption(_options_, *"usage"*, *"string"*, «*"sort"*, *"search"*», *"sort"*).
-        8. ReturnIfAbrupt(_u_).
-        9. Set _collator_.[[usage]] to _u_.
-        10. If _u_ is *"sort"*, then
-          1. Let _localeData_ be the value of *%Collator%*.[[sortLocaleData]];
-        11. Else
+        1. Else
+          1. Let _options_ be ? ToObject(_options_).
+        1. Let _u_ be ? GetOption(_options_, *"usage"*, *"string"*, «*"sort"*, *"search"*», *"sort"*).
+        1. Set _collator_.[[usage]] to _u_.
+        1. If _u_ is *"sort"*, then
+          1. Let _localeData_ be the value of *%Collator%*.[[sortLocaleData]].
+        1. Else,
           1. Let _localeData_ be the value of *%Collator%*.[[searchLocaleData]].
-        12. Let _opt_ be a new Record.
-        13. Let _matcher_ be GetOption(_options_, *"localeMatcher"*, *"string"*, «*"lookup"*, *"best fit"*», *"best fit"*).
-        14. ReturnIfAbrupt(_matcher_).
-        15. Set _opt_.[[localeMatcher]] to _matcher_.
-        16. For each row in <emu-xref href="#table-1">Table 1</emu-xref>, except the header row, do:
+        1. Let _opt_ be a new Record.
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, «*"lookup"*, *"best fit"*», *"best fit"*).
+        1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. For each row in <emu-xref href="#table-1">Table 1</emu-xref>, except the header row, do:
           1. Let _key_ be the name given in the Key column of the row.
           1. Let _prop_ be the name given in the Property column of the row.
           1. Let _type_ be the string given in the Type column of the row.
           1. Let _list_ be a List containing the Strings given in the Values column of the row, or *undefined* if no strings are given.
-          1. Let _value_ be GetOption(_options_, _prop_, _type_, _list_, *undefined*).
-          1. ReturnIfAbrupt(_value_).
+          1. Let _value_ be ? GetOption(_options_, _prop_, _type_, _list_, *undefined*).
           1. If the string given in the Type column of the row is *"boolean"* and value is not *undefined*, then
-            1. Let _value_ be ToString(_value_).
-            1. ReturnIfAbrupt(_value_).
+            1. Let _value_ be ? ToString(_value_).
           1. Set _opt_.[[&lt;_key_&gt;]] to _value_.
-        17. Let _relevantExtensionKeys_ be the value of *%Collator%*.[[relevantExtensionKeys]].
-        18. Let _r_ be ResolveLocale(*%Collator%*.[[availableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
-        19. Set _collator_.[[locale]] to the value of _r_.[[locale]].
-        20. Let _k_ be 0.
-        21. Let _lenValue_ be Get(_relevantExtensionKeys_, *"length"*).
-        22. Let _len_ be ToLength(_lenValue_).
-        23. Repeat while _k_ < _len_:
+        1. Let _relevantExtensionKeys_ be the value of *%Collator%*.[[relevantExtensionKeys]].
+        1. Let _r_ be ResolveLocale(*%Collator%*.[[availableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
+        1. Set _collator_.[[locale]] to the value of _r_.[[locale]].
+        1. Let _k_ be 0.
+        1. Let _lenValue_ be Get(_relevantExtensionKeys_, `"length"`).
+        1. Let _len_ be ToLength(_lenValue_).
+        1. Repeat while _k_ < _len_:
           1. Let _Pk_ be ToString(_k_).
-          1. Let _key_ be Get(_relevantExtensionKeys_, _Pk_).
-          1. ReturnIfAbrupt(_key_).
+          1. Let _key_ be ? Get(_relevantExtensionKeys_, _Pk_).
           1. If _key_ is *"co"*, then
             1. Let _property_ be *"collation"*.
             1. Let _value_ be the value of _r_.[[co]].
@@ -99,21 +92,20 @@
             1. If the name given in the Type column of the row is *"boolean"*, let _value_ be the result of comparing value with *"true"*.
           1. Set _collator_.[[&lt;_property_&gt;]] to _value_.
           1. Increase _k_ by 1.
-        24. Let _s_ be GetOption(_options_, *"sensitivity"*, *"string"*, «*"base"*, *"accent"*, *"case"*, *"variant"*», *undefined*).
-        25. ReturnIfAbrupt(_s_).
-        26. If _s_ is *undefined*, then
-          1. If _u_ is *"sort"*, then let _s_ be *"variant"*.
-          1. Else
+        1. Let _s_ be ? GetOption(_options_, *"sensitivity"*, *"string"*, «*"base"*, *"accent"*, *"case"*, *"variant"*», *undefined*).
+        1. If _s_ is *undefined*, then
+          1. If _u_ is *"sort"*, then
+            1. Let _s_ be *"variant"*.
+          1. Else,
             1. Let _dataLocale_ be the value of _r_.[[dataLocale]].
             1. Let _dataLocaleData_ be Get(_localeData_, _dataLocale_).
             1. Let _s_ be Get(_dataLocaleData_, *"sensitivity"*).
-        27. Set _collator_.[[sensitivity]] to _s_.
-        28. Let _ip_ be GetOption(_options_, *"ignorePunctuation"*, *"boolean"*, *undefined*, *false*).
-        29. ReturnIfAbrupt(_ip_).
-        30. Set _collator_.[[ignorePunctuation]] to _ip_.
-        31. Set _collator_.[[boundCompare]] to *undefined*.
-        32. Set _collator_.[[initializedCollator]] to *true*.
-        33. Return _collator_.
+        1. Set _collator_.[[sensitivity]] to _s_.
+        1. Let _ip_ be ? GetOption(_options_, *"ignorePunctuation"*, *"boolean"*, *undefined*, *false*).
+        1. Set _collator_.[[ignorePunctuation]] to _ip_.
+        1. Set _collator_.[[boundCompare]] to *undefined*.
+        1. Set _collator_.[[initializedCollator]] to *true*.
+        1. Return _collator_.
       </emu-alg>
 
     </emu-clause>
@@ -127,9 +119,8 @@
 
       <emu-alg>
         1. If _NewTarget_ is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be _NewTarget_.
-        2. Let _collator_ be OrdinaryCreateFromConstructor(_newTarget_, *%CollatorPrototype%*).
-        3. ReturnIfAbrupt(_collator_).
-        4. Return InitializeCollator(_collator_, _locales_, _options_).
+        1. Let _collator_ be ? OrdinaryCreateFromConstructor(_newTarget_, *%CollatorPrototype%*).
+        1. Return InitializeCollator(_collator_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -138,7 +129,7 @@
     <h1>Properties of the Intl.Collator Constructor</h1>
 
     <p>
-      Besides the internal slots and the *length* property (whose value is 0), the Intl.Collator constructor has the following properties:
+      Besides the internal slots and the `length` property (whose value is 0), the Intl.Collator constructor has the following properties:
     </p>
 
     <emu-clause id="sec-Intl.Collator.prototype">
@@ -161,13 +152,12 @@
       </p>
 
       <emu-alg>
-        1. Let _requestedLocales_ be CanonicalizeLocaleList(_locales_).
-        2. ReturnIfAbrupt(_requestedLocales_).
-        3. Return SupportedLocales(*%Collator%*.[[availableLocales]], _requestedLocales_, _options_).
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+        1. Return SupportedLocales(*%Collator%*.[[availableLocales]], _requestedLocales_, _options_).
       </emu-alg>
 
       <p>
-        The value of the *length* property of the *supportedLocalesOf* method is 1.
+        The value of the `length` property of the *supportedLocalesOf* method is 1.
       </p>
     </emu-clause>
 
@@ -187,7 +177,7 @@
       </p>
 
       <ul>
-        <li>The first element of [[sortLocaleData]][locale].co and [[searchLocaleData]][locale].co must be null for all locale values.</li>
+        <li>The first element of [[sortLocaleData]][locale].co and [[searchLocaleData]][locale].co must be *null* for all locale values.</li>
         <li>The values *"standard"* and *"search"* must not be used as elements in any [[sortLocaleData]][locale].co and [[searchLocaleData]][locale].co array.</li>
         <li>[[searchLocaleData]][locale] must have a sensitivity property with a String value equal to *"base"*, *"accent"*, *"case"*, or *"variant"* for all locale values.</li>
       </ul>
@@ -237,13 +227,15 @@
       </p>
 
       <emu-alg>
-        1. Let _collator_ be this Collator object.
-        2. If _collator_.[[boundCompare]] is *undefined*, then
-          1. Let _F_ be a new built-in function object as defined in 11.3.4.
-          1. The value of _F_'s length property is 2.
-          1. Let _bc_ be BoundFunctionCreate(_F_, «*this* value»).
+        1. Let _collator_ be *this* value.
+        1. If Type(_collator_) is not Object, throw a *TypeError* exception.
+        1. If _collator_ does not have a [[boundCompare]] internal slot, throw a *TypeError* exception.
+        1. If _collator_.[[boundCompare]] is *undefined*, then
+          1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-collator-compare-functions"></emu-xref>.
+          1. The value of _F_'s `length` property is 2.
+          1. Let _bc_ be BoundFunctionCreate(_F_, _collator_).
           1. Set _collator_.[[boundCompare]] to _bc_.
-        3. Return _collator_.[[boundCompare]].
+        1. Return _collator_.[[boundCompare]].
       </emu-alg>
 
       <emu-note>
@@ -265,14 +257,12 @@
 
       <emu-alg>
         1. Let _collator_ be the *this* value.
-        2. Assert: Type(collator) is Object and collator has an [[initializedCollator]] internal slot whose value is *true*.
-        3. If _x_ is not provided, let _x_ be undefined.
-        4. If _y_ is not provided, let _y_ be undefined.
-        5. Let _X_ be ToString(_x_).
-        6. ReturnIfAbrupt(_X_).
-        7. Let _Y_ be ToString(_y_).
-        8. ReturnIfAbrupt(_Y_).
-        9. Return CompareStrings(_collator_, _X_, _Y_).
+        1. Assert: Type(collator) is Object and collator has an [[initializedCollator]] internal slot whose value is *true*.
+        1. If _x_ is not provided, let _x_ be undefined.
+        1. If _y_ is not provided, let _y_ be undefined.
+        1. Let _X_ be ? ToString(_x_).
+        1. Let _Y_ be ? ToString(_y_).
+        1. Return CompareStrings(_collator_, _X_, _Y_).
       </emu-alg>
 
       <p>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -48,12 +48,12 @@
       </p>
 
       <emu-alg>
-        1. If collator has an [[initializedIntlObject]] internal slot with value *true*, throw a *TypeError* exception.
-        1. Set collator.[[initializedIntlObject]] to *true*.
+        1. If _collator_ has an [[initializedIntlObject]] internal slot with value *true*, throw a *TypeError* exception.
+        1. Set _collator_.[[initializedIntlObject]] to *true*.
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
           1. Let _options_ be ObjectCreate(*%ObjectPrototype%*).
-        1. Else
+        1. Else,
           1. Let _options_ be ? ToObject(_options_).
         1. Let _u_ be ? GetOption(_options_, *"usage"*, *"string"*, «*"sort"*, *"search"*», *"sort"*).
         1. Set _collator_.[[usage]] to _u_.
@@ -257,7 +257,7 @@
 
       <emu-alg>
         1. Let _collator_ be the *this* value.
-        1. Assert: Type(collator) is Object and collator has an [[initializedCollator]] internal slot whose value is *true*.
+        1. Assert: Type(_collator_) is Object and _collator_ has an [[initializedCollator]] internal slot whose value is *true*.
         1. If _x_ is not provided, let _x_ be undefined.
         1. If _y_ is not provided, let _y_ be undefined.
         1. Let _X_ be ? ToString(_x_).

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -77,7 +77,7 @@
         1. Let _r_ be ResolveLocale(*%Collator%*.[[availableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
         1. Set _collator_.[[locale]] to the value of _r_.[[locale]].
         1. Let _k_ be 0.
-        1. Let _lenValue_ be Get(_relevantExtensionKeys_, `"length"`).
+        1. Let _lenValue_ be Get(_relevantExtensionKeys_, *"length"*).
         1. Let _len_ be ToLength(_lenValue_).
         1. Repeat while _k_ < _len_:
           1. Let _Pk_ be ToString(_k_).
@@ -129,7 +129,7 @@
     <h1>Properties of the Intl.Collator Constructor</h1>
 
     <p>
-      Besides the internal slots and the `length` property (whose value is 0), the Intl.Collator constructor has the following properties:
+      Besides the internal slots and the *length* property (whose value is 0), the Intl.Collator constructor has the following properties:
     </p>
 
     <emu-clause id="sec-Intl.Collator.prototype">
@@ -157,7 +157,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *supportedLocalesOf* method is 1.
+        The value of the *length* property of the *supportedLocalesOf* method is 1.
       </p>
     </emu-clause>
 
@@ -232,7 +232,7 @@
         1. If _collator_ does not have a [[boundCompare]] internal slot, throw a *TypeError* exception.
         1. If _collator_.[[boundCompare]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-collator-compare-functions"></emu-xref>.
-          1. The value of _F_'s `length` property is 2.
+          1. The value of _F_'s *length* property is 2.
           1. Let _bc_ be BoundFunctionCreate(_F_, _collator_).
           1. Set _collator_.[[boundCompare]] to _bc_.
         1. Return _collator_.[[boundCompare]].

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -151,12 +151,10 @@
             1. If _value_ is not *undefined*, let _needDefaults_ be *false*.
         1. If _needDefaults_ is *true* and _defaults_ is either *"date"* or *"all"*, then
           1. For each of the property names *"year"*, *"month"*, *"day"*:
-            1. Let _status_ be the result of calling CreateDatePropertyOrThrow(_options_, _prop_, *"numeric"*).
-            1. ReturnIfAbrupt(_status_).
+            1. Let _status_ be ? CreateDataPropertyOrThrow(_options_, _prop_, *"numeric"*).
         1. If _needDefaults_ is *true* and _defaults_ is either *"time"* or *"all"*, then
           1. For each of the property names *"hour"*, *"minute"*, *"second"*:
-            1. Let _status_ be the result of calling CreateDatePropertyOrThrow(_options_, _prop_, *"numeric"*).
-            1. ReturnIfAbrupt(_status_).
+            1. Let _status_ be ? CreateDataPropertyOrThrow(_options_, _prop_, *"numeric"*).
         1. Return _options_.
       </emu-alg>
 
@@ -175,7 +173,7 @@
         1. Let _bestFormat_ be *undefined*.
         1. Let _k_ be 0.
         1. Assert: _formats_ is an Array object.
-        1. Let _len_ be Get(_formats_, `"length"`).
+        1. Let _len_ be Get(_formats_, *"length"*).
         1. Repeat while _k_ < _len_:
           1. Let _format_ be Get(_formats_, ToString(_k_)).
           1. Let _score_ be 0.
@@ -224,7 +222,7 @@
     <h1>Properties of the Intl.DateTimeFormat Constructor</h1>
 
     <p>
-      Besides the internal slots and the `length` property (whose value is 0), the Intl.DateTimeFormat constructor has the following properties:
+      Besides the internal slots and the *length* property (whose value is 0), the Intl.DateTimeFormat constructor has the following properties:
     </p>
 
     <emu-clause id="sec-Intl.DateTimeFormat.prototype">
@@ -252,7 +250,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *supportedLocalesOf* method is 1.
+        The value of the *length* property of the *supportedLocalesOf* method is 1.
       </p>
     </emu-clause>
 
@@ -355,7 +353,7 @@
         1. If _dtf_ does not have a [[boundFormat]] internal slot, throw a *TypeError* exception.
         1. If the [[boundFormat]] internal slot of _dtf_ is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-datetime-format-functions"></emu-xref>.
-          1. The value of _F_’s `length` property is 1.
+          1. The value of _F_’s *length* property is 1.
           1. Let _bf_ be BoundFunctionCreate(F, _dft_).
           1. Set _dtf_.[[boundFormat]] to _bf_.
         1. Return _dtf_.[[boundFormat]].
@@ -413,7 +411,7 @@
               1. Let _fv_ be FormatNumber(_nf_, _v_).
             1. Else if f is *"2-digit"*, then
               1. Let _fv_ be FormatNumber(_nf2_, _v_).
-              1. If the `length` property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
+              1. If the *length* property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
             1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _f_ in the desired form; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _dateTimeFormat_ has a [[day]] internal slot. If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[inDST]] field of _tm_, and if the implementation does not have a localized representation of _f_, then use _f_ itself.
             1. Replace the substring of _result_ that consists of *"{"*, p, and *"}"*, with _fv_.
         1. If _dateTimeFormat_.[[hour12]] is *true*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -74,13 +74,10 @@
       <emu-alg>
         1. If _dateTimeFormat_.[[initializedIntlObject]] is *true*, throw a *TypeError* exception.
         1. Set _dateTimeFormat_.[[initializedIntlObject]] to *true*.
-        1. Let _requestedLocales_ be CanonicalizeLocaleList(_locales_).
-        1. ReturnIfAbrupt(_requestedLocales_),
-        1. Let _options_ be ToDateTimeOptions(_options_, *"any"*, *"date"*).
-        1. ReturnIfAbrupt(_options_).
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+        1. Let _options_ be ? ToDateTimeOptions(_options_, *"any"*, *"date"*).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be GetOption(_options_, *"localeMatcher"*, *"string"*, «*"lookup"*, *"best fit"*», *"best fit"*).
-        1. ReturnIfAbrupt(_matcher_).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, «*"lookup"*, *"best fit"*», *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be the value of *%DateTimeFormat%*.[[localeData]].
         1. Let _r_ be ResolveLocale( *%DateTimeFormat%*.[[availableLocales]], _requestedLocales_, opt, *%DateTimeFormat%*.[[relevantExtensionKeys]], _localeData_).
@@ -88,11 +85,9 @@
         1. Set _dateTimeFormat_.[[calendar]] to the value of _r_.[[ca]].
         1. Set _dateTimeFormat_.[[numberingSystem]] to the value of _r_.[[nu]].
         1. Let _dataLocale_ be the value of _r_.[[dataLocale]].
-        1. Let _tz_ be Get(_options_, *"timeZone"*).
-        1. ReturnIfAbrupt(_tz_).
+        1. Let _tz_ be ? Get(_options_, *"timeZone"*).
         1. If _tz_ is not *undefined*, then
-          1. Let _tz_ be ToString(_tz_).
-          1. ReturnIfAbrupt(_tz_).
+          1. Let _tz_ be ? ToString(_tz_).
           1. If the result of IsValidTimeZoneName(_tz_) is *false*, then
             1. Throw a *RangeError* exception.
           1. Let _tz_ be CanonicalizeTimeZoneName(_tz_).
@@ -102,16 +97,14 @@
         1. Let _opt_ be a new Record.
         1. For each row of <emu-xref href="#table-3">Table 3</emu-xref>, except the header row, do:
           1. Let _prop_ be the name given in the Property column of the row.
-          1. Let _value_ be GetOption(_options_, _prop_, *"string"*, «the strings given in the Values column of the row», *undefined*).
-          1. ReturnIfAbrupt(_value_).
+          1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, «the strings given in the Values column of the row», *undefined*).
           1. Set _opt_.[[<_prop_>]] to _value_.
         1. Let _dataLocaleData_ be Get(_localeData_, _dataLocale_).
         1. Let _formats_ be Get(_dataLocaleData_, *"formats"*).
-        1. Let _matcher_ be GetOption(_options_, *"formatMatcher"*, *"string"*, «*"basic"*, *"best fit"*», *"best fit"*).
-        1. ReturnIfAbrupt(_matcher_).
+        1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, «*"basic"*, *"best fit"*», *"best fit"*).
         1. If _matcher_ is *"basic"*, then
           1. Let _FormatMatcher_ be the abstract operation BasicFormatMatcher.
-        1. Else
+        1. Else,
           1. Let _FormatMatcher_ be the abstract operation BestFitFormatMatcher.
         1. Let _bestFormat_ be _FormatMatcher_(_opt_, _formats_).
         1. For each row in <emu-xref href="#table-3">Table 3</emu-xref>, except the header row, do
@@ -119,8 +112,7 @@
           1. Let _p_ be Get(_bestFormat_, _prop_).
           1. If _p_ not *undefined*, then
             1. Set _dateTimeFormat_.[[<_prop_>]] to _p_.
-        1. Let _hr12_ be GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
-        1. ReturnIfAbrupt(_hr12_).
+        1. Let _hr12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
         1. If _dateTimeFormat_ has an internal slot [[hour]], then
           1. If _hr12_ is *undefined*, then
             1. Let _hr12_ be Get(_dataLocaleData_, *"hour12"*).
@@ -129,9 +121,9 @@
             1. Let _hourNo0_ be Get(_dataLocaleData_, *"hourNo0"*).
             1. Set _dateTimeFormat_.[[hourNo0]] to _hourNo0_.
             1. Let _pattern_ be Get(_bestFormat_, *"pattern12"*).
-          1. Else
+          1. Else,
             1. Let _pattern_ be Get(_bestFormat_, *"pattern"*).
-        1. Else
+        1. Else,
           1. Let _pattern_ be Get(_bestFormat_, *"pattern"*).
         1. Set _dateTimeFormat_.[[pattern]] to _pattern_.
         1. Set _dateTimeFormat_.[[boundFormat]] to *undefined*.
@@ -144,29 +136,26 @@
       </p>
 
       <emu-alg aoid="ToDateTimeOptions">
-        1. If _options_ is *undefined*, then let _options_ be *null*, else let _options_ be ToObject(_options_).
-        1. ReturnIfAbrupt(_options_).
+        1. If _options_ is *undefined*, let _options_ be *null*; otherwise let _options_ be ? ToObject(_options_).
         1. Let _options_ be ObjectCreate(_options_).
         1. Let _needDefaults_ be *true*.
         1. If _required_ is *"date"* or *"any"*,
           1. For each of the property names *"weekday"*, *"year"*, *"month"*, *"day"*:
             1. Let _prop_ be the property name.
-            1. Let _value_ be Get(_options_, _prop_).
-            1. ReturnIfAbrupt(_value_).
-            1. If _value_ is not *undefined*, then let _needDefaults_ be *false*.
+            1. Let _value_ be ? Get(_options_, _prop_).
+            1. If _value_ is not *undefined*, let _needDefaults_ be *false*.
         1. If _required_ is *"time"* or *"any"*,
           1. For each of the property names *"hour"*, *"minute"*, *"second"*:
             1. Let _prop_ be the property name.
-            1. Let _value_ be Get(_options_, _prop_).
-            1. ReturnIfAbrupt(_value_).
-            1. If _value_ is not *undefined*, then let _needDefaults_ be *false*.
+            1. Let _value_ be ? Get(_options_, _prop_).
+            1. If _value_ is not *undefined*, let _needDefaults_ be *false*.
         1. If _needDefaults_ is *true* and _defaults_ is either *"date"* or *"all"*, then
           1. For each of the property names *"year"*, *"month"*, *"day"*:
-            1. Let _status_ be CreateDatePropertyOrThrow(_options_, _prop_, *"numeric"*).
+            1. Let _status_ be the result of calling CreateDatePropertyOrThrow(_options_, _prop_, *"numeric"*).
             1. ReturnIfAbrupt(_status_).
         1. If _needDefaults_ is *true* and _defaults_ is either *"time"* or *"all"*, then
           1. For each of the property names *"hour"*, *"minute"*, *"second"*:
-            1. Let _status_ be CreateDatePropertyOrThrow(_options_, _prop_, *"numeric"*).
+            1. Let _status_ be the result of calling CreateDatePropertyOrThrow(_options_, _prop_, *"numeric"*).
             1. ReturnIfAbrupt(_status_).
         1. Return _options_.
       </emu-alg>
@@ -186,7 +175,7 @@
         1. Let _bestFormat_ be *undefined*.
         1. Let _k_ be 0.
         1. Assert: _formats_ is an Array object.
-        1. Let _len_ be Get(_formats_, *"length"*).
+        1. Let _len_ be Get(_formats_, `"length"`).
         1. Repeat while _k_ < _len_:
           1. Let _format_ be Get(_formats_, ToString(_k_)).
           1. Let _score_ be 0.
@@ -225,8 +214,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _dateTimeFormat_ be OrdinaryCreateFromConstructor(_newTarget_, *%DateTimeFormatPrototype%*).
-        1. ReturnIfAbrupt(_dateTimeFormat_).
+        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *%DateTimeFormatPrototype%*).
         1. Return InitializeDateTimeFormat(_dateTimeFormat_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -236,7 +224,7 @@
     <h1>Properties of the Intl.DateTimeFormat Constructor</h1>
 
     <p>
-      Besides the internal slots and the *length* property (whose value is 0), the Intl.DateTimeFormat constructor has the following properties:
+      Besides the internal slots and the `length` property (whose value is 0), the Intl.DateTimeFormat constructor has the following properties:
     </p>
 
     <emu-clause id="sec-Intl.DateTimeFormat.prototype">
@@ -259,13 +247,12 @@
 
       <emu-alg>
         1. Let _availableLocales_ be the value of *%DateTimeFormat%*.[[availableLocales]].
-        1. Let _requestedLocales_ be CanonicalizeLocaleList(_locales_).
-        1. ReturnIfAbrupt(_requestedLocales_).
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return _supportedLocales_ be SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
 
       <p>
-        The value of the *length* property of the *supportedLocalesOf* method is 1.
+        The value of the `length` property of the *supportedLocalesOf* method is 1.
       </p>
     </emu-clause>
 
@@ -363,12 +350,13 @@
       </p>
 
       <emu-alg>
-        1. Let _dtf_ be this DateTimeFormat object.
-        1. ReturnIfAbrupt(_dtf_).
-        1. If the [[boundFormat]] internal slot of this DateTimeFormat object is *undefined*, then
+        1. Let _dtf_ be *this* value.
+        1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
+        1. If _dtf_ does not have a [[boundFormat]] internal slot, throw a *TypeError* exception.
+        1. If the [[boundFormat]] internal slot of _dtf_ is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-datetime-format-functions"></emu-xref>.
-          1. The value of _F_’s *length* property is 1.
-          1. Let _bf_ be BoundFunctionCreate(F, «*this* value»).
+          1. The value of _F_’s `length` property is 1.
+          1. Let _bf_ be BoundFunctionCreate(F, _dft_).
           1. Set _dtf_.[[boundFormat]] to _bf_.
         1. Return _dtf_.[[boundFormat]].
       </emu-alg>
@@ -386,9 +374,8 @@
         1. Assert: Type(_dtf_) is Object and _dtf_ has an [[initializedDateTimeFormat]] internal slot whose value is *true*.
         1. If _date_ is not provided or is *undefined*, then
           1. Let _x_ be *%Date_now%*().
-        1. Else
-          1. Let _x_ be ToNumber(_date_).
-          1. ReturnIfAbrupt(_x_).
+        1. Else,
+          1. Let _x_ be ? ToNumber(_date_).
         1. Return FormatDateTime(_dtf_, _x_).
       </emu-alg>
 
@@ -405,12 +392,10 @@
       </p>
 
       <emu-alg aoid="FormatDateTime">
-        1. If _x_ is not a finite Number, then throw a *RangeError* exception.
+        1. If _x_ is not a finite Number, throw a *RangeError* exception.
         1. Let _locale_ be the value of _dateTimeFormat_.[[locale]].
-        1. Let _nf_ be Construct(%NumberFormat%, «[locale], {useGrouping: *false*}»).
-        1. ReturnIfAbrupt(_nf_).
-        1. Let _nf2_ be Construct(%NumberFormat%, «[locale], {minimumIntegerDigits: 2, useGrouping: *false*}»).
-        1. ReturnIfAbrupt(_nf2_).
+        1. Let _nf_ be ? Construct(%NumberFormat%, «[locale], {useGrouping: *false*}»).
+        1. Let _nf2_ be ? Construct(%NumberFormat%, «[locale], {minimumIntegerDigits: 2, useGrouping: *false*}»).
         1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[calendar]], _dateTimeFormat_.[[timeZone]]).
         1. Let _result_ be the value of the _dateTimeFormat_.[[pattern]].
         1. For each row of <emu-xref href="#table-3">Table 3</emu-xref>, except the header row, do:
@@ -428,13 +413,13 @@
               1. Let _fv_ be FormatNumber(_nf_, _v_).
             1. Else if f is *"2-digit"*, then
               1. Let _fv_ be FormatNumber(_nf2_, _v_).
-              1. If the length of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
+              1. If the `length` property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
             1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _f_ in the desired form; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _dateTimeFormat_ has a [[day]] internal slot. If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[inDST]] field of _tm_, and if the implementation does not have a localized representation of _f_, then use _f_ itself.
             1. Replace the substring of _result_ that consists of *"{"*, p, and *"}"*, with _fv_.
         1. If _dateTimeFormat_.[[hour12]] is *true*, then
           1. If _pm_ is *true*, then
             1. Let _fv_ be an implementation and locale dependent String value representing "post meridiem";
-          1. Else
+          1. Else,
             1. Let _fv_ be an implementation and locale dependent String value representing "ante meridiem".
           1. Replace the substring of _result_ that consists of *"{ampm}"*, with _fv_.
         1. Return _result_.

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -25,17 +25,14 @@
 
       <emu-alg>
         1. Let _O_ be RequireObjectCoercible(*this* value).
-        2. Let _S_ be ToString(_O_).
-        3. ReturnIfAbrupt(_S_).
-        4. Let _That_ be ToString(_that_).
-        5. ReturnIfAbrupt(_That_).
-        6. Let _collator_ be Construct(*%Collator%*, «*locales*, *options*»).
-        7. ReturnIfAbrupt(_collator_).
-        8. Return CompareStrings(_collator_, _S_, _That_)
+        1. Let _S_ be ? ToString(_O_).
+        1. Let _That_ be ? ToString(_that_).
+        1. Let _collator_ be ? Construct(*%Collator%*, «*locales*, *options*»).
+        1. Return CompareStrings(_collator_, _S_, _That_)
       </emu-alg>
 
       <p>
-        The value of the *length* property of the *localeCompare* method is 1.
+        The value of the `length` property of the *localeCompare* method is 1.
       </p>
 
       <emu-note>
@@ -61,25 +58,23 @@
 
       <emu-alg>
         1. Let _O_ be RequireObjectCoercible(*this* value).
-        2. Let _S_ be ToString(_O_).
-        3. ReturnIfAbrupt(_S_).
-        4. Let _requestedLocales_ be CanonicalizeLocaleList(_locales_).
-        5. ReturnIfAbrupt(_requestedLocales_).
-        6. Let _len_ be the number of elements in _requestedLocales_.
-        7. If _len_ > 0, then
+        1. Let _S_ be ? ToString(_O_).
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+        1. Let _len_ be the number of elements in _requestedLocales_.
+        1. If _len_ > 0, then
           1. Let _requestedLocale_ be the first element of _requestedLocales_.
-        8. Else
+        1. Else
           1. Let _requestedLocale_ be DefaultLocale().
-        9. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with all Unicode locale extension sequences (6.2.1) removed.
-        10. Let _availableLocales_ be a List with the language tags of the languages for which the Unicode character database contains language sensitive case mappings.
-        11. Let _locale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
-        12. If _locale_ is *undefined*, let _locale_ be *"und"*.
-        13. Let _cpList_ be a List containing in order the code points of _S_ as defined in ES2015, 6.1.4, starting at the first element of _S_.
-        14. For each code point _c_ in _cpList_, if the Unicode Character Database provides a lower case equivalent of _c_ that is either language insensitive or for the language _locale_, then replace _c_ in _cpList_ with that/those equivalent code point(s).
-        15. Let _cuList_ be a new List.
-        16. For each code point _c_ in _cpList_, in order, append to cuList the elements of the UTF-16 Encoding (defined in ES2015, 6.1.4) of _c_.
-        17. Let _L_ be a String whose elements are, in order, the elements of _cuList_.
-        18. Return _L_.
+        1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with all Unicode locale extension sequences (6.2.1) removed.
+        1. Let _availableLocales_ be a List with the language tags of the languages for which the Unicode character database contains language sensitive case mappings.
+        1. Let _locale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
+        1. If _locale_ is *undefined*, let _locale_ be *"und"*.
+        1. Let _cpList_ be a List containing in order the code points of _S_ as defined in ES2015, 6.1.4, starting at the first element of _S_.
+        1. For each code point _c_ in _cpList_, if the Unicode Character Database provides a lower case equivalent of _c_ that is either language insensitive or for the language _locale_, replace _c_ in _cpList_ with that/those equivalent code point(s).
+        1. Let _cuList_ be a new List.
+        1. For each code point _c_ in _cpList_, in order, append to cuList the elements of the UTF-16 Encoding (defined in ES2015, 6.1.4) of _c_.
+        1. Let _L_ be a String whose elements are, in order, the elements of _cuList_.
+        1. Return _L_.
       </emu-alg>
 
       <p>
@@ -87,7 +82,7 @@
       </p>
 
       <p>
-        The value of the *length* property of the *toLocaleLowerCase* method is 0.
+        The value of the `length` property of the *toLocaleLowerCase* method is 0.
       </p>
 
       <emu-note>
@@ -116,7 +111,7 @@
       </p>
 
       <p>
-        The value of the *length* property of the *toLocaleUpperCase* method is 0.
+        The value of the `length` property of the *toLocaleUpperCase* method is 0.
       </p>
 
       <emu-note>
@@ -146,15 +141,13 @@
       </p>
 
       <emu-alg>
-        1. Let _x_ be thisNumberValue(*this* value).
-        2. ReturnIfAbrupt(_x_).
-        3. Let _numberFormat_ be Construct(*%NumberFormat%*, «*locales*, *options*»).
-        4. ReturnIfAbrupt(_numberFormat_).
-        5. Return FormatNumber(_numberFormat_, _x_).
+        1. Let _x_ be ? thisNumberValue(*this* value).
+        1. Let _numberFormat_ be ? Construct(*%NumberFormat%*, «*locales*, *options*»).
+        1. Return FormatNumber(_numberFormat_, _x_).
       </emu-alg>
 
       <p>
-        The value of the *length* property of the *toLocaleString* method is 0.
+        The value of the `length` property of the *toLocaleString* method is 0.
       </p>
 
     </emu-clause>
@@ -179,18 +172,15 @@
       </p>
 
       <emu-alg>
-        1. Let _x_ be thisTimeValue(*this* value).
-        2. ReturnIfAbrupt(_x_).
-        3. If _x_ is *NaN*, return *"Invalid Date"*.
-        4. Let _options_ be ToDateTimeOptions(_options_, *"any"*, *"all"*).
-        5. ReturnIfAbrupt(_options_).
-        6. Let _dateFormat_ be Construct(*%DateTimeFormat%*, «*locales*, *options*»).
-        7. ReturnIfAbrupt(_dateFormat_).
-        8. Return FormatDateTime(_dateFormat_, _x_).
+        1. Let _x_ be ? thisTimeValue(*this* value).
+        1. If _x_ is *NaN*, return *"Invalid Date"*.
+        1. Let _options_ be ? ToDateTimeOptions(_options_, *"any"*, *"all"*).
+        1. Let _dateFormat_ be ? Construct(*%DateTimeFormat%*, «*locales*, *options*»).
+        1. Return FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
 
       <p>
-        The value of the *length* property of the *toLocaleString* method is 0.
+        The value of the `length` property of the *toLocaleString* method is 0.
       </p>
 
     </emu-clause>
@@ -207,18 +197,15 @@
       </p>
 
       <emu-alg>
-        1. Let _x_ be thisTimeValue(*this* value).
-        2. ReturnIfAbrupt(_x_).
-        3. If _x_ is *NaN*, return *"Invalid Date"*.
-        4. Let _options_ be ToDateTimeOptions(_options_, *"date"*, *"date"*).
-        5. ReturnIfAbrupt(_options_).
-        6. Let _dateFormat_ be Construct(*%DateTimeFormat%*, «*locales*, *options*»).
-        7. ReturnIfAbrupt(_dateFormat_).
-        8. Return FormatDateTime(_dateFormat_, _x_).
+        1. Let _x_ be ? thisTimeValue(*this* value).
+        1. If _x_ is *NaN*, return *"Invalid Date"*.
+        1. Let _options_ be ? ToDateTimeOptions(_options_, *"date"*, *"date"*).
+        1. Let _dateFormat_ be ? Construct(*%DateTimeFormat%*, «*locales*, *options*»).
+        1. Return FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
 
       <p>
-        The value of the *length* property of the *toLocaleDateString* method is 0.
+        The value of the `length` property of the *toLocaleDateString* method is 0.
       </p>
 
     </emu-clause>
@@ -235,18 +222,15 @@
       </p>
 
       <emu-alg>
-        1. Let _x_ be thisTimeValue(*this* value).
-        2. ReturnIfAbrupt(_x_).
-        3. If _x_ is *NaN*, return *"Invalid Date"*.
-        4. Let _options_ be ToDateTimeOptions(_options_, *"time"*, *"time"*).
-        5. ReturnIfAbrupt(_options_).
-        6. Let _timeFormat_ be Construct(*%DateTimeFormat%*, «*locales*, *options*»).
-        7. ReturnIfAbrupt(_timeFormat_),
-        8. Return FormatDateTime(_timeFormat_, _x_).
+        1. Let _x_ be ? thisTimeValue(*this* value).
+        1. If _x_ is *NaN*, return *"Invalid Date"*.
+        1. Let _options_ be ? ToDateTimeOptions(_options_, *"time"*, *"time"*).
+        1. Let _timeFormat_ be ? Construct(*%DateTimeFormat%*, «*locales*, *options*»).
+        1. Return FormatDateTime(_timeFormat_, _x_).
       </emu-alg>
 
       <p>
-        The value of the *length* property of the *toLocaleTimeString* method is 0.
+        The value of the `length` property of the *toLocaleTimeString* method is 0.
       </p>
 
     </emu-clause>
@@ -267,32 +251,26 @@
       </p>
 
       <emu-alg>
-        1. Let _A_ be ToObject(*this* value).
-        2. ReturnIfAbrupt(_A_).
-        3. Let _len_ be ToLength(Get(_A_, *"length"*)).
-        4. ReturnIfAbrupt(_len_).
-        5. Let _separator_ be the String value for the list-separator String appropriate for the host environment’s current locale (this is derived in an implementation-defined way).
-        6. If _len_ is zero, return the empty String.
-        7. Let _firstElement_ be Get(_A_, *"0"*).
-        8. ReturnIfAbrupt(_firstElement_).
-        9. If _firstElement_ is *undefined* or *null*, then
+        1. Let _A_ be ? ToObject(*this* value).
+        1. Let _len_ be ? ToLength(Get(_A_, `"length"`)).
+        1. Let _separator_ be the String value for the list-separator String appropriate for the host environment’s current locale (this is derived in an implementation-defined way).
+        1. If _len_ is zero, return the empty String.
+        1. Let _firstElement_ be ? Get(_A_, *"0"*).
+        1. If _firstElement_ is *undefined* or *null*, then
           1. Let _R_ be an empty String.
-        10. Else
-          1. Let _R_ be ToString(Invoke(_firstElement_, *"toLocaleString"*, «*locales*, *options*»)).
-          1. ReturnIfAbrupt(_R_).
-        11. Let _k_ be 1.
-        12. Repeat, while _k_ < _len_
+        1. Else
+          1. Let _R_ be ? ToString(Invoke(_firstElement_, *"toLocaleString"*, «*locales*, *options*»)).
+        1. Let _k_ be 1.
+        1. Repeat, while _k_ < _len_
           1. Let _S_ be a String value produced by concatenating _R_ and _separator_.
-          1. Let _nextElement_ be Get(_A_, ToString(_k_)).
-          1. ReturnIfAbrupt(_nextElement_).
+          1. Let _nextElement_ be ? Get(_A_, ToString(_k_)).
           1. If _nextElement_ is *undefined* or *null*, then
             1. Let _R_ be the empty String.
-          1. Else
-            1. Let _R_ be ToString(Invoke(_nextElement_, *"toLocaleString"*, «*locales*, *options*»)).
-            1. ReturnIfAbrupt(_R_).
+          1. Else,
+            1. Let _R_ be ? ToString(Invoke(_nextElement_, *"toLocaleString"*, «*locales*, *options*»)).
           1. Let _R_ be a String value produced by concatenating _S_ and _R_.
           1. Increase _k_ by 1.
-        13. Return _R_.
+        1. Return _R_.
       </emu-alg>
 
       <emu-note>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -32,7 +32,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *localeCompare* method is 1.
+        The value of the *length* property of the *localeCompare* method is 1.
       </p>
 
       <emu-note>
@@ -82,7 +82,7 @@
       </p>
 
       <p>
-        The value of the `length` property of the *toLocaleLowerCase* method is 0.
+        The value of the *length* property of the *toLocaleLowerCase* method is 0.
       </p>
 
       <emu-note>
@@ -111,7 +111,7 @@
       </p>
 
       <p>
-        The value of the `length` property of the *toLocaleUpperCase* method is 0.
+        The value of the *length* property of the *toLocaleUpperCase* method is 0.
       </p>
 
       <emu-note>
@@ -147,7 +147,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *toLocaleString* method is 0.
+        The value of the *length* property of the *toLocaleString* method is 0.
       </p>
 
     </emu-clause>
@@ -180,7 +180,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *toLocaleString* method is 0.
+        The value of the *length* property of the *toLocaleString* method is 0.
       </p>
 
     </emu-clause>
@@ -205,7 +205,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *toLocaleDateString* method is 0.
+        The value of the *length* property of the *toLocaleDateString* method is 0.
       </p>
 
     </emu-clause>
@@ -230,7 +230,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *toLocaleTimeString* method is 0.
+        The value of the *length* property of the *toLocaleTimeString* method is 0.
       </p>
 
     </emu-clause>
@@ -252,7 +252,7 @@
 
       <emu-alg>
         1. Let _A_ be ? ToObject(*this* value).
-        1. Let _len_ be ? ToLength(Get(_A_, `"length"`)).
+        1. Let _len_ be ? ToLength(Get(_A_, *"length"*)).
         1. Let _separator_ be the String value for the list-separator String appropriate for the host environment’s current locale (this is derived in an implementation-defined way).
         1. If _len_ is zero, return the empty String.
         1. Let _firstElement_ be ? Get(_A_, *"0"*).

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -63,7 +63,7 @@
         1. Let _len_ be the number of elements in _requestedLocales_.
         1. If _len_ > 0, then
           1. Let _requestedLocale_ be the first element of _requestedLocales_.
-        1. Else
+        1. Else,
           1. Let _requestedLocale_ be DefaultLocale().
         1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with all Unicode locale extension sequences (6.2.1) removed.
         1. Let _availableLocales_ be a List with the language tags of the languages for which the Unicode character database contains language sensitive case mappings.
@@ -258,7 +258,7 @@
         1. Let _firstElement_ be ? Get(_A_, *"0"*).
         1. If _firstElement_ is *undefined* or *null*, then
           1. Let _R_ be an empty String.
-        1. Else
+        1. Else,
           1. Let _R_ be ? ToString(Invoke(_firstElement_, *"toLocaleString"*, «*locales*, *options*»)).
         1. Let _k_ be 1.
         1. Repeat, while _k_ < _len_

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -97,9 +97,9 @@
 
       <emu-alg>
         1. Let _normalized_ be the result of mapping _currency_ to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
-        2. If the string length of _normalized_ is not 3, return *false*.
-        3. If _normalized_ contains any character that is not in the range "A" to "Z" (U+0041 to U+005A), return *false*.
-        4. Return *true*.
+        1. If the string length of _normalized_ is not 3, return *false*.
+        1. If _normalized_ contains any character that is not in the range "A" to "Z" (U+0041 to U+005A), return *false*.
+        1. Return *true*.
       </emu-alg>
     </emu-clause>
 
@@ -136,9 +136,9 @@
 
       <emu-alg>
         1. Let _ianaTimeZone_ be the Zone or Link name of the IANA Time Zone Database such that _timeZone_, converted to  upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>, is equal to _ianaTimeZone_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
-        2. If _ianaTimeZone_ is a Link name, then let _ianaTimeZone_ be the corresponding Zone name as specified in the "backward" file of the IANA Time Zone Database.
-        3. If _ianaTimeZone_ is *"Etc/UTC"* or *"Etc/GMT"*, then return *"UTC"*.
-        4. Return _ianaTimeZone_.
+        1. If _ianaTimeZone_ is a Link name, let _ianaTimeZone_ be the corresponding Zone name as specified in the "backward" file of the IANA Time Zone Database.
+        1. If _ianaTimeZone_ is *"Etc/UTC"* or *"Etc/GMT"*, return *"UTC"*.
+        1. Return _ianaTimeZone_.
       </emu-alg>
 
       <p>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -241,7 +241,7 @@
       <emu-alg>
         1. If _options_ is not *undefined*, then
           1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
-        1. Else, let _matcher_ be *"best fit"*.
+        1. Else let _matcher_ be *"best fit"*.
         1. If _matcher_ is *"best fit"*,
           1. Let _MatcherOperation_ be the abstract operation BestFitSupportedLocales.
         1. Else,

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -19,7 +19,7 @@
     </ul>
 
     <p>
-      EXAMPLE     An implementation of DateTimeFormat might include the language tag "th" in its [[availableLocales]] internal slot, and must (according to 12.2.3) include the key "ca" in its [[relevantExtensionKeys]] internal slot. For Thai, the "buddhist" calendar is usually the default, but an implementation might also support the calendars "gregory", "chinese", and "islamicc" for the locale "th". The [[localeData]] internal slot would therefore at least include {"th": {ca: ["buddhist", "gregory", "chinese", "islamicc"]}}.
+      EXAMPLE     An implementation of DateTimeFormat might include the language tag "th" in its [[availableLocales]] internal slot, and must (according to <emu-xref href="#sec-Intl.DateTimeFormat-internal-slots"></emu-xref>) include the key "ca" in its [[relevantExtensionKeys]] internal slot. For Thai, the "buddhist" calendar is usually the default, but an implementation might also support the calendars "gregory", "chinese", and "islamicc" for the locale "th". The [[localeData]] internal slot would therefore at least include {"th": {ca: ["buddhist", "gregory", "chinese", "islamicc"]}}.
     </p>
   </emu-clause>
 
@@ -43,20 +43,16 @@
         1. Let _seen_ be an empty List.
         1. If Type(_locales_) is String, then
           1. Let _aLocales_ be CreateArrayFromList(«_locales_»).
-        1. Let _O_ be ToObject(_aLocales_).
-        1. ReturnIfAbrupt(_O_).
-        1. Let _len_ be ToLength(Get(_O_, *"length"*)).
+        1. Let _O_ be ? ToObject(_aLocales_).
+        1. Let _len_ be ToLength(Get(_O_, `"length"`)).
         1. Let _k_ be 0.
         1. Repeat, while _k_ < _len_
           1. Let _Pk_ be ToString(_k_).
-          1. Let _kPresent_ be HasProperty(_O_, _Pk_).
-          1. ReturnIfAbrupt(_kPresent_).
-          1. If _kPresent_ is true, then
-            1. Let _kValue_ be Get(_O_, _Pk_).
-            1. ReturnIfAbrupt(_kValue_).
+          1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
+          1. If _kPresent_ is *true*, then
+            1. Let _kValue_ be ? Get(_O_, _Pk_).
             1. If Type(_kValue_) is not String or Object, throw a *TypeError* exception.
-            1. Let _tag_ be ToString(_kValue_).
-            1. ReturnIfAbrupt(_tag_).
+            1. Let _tag_ be ? ToString(_kValue_).
             1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
             1. Let _canonicalizedTag_ be CanonicalizeLanguageTag(_tag_).
             1. If _canonicalizedTag_ is not an element of _seen_, append _canonicalizedTag_ as the last element of _seen_.
@@ -83,9 +79,9 @@
       <emu-alg>
         1. Let _candidate_ be locale.
         1. Repeat
-          1. If _availableLocales_ contains an element equal to _candidate_, then return _candidate_.
+          1. If _availableLocales_ contains an element equal to _candidate_, return _candidate_.
           1. Let _pos_ be the character index of the last occurrence of *"-"* (U+002D) within _candidate_. If that character does not occur, return *undefined*.
-          1. If _pos_ ≥ 2 and the character *"-"* occurs at index _pos_-2 of candidate, then decrease _pos_ by 2.
+          1. If _pos_ ≥ 2 and the character *"-"* occurs at index _pos_-2 of candidate, decrease _pos_ by 2.
           1. Let _candidate_ be the substring of _candidate_ from position 0, inclusive, to position _pos_, exclusive.
       </emu-alg>
     </emu-clause>
@@ -100,12 +96,11 @@
       <emu-alg>
         1. Let _k_ be 0.
         1. Let _rLocales_ be CreateArrayFromList(_requestedLocales_).
-        1. Let _len_ be ToLength(Get(_rLocales_, *"length"*)).
+        1. Let _len_ be ToLength(Get(_rLocales_, `"length"`)).
         1. Let _availableLocale_ be *undefined*.
         1. Repeat while _k_ < _len_ and _availableLocale_ is *undefined*:
           1. Let _Pk_ be ToString(_k_).
-          1. Let _locale_ be Get(_rLocales_, _Pk_) .
-          1. ReturnIfAbrupt(_locale_)
+          1. Let _locale_ be ? Get(_rLocales_, _Pk_) .
           1. Let _noExtensionsLocale_ be the String value that is _locale_ with all Unicode locale extension sequences removed.
           1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
           1. Increase _k_ by 1.
@@ -118,7 +113,7 @@
             extension sequence within _locale_.
             1. Set _result_.[[extension]] to _extension_.
             1. Set _result_.[[extensionIndex]] to _extensionIndex_.
-        1. Else
+        1. Else,
           1. Let _defLocale_ be DefaultLocale().
           1. Set _result_.[[locale]] to _defLocale_.
         1. Return _result_.
@@ -152,7 +147,7 @@
         1. Let _matcher_ be the value of _options_.[[localeMatcher]].
         1. If _matcher_ is *"lookup"*, then
           1. Let _MatcherOperation_ be the abstract operation LookupMatcher.
-        1. Else
+        1. Else,
           1. Let _MatcherOperation_ be the abstract operation BestFitMatcher.
         1. Let _r_ be _MatcherOperation_(_availableLocales_, _requestedLocales_).
         1. Let _foundLocale_ be the value of _r_.[[locale]].
@@ -160,37 +155,31 @@
           1. Let _extension_ be the value of _r_.[[extension]].
           1. Let _extensionIndex_ be the value of _r_.[[extensionIndex]].
           1. Let _extensionSubtags_ be Call(*%StringProto_split%*, extension, «*"-"*») .
-          1. Let _extensionSubtagsLength_ be Get(CreateArrayFromList(_extensionSubtags_), *"length"*).
+          1. Let _extensionSubtagsLength_ be Get(CreateArrayFromList(_extensionSubtags_), `"length"`).
         1. Let _result_ be a new Record.
         1. Set _result_.[[dataLocale]] to _foundLocale_.
         1. Let _supportedExtension_ be *"-u"*.
         1. Let _k_ be 0.
-        1. Let _rExtensionKeys_ be ToObject(CreateArrayFromList(_relevantExtensionKeys_)).
-        1. ReturnIfAbrupt(_rExtensionKeys_).
-        1. Let _len_ be ToLength(Get(_rExtensionKeys_, *"length"*)).
+        1. Let _rExtensionKeys_ be ? ToObject(CreateArrayFromList(_relevantExtensionKeys_)).
+        1. Let _len_ be ToLength(Get(_rExtensionKeys_, `"length"`)).
         1. Repeat while _k_ < _len_
-          1. Let _key_ be Get(_rExtensionKeys_ , ToString(_k_)).
-          1. ReturnIfAbrupt(_key_).
-          1. Let _foundLocaleData_ be Get(_localeData_, _foundLocale_).
-          1. ReturnIfAbrupt(_foundLocaleData_).
-          1. Let _keyLocaleData_ be ToObject(Get(_foundLocaleData_, _key_)).
-          1. ReturnIfAbrupt(_keyLocaleData_).
-          1. Let _value_ be ToString(Get(_keyLocaleData_, *"0"*)).
-          1. ReturnIfAbrupt(_value_).
+          1. Let _key_ be ? Get(_rExtensionKeys_ , ToString(_k_)).
+          1. Let _foundLocaleData_ be ? Get(_localeData_, _foundLocale_).
+          1. Let _keyLocaleData_ be ? ToObject(Get(_foundLocaleData_, _key_)).
+          1. Let _value_ be ? ToString(Get(_keyLocaleData_, *"0"*)).
           1. Let _supportedExtensionAddition_ be *""*.
           1. If _extensionSubtags_ is not *undefined*, then
             1. Let _keyPos_ be Call(*%ArrayProto_indexOf%*, _extensionSubtags_, «_key_») .
             1. If _keyPos_ ≠ -1, then
-              1. If _keyPos_ + 1 < _extensionSubtagsLength_ and the length of the result of Get(_extensionSubtags_, ToString(_keyPos_ +1)) is greater than 2, then
+              1. If _keyPos_ + 1 < _extensionSubtagsLength_ and the `length` property of the result of Get(_extensionSubtags_, ToString(_keyPos_ +1)) is greater than 2, then
                 1. Let _requestedValue_ be Get(_extensionSubtags_, ToString(_keyPos_ +1)).
                 1. If the result of Call(*%StringProto_includes%*, _keyLocaleData_, «_requestedValue_») is *true*, then
                   1. Let _value_ be _requestedValue_.
                   1. Let _supportedExtensionAddition_ be the concatenation of *"-"*, _key_, *"-"*, and _value_.
-              1. Else, if the result of Call(*%StringProto_includes%*, _keyLocaleData_, «*"true"*») is *true*, then
+              1. Else if the result of Call(*%StringProto_includes%*, _keyLocaleData_, «*"true"*») is *true*, then
                 1. Let _value_ be *"true"*.
           1. If _options_ has a field [[<_key_>]], then
-            1. Let _optionsValue_ be the value of ToString(_options_.[[<_key_>]]).
-            1. ReturnIfAbrupt(_optionsValue_).
+            1. Let _optionsValue_ be ? ToString(_options_.[[<_key_>]]).
             1. If the result of Call(*%StringProto_includes%*, _keyLocaleData_, «_optionsValue_») is *true*, then
               1. If _optionsValue_ is not equal to _value_, then
                 1. Let _value_ be _optionsValue_.
@@ -220,16 +209,15 @@
 
       <emu-alg>
         1. Let _rLocales_ be CreateArrayFromList(_requestedLocales_).
-        1. Let _len_ be ToLength(Get(_rLocales_, *"length"*)).
+        1. Let _len_ be ToLength(Get(_rLocales_, `"length"`)).
         1. Let _subset_ be an empty List.
         1. Let _k_ be 0.
         1. Repeat while _k_ < _len_
           1. Let _Pk_ be ToString(_k_).
-          1. Let _locale_ be Get(_rLocales_, _Pk_).
-          1. ReturnIfAbrupt(_locale_).
+          1. Let _locale_ be ? Get(_rLocales_, _Pk_).
           1. Let _noExtensionsLocale_ be the String value that is _locale_ with all Unicode locale extension sequences removed.
           1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
-          1. If _availableLocale_ is not *undefined*, then append _locale_ to the end of subset.
+          1. If _availableLocale_ is not *undefined*, append _locale_ to the end of subset.
           1. Increment _k_ by 1.
         1. Return _subset_.
       </emu-alg>
@@ -252,12 +240,11 @@
 
       <emu-alg>
         1. If _options_ is not *undefined*, then
-          1. Let _matcher_ be GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
-          1. ReturnIfAbrupt(_matcher_).
+          1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Else, let _matcher_ be *"best fit"*.
         1. If _matcher_ is *"best fit"*,
           1. Let _MatcherOperation_ be the abstract operation BestFitSupportedLocales.
-        1. Else
+        1. Else,
           1. Let _MatcherOperation_ be the abstract operation LookupSupportedLocales.
         1. Let _supportedLocales_ be MatcherOperation(_availableLocales_, _requestedLocales_).
         1. Let _subset_ be CreateArrayFromList(_supportedLocales_).
@@ -278,21 +265,18 @@
       </p>
 
       <emu-alg>
-        1. Let _opts_ be ToObject(_options_).
-        1. ReturnIfAbrupt(_opts_).
-        1. Let _value_ be Get(_opts_, _property_).
-        1. ReturnIfAbrupt(_value_).
+        1. Let _opts_ be ? ToObject(_options_).
+        1. Let _value_ be ? Get(_opts_, _property_).
         1. If _value_ is not *undefined*, then
           1. Assert: _type_ is *"boolean"* or *"string"*.
           1. If _type_ is *"boolean"*, then
             1. Let _value_ be ToBoolean(_value_).
           1. If _type_ is *"string"*, then
-            1. Let _value_ be ToString(_value_).
-            1. ReturnIfAbrupt(_value_).
+            1. Let _value_ be ? ToString(_value_).
           1. If _values_ is not *undefined*, then
             1. If _values_ does not contain an element equal to _value_, throw a *RangeError* exception.
           1. Return _value_.
-        1. Else return _fallback_.
+        1. Else, return _fallback_.
       </emu-alg>
     </emu-clause>
 
@@ -304,16 +288,13 @@
       </p>
 
       <emu-alg>
-        1. Let _opts_ be ToObject(_options_).
-        1. ReturnIfAbrupt(_opts_).
-        1. Let _value_ be Get(_opts_, _property_).
-        1. ReturnIfAbrupt(_value_).
+        1. Let _opts_ be ? ToObject(_options_).
+        1. Let _value_ be ? Get(_opts_, _property_).
         1. If _value_ is not *undefined*, then
-          1. Let _value_ be ToNumber(_value_).
-          1. ReturnIfAbrupt(_value_).
+          1. Let _value_ be ? ToNumber(_value_).
         1. If _value_ is *NaN* or less than _minimum_ or greater than _maximum_, throw a *RangeError* exception.
           1. Return floor(_value_).
-        1. Else return _fallback_.
+        1. Else, return _fallback_.
       </emu-alg>
     </emu-clause>
 

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -44,7 +44,7 @@
         1. If Type(_locales_) is String, then
           1. Let _aLocales_ be CreateArrayFromList(«_locales_»).
         1. Let _O_ be ? ToObject(_aLocales_).
-        1. Let _len_ be ToLength(Get(_O_, `"length"`)).
+        1. Let _len_ be ToLength(Get(_O_, *"length"*)).
         1. Let _k_ be 0.
         1. Repeat, while _k_ < _len_
           1. Let _Pk_ be ToString(_k_).
@@ -96,7 +96,7 @@
       <emu-alg>
         1. Let _k_ be 0.
         1. Let _rLocales_ be CreateArrayFromList(_requestedLocales_).
-        1. Let _len_ be ToLength(Get(_rLocales_, `"length"`)).
+        1. Let _len_ be ToLength(Get(_rLocales_, *"length"*)).
         1. Let _availableLocale_ be *undefined*.
         1. Repeat while _k_ < _len_ and _availableLocale_ is *undefined*:
           1. Let _Pk_ be ToString(_k_).
@@ -155,13 +155,13 @@
           1. Let _extension_ be the value of _r_.[[extension]].
           1. Let _extensionIndex_ be the value of _r_.[[extensionIndex]].
           1. Let _extensionSubtags_ be Call(*%StringProto_split%*, extension, «*"-"*») .
-          1. Let _extensionSubtagsLength_ be Get(CreateArrayFromList(_extensionSubtags_), `"length"`).
+          1. Let _extensionSubtagsLength_ be Get(CreateArrayFromList(_extensionSubtags_), *"length"*).
         1. Let _result_ be a new Record.
         1. Set _result_.[[dataLocale]] to _foundLocale_.
         1. Let _supportedExtension_ be *"-u"*.
         1. Let _k_ be 0.
         1. Let _rExtensionKeys_ be ? ToObject(CreateArrayFromList(_relevantExtensionKeys_)).
-        1. Let _len_ be ToLength(Get(_rExtensionKeys_, `"length"`)).
+        1. Let _len_ be ToLength(Get(_rExtensionKeys_, *"length"*)).
         1. Repeat while _k_ < _len_
           1. Let _key_ be ? Get(_rExtensionKeys_ , ToString(_k_)).
           1. Let _foundLocaleData_ be ? Get(_localeData_, _foundLocale_).
@@ -171,7 +171,7 @@
           1. If _extensionSubtags_ is not *undefined*, then
             1. Let _keyPos_ be Call(*%ArrayProto_indexOf%*, _extensionSubtags_, «_key_») .
             1. If _keyPos_ ≠ -1, then
-              1. If _keyPos_ + 1 < _extensionSubtagsLength_ and the `length` property of the result of Get(_extensionSubtags_, ToString(_keyPos_ +1)) is greater than 2, then
+              1. If _keyPos_ + 1 < _extensionSubtagsLength_ and the *length* property of the result of Get(_extensionSubtags_, ToString(_keyPos_ +1)) is greater than 2, then
                 1. Let _requestedValue_ be Get(_extensionSubtags_, ToString(_keyPos_ +1)).
                 1. If the result of Call(*%StringProto_includes%*, _keyLocaleData_, «_requestedValue_») is *true*, then
                   1. Let _value_ be _requestedValue_.
@@ -209,7 +209,7 @@
 
       <emu-alg>
         1. Let _rLocales_ be CreateArrayFromList(_requestedLocales_).
-        1. Let _len_ be ToLength(Get(_rLocales_, `"length"`)).
+        1. Let _len_ be ToLength(Get(_rLocales_, *"length"*)).
         1. Let _subset_ be an empty List.
         1. Let _k_ be 0.
         1. Repeat while _k_ < _len_

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -104,7 +104,7 @@
     <h1>Properties of the Intl.NumberFormat Constructor</h1>
 
     <p>
-      Besides the internal slots and the `length` property (whose value is 0), the Intl.NumberFormat constructor has the following properties:
+      Besides the internal slots and the *length* property (whose value is 0), the Intl.NumberFormat constructor has the following properties:
     </p>
 
     <emu-clause id="sec-Intl.NumberFormat.prototype">
@@ -132,7 +132,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *supportedLocalesOf* method is 1.
+        The value of the *length* property of the *supportedLocalesOf* method is 1.
       </p>
     </emu-clause>
 
@@ -211,7 +211,7 @@
         1. If _nf_ does not have a [[boundFormat]] internal slot, throw a *TypeError* exception.
         1. If _nf_.[[boundFormat]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-number-format-functions"></emu-xref>.
-          1. The value of _F_’s `length` property is 1.
+          1. The value of _F_’s *length* property is 1.
           1. Let _bf_ be BoundFunctionCreate(_F_, _nf_).
           1. Set _nf_.[[boundFormat]] to _bf_.
         1. Return _nf_.[[boundFormat]].

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -22,61 +22,47 @@
       <emu-alg>
         1. If _numberFormat_ has an [[initializedIntlObject]] internal slot with value *true*, throw a *TypeError* exception.
         1. Set _numberFormat_.[[initializedIntlObject]] to *true*.
-        1. Let _requestedLocales_ be CanonicalizeLocaleList(_locales_).
-        1. ReturnIfAbrupt(_requestedLocales_).
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
           1. Let _options_ be ObjectCreate(*%ObjectPrototype%*).
-        1. Else
-          1. Let _options_ be ToObject(_options_).
-          1. ReturnIfAbrupt(_options_).
+        1. Else,
+          1. Let _options_ be ? ToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be GetOption(_options_, *"localeMatcher"*, *"string"*, «*"lookup"*, *"best fit"*», *"best fit"*).
-        1. ReturnIfAbrupt(_matcher_).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, «*"lookup"*, *"best fit"*», *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be *%NumberFormat%*.[[localeData]].
         1. Let _r_ be ResolveLocale(*%NumberFormat%*.[[availableLocales]], _requestedLocales_, _opt_, *%NumberFormat%*.[[relevantExtensionKeys]], _localeData_).
         1. Set _numberFormat_.[[locale]] to the value of _r_.[[locale]].
         1. Set _numberFormat_.[[numberingSystem]] to the value of _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _s_ be GetOption(_options_, *"style"*, *"string"*, «*"decimal"*, *"percent"*, *"currency"*», *"decimal"*).
-        1. ReturnIfAbrupt(_s_).
+        1. Let _s_ be ? GetOption(_options_, *"style"*, *"string"*, «*"decimal"*, *"percent"*, *"currency"*», *"decimal"*).
         1. Set _numberFormat_.[[style]] to _s_.
-        1. Let _c_ be GetOption(_options_, *"currency"*, *"string"*, *undefined*, *undefined*).
-        1. ReturnIfAbrupt(_c_).
+        1. Let _c_ be ? GetOption(_options_, *"currency"*, *"string"*, *undefined*, *undefined*).
         1. If _c_ is not *undefined*, then
-          1. If the result of IsWellFormedCurrencyCode(_c_), is *false*, then throw a *RangeError* exception.
+          1. If the result of IsWellFormedCurrencyCode(_c_), is *false*, throw a *RangeError* exception.
         1. If _s_ is *"currency"* and _c_ is *undefined*, throw a *TypeError* exception.
         1. If _s_ is *"currency"*, then
           1. Let _c_ be converting _c_ to upper case as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
           1. Set _numberFormat_.[[currency]] to _c_.
           1. Let _cDigits_ be CurrencyDigits(_c_)
-        1. Let _cd_ be GetOption(_options_, *"currencyDisplay"*, *"string"*, «*"code"*, *"symbol"*, *"name"*», *"symbol"*).
-        1. ReturnIfAbrupt(_cd_).
+        1. Let _cd_ be ? GetOption(_options_, *"currencyDisplay"*, *"string"*, «*"code"*, *"symbol"*, *"name"*», *"symbol"*).
         1. If _s_ is *"currency"*, set _numberFormat_.[[currencyDisplay]] to _cd_.
-        1. Let _mnid_ be GetNumberOption(_options_, *"minimumIntegerDigits"*, 1, 21, 1).
-        1. ReturnIfAbrupt(_mnid_).
+        1. Let _mnid_ be ? GetNumberOption(_options_, *"minimumIntegerDigits"*, 1, 21, 1).
         1. Set _numberFormat_.[[minimumIntegerDigits]] to _mnid_.
         1. If _s_ is *"currency"*, let _mnfdDefault_ be _cDigits_; else let _mnfdDefault_ be 0.
-        1. Let _mnfd_ be GetNumberOption(_options_, *"minimumFractionDigits"*, 0, 20, _mnfdDefault_).
-        1. ReturnIfAbrupt(_mnfd_).
+        1. Let _mnfd_ be ? GetNumberOption(_options_, *"minimumFractionDigits"*, 0, 20, _mnfdDefault_).
         1. Set _numberFormat_.[[minimumFractionDigits]] to _mnfd_.
         1. If _s_ is *"currency"*, let _mxfdDefault_ be max(_mnfd_, _cDigits_); else if _s_ is *"percent"*, let _mxfdDefault_ be max(_mnfd_, 0); else let _mxfdDefault_ be max(_mnfd_, 3).
-        1. Let _mxfd_ be GetNumberOption(_options_, *"maximumFractionDigits"*, _mnfd_, 20, _mxfdDefault_).
-        1. ReturnIfAbrupt(_mxfd_).
+        1. Let _mxfd_ be ? GetNumberOption(_options_, *"maximumFractionDigits"*, _mnfd_, 20, _mxfdDefault_).
         1. Set _numberFormat_.[[maximumFractionDigits]] to _mxfd_.
-        1. Let _mnsd_ be Get(_options_, *"minimumSignificantDigits"*).
-        1. ReturnIfAbrupt(_mnsd_).
-        1. Let _mxsd_ be Get(_options_, *"maximumSignificantDigits"*).
-        1. ReturnIfAbrupt(_mxsd_).
+        1. Let _mnsd_ be ? Get(_options_, *"minimumSignificantDigits"*).
+        1. Let _mxsd_ be ? Get(_options_, *"maximumSignificantDigits"*).
         1. If _mnsd_ is not *undefined* or _mxsd_ is not *undefined*, then
-          1. Let _mnsd_ be GetNumberOption(_options_, *"minimumSignificantDigits"*, 1, 21, 1).
-          1. ReturnIfAbrupt(_mnsd_).
-          1. Let _mxsd_ be GetNumberOption(_options_, *"maximumSignificantDigits"*, _mnsd_, 21, 21).
-          1. ReturnIfAbrupt(_mxsd_).
+          1. Let _mnsd_ be ? GetNumberOption(_options_, *"minimumSignificantDigits"*, 1, 21, 1).
+          1. Let _mxsd_ be ? GetNumberOption(_options_, *"maximumSignificantDigits"*, _mnsd_, 21, 21).
           1. Set _numberFormat_.[[minimumSignificantDigits]] to _mnsd_.
           1. Set _numberFormat_.[[maximumSignificantDigits]] to _mxsd_.
-        1. Let _g_ be GetOption(_options_, *"useGrouping"*, *"boolean"*, *undefined*, *true*).
-        1. ReturnIfAbrupt(_g_).
+        1. Let _g_ be ? GetOption(_options_, *"useGrouping"*, *"boolean"*, *undefined*, *true*).
         1. Set _numberFormat_.[[useGrouping]] to _g_.
         1. Let _dataLocaleData_ be Get(_localeData_, _dataLocale_).
         1. Let _patterns_ be Get(_dataLocaleData_, *"patterns"*).
@@ -94,7 +80,7 @@
       </p>
 
       <emu-alg aoid="CurrencyDigits">
-        1. If the ISO 4217 currency and funds code list contains _currency_ as an alphabetic code, then return the minor unit value corresponding to the _currency_ from the list; else return 2.
+        1. If the ISO 4217 currency and funds code list contains _currency_ as an alphabetic code, return the minor unit value corresponding to the _currency_ from the list; otherwise, return 2.
       </emu-alg>
 
     </emu-clause>
@@ -108,8 +94,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _numberFormat_ be OrdinaryCreateFromConstructor(_newTarget_, *%NumberFormatPrototype%*).
-        1. ReturnIfAbrupt(_numberFormat_).
+        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *%NumberFormatPrototype%*).
         1. Return InitializeNumberFormat(_numberFormat_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -119,7 +104,7 @@
     <h1>Properties of the Intl.NumberFormat Constructor</h1>
 
     <p>
-      Besides the internal slots and the *length* property (whose value is 0), the Intl.NumberFormat constructor has the following properties:
+      Besides the internal slots and the `length` property (whose value is 0), the Intl.NumberFormat constructor has the following properties:
     </p>
 
     <emu-clause id="sec-Intl.NumberFormat.prototype">
@@ -147,7 +132,7 @@
       </emu-alg>
 
       <p>
-        The value of the *length* property of the *supportedLocalesOf* method is 1.
+        The value of the `length` property of the *supportedLocalesOf* method is 1.
       </p>
     </emu-clause>
 
@@ -221,11 +206,13 @@
       </p>
 
       <emu-alg>
-        1. Let _nf_ be this NumberFormat object.
+        1. Let _nf_ be *this* value.
+        1. If Type(_nf_) is not Object, throw a *TypeError* exception.
+        1. If _nf_ does not have a [[boundFormat]] internal slot, throw a *TypeError* exception.
         1. If _nf_.[[boundFormat]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-number-format-functions"></emu-xref>.
-          1. The value of _F_’s *length* property is 1.
-          1. Let _bf_ be BoundFunctionCreate(_F_, «*this* value»).
+          1. The value of _F_’s `length` property is 1.
+          1. Let _bf_ be BoundFunctionCreate(_F_, _nf_).
           1. Set _nf_.[[boundFormat]] to _bf_.
         1. Return _nf_.[[boundFormat]].
       </emu-alg>
@@ -250,8 +237,7 @@
         1. Let _nf_ be the *this* value.
         1. Assert: Type(_nf_) is Object and _nf_ has an [[initializedNumberFormat]] internal slot whose value is *true*.
         1. If _value_ is not provided, let _value_ be *undefined*.
-        1. Let _x_ be ToNumber(_value_).
-        1. ReturnIfAbrupt(_x_).
+        1. Let _x_ be ? ToNumber(_value_).
         1. Return FormatNumber(_nf_, _x_).
       </emu-alg>
 
@@ -276,24 +262,24 @@
         1. If the _result_ of isFinite(_x_) is *false*, then
           1. If _x_ is *NaN*,
             1. Let _n_ be an ILD String value indicating the *NaN* value.
-          1. Else
+          1. Else,
             1. Let _n_ be an ILD String value indicating infinity.
-            1. If _x_ < 0, then let _negative_ be *true*.
-        1. Else
+            1. If _x_ < 0, let _negative_ be *true*.
+        1. Else,
           1. If _x_ < 0, then
             1. Let _negative_ be *true*.
             1. Let _x_ be -_x_.
           1. If the value of _numberFormat_.[[style]] is *"percent"*, let _x_ be 100 × _x_.
           1. If the _numberFormat_.[[minimumSignificantDigits]] and _numberFormat_.[[maximumSignificantDigits]] are present, then
             1. Let _n_ be ToRawPrecision(_x_, _numberFormat_.[[minimumSignificantDigits]], _numberFormat_.[[maximumSignificantDigits]]).
-          1. Else
+          1. Else,
             1. Let _n_ be ToRawFixed(_x_, _numberFormat_.[[minimumIntegerDigits]], _numberFormat_.[[minimumFractionDigits]], _numberFormat_.[[maximumFractionDigits]]).
           1. If the value of the _numberFormat_.[[numberingSystem]] matches one of the values in the "Numbering System" column of <emu-xref href="#table-2">Table 2</emu-xref> below, then
             1. Let _digits_ be an array whose 10 String valued elements are the UTF-16 string representations of the 10 _digits_ specified in the "Digits" column of the matching row in <emu-xref href="#table-2">Table 2</emu-xref>.
             1. Replace each _digit_ in _n_ with the value of _digits_[_digit_].
           1. Else use an implementation dependent algorithm to map _n_ to the appropriate representation of _n_ in the given numbering system.
-          1. If _n_ contains the character *"."*, then replace it with an ILND String representing the decimal separator.
-          1. If the value of the _numberFormat_.[[useGrouping]] is *true*, then insert an ILND String representing a grouping separator into an ILND set of locations within the integer part of _n_.
+          1. If _n_ contains the character *"."*, replace it with an ILND String representing the decimal separator.
+          1. If the value of the _numberFormat_.[[useGrouping]] is *true*, insert an ILND String representing a grouping separator into an ILND set of locations within the integer part of _n_.
         1. If _negative_ is *true*, then
           1. Let _result_ be the value of _numberFormat_.[[negativePattern]].
         1. Else,
@@ -303,9 +289,9 @@
           1. Let _currency_ be the value of _numberFormat_.[[currency]].
           1. If _numberFormat_.[[currencyDisplay]] is *"code"*, then
             1. Let _cd_ be _currency_.
-          1. Else, if _numberFormat_.[[currencyDisplay]] is *"symbol"*, then
-            1. Let _cd_ be an ILD string representing _currency_ in short form. If the implementation does not have such a representation of _currency_, then use _currency_ itself.
-          1. Else, if _numberFormat_.[[currencyDisplay]] is *"name"*, then
+          1. Else if _numberFormat_.[[currencyDisplay]] is *"symbol"*, then
+            1. Let _cd_ be an ILD string representing _currency_ in short form. If the implementation does not have such a representation of _currency_, use _currency_ itself.
+          1. Else if _numberFormat_.[[currencyDisplay]] is *"name"*, then
             1. Let _cd_ be an ILD string representing _currency_ in long form. If the implementation does not have such a representation of _currency_, then use _currency_ itself.
           1. Replace the substring *"{currency}"* within _result_ with _cd_.
         1. Return _result_.
@@ -320,7 +306,7 @@
         1. If _x_ = 0, then
           1. Let _m_ be the String consisting of _p_ occurrences of the character *"0"*.
           1. Let _e_ be 0.
-        1. Else
+        1. Else,
           1. Let _e_ and _n_ be integers such that 10<sup>_p_–1</sup> ≤ _n_ < 10<sup>_p_</sup> and for which the exact mathematical value of _n_ × 10<sup>_e_–_p_+1</sup> – _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ × 10<sup>_e_–_p_+1</sup> is larger.
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
         1. If _e_ ≥ _p_, then
@@ -358,7 +344,7 @@
           1. Let _a_ be the first _k_–_f_ characters of _m_, and let _b_ be the remaining _f_ characters of _m_.
           1. Let _m_ be the concatenation of the three Strings _a_, *"."*, and _b_.
           1. Let _int_ be the number of characters in _a_.
-        1. Else let _int_ be the number of characters in _m_.
+        1. Else, let _int_ be the number of characters in _m_.
         1. Let _cut_ be _maxFraction_ – _minFraction_.
         1. Repeat while _cut_ > 0 and the last character of _m_ is *"0"*:
           1. Remove the last character from _m_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -344,7 +344,7 @@
           1. Let _a_ be the first _k_–_f_ characters of _m_, and let _b_ be the remaining _f_ characters of _m_.
           1. Let _m_ be the concatenation of the three Strings _a_, *"."*, and _b_.
           1. Let _int_ be the number of characters in _a_.
-        1. Else, let _int_ be the number of characters in _m_.
+        1. Else let _int_ be the number of characters in _m_.
         1. Let _cut_ be _maxFraction_ – _minFraction_.
         1. Repeat while _cut_ > 0 and the last character of _m_ is *"0"*:
           1. Remove the last character from _m_.


### PR DESCRIPTION
## Editorial fixes

- then and else corrections
- algos with numeric index in the steps are now set to 1.
- few missing cross-links
- proper use of `*this* value`

## Aligning with 262:

- ReturnIfAbrupt -> ?
- inline styles and conventions