### PR TITLE
[4rd Edition] DateTimeFormat.formatToParts()

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -223,16 +223,20 @@
         1. Return FormatDateTime(_dtf_, _x_).
       </emu-alg>
 
+      <emu-note>
+        The function returned by [[Get]] is bound to this DateTimeFormat object so that it can be passed directly to Array.prototype.map or other functions.
+      </emu-note>
+
       <p>
         The *length* property of a DateTime format function is 1.
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-formatdatetime" aoid="FormatDateTime">
-      <h1>FormatDateTime (dateTimeFormat, x)</h1>
+    <emu-clause id="sec-partitiondatetimepattern" aoid="PartitionDateTimePattern">
+      <h1>PartitionDateTimePattern (dateTimeFormat, x)</h1>
 
       <p>
-        When the FormatDateTime abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), it returns a String value representing _x_ (interpreted as a time value as specified in ES2017, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>) according to the effective locale and the formatting options of _dateTimeFormat_. This abstract operation functions as follows:
+        The *PartitionDateTimePattern* abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), interprets _x_ as a time value as specified in ES2015, 20.3.1.1, and creates the corresponding parts according to the effective locale and the formatting options of _dateTimeFormat_. The following steps are taken:
       </p>
 
       <emu-alg>
@@ -247,17 +251,27 @@
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, `"useGrouping"`, *false*).
         1. Let _nf2_ be ? Construct(%NumberFormat%, « _nfLocale_, _nf2Options_ »).
         1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[calendar]], _dateTimeFormat_.[[timeZone]]).
-        1. Let _result_ be _dateTimeFormat_.[[pattern]].
-        1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, do:
-          1. If _dateTimeFormat_ has an internal slot with the name given in the Property column of the row, then
-            1. Let _p_ be the name given in the Property column of the row.
+        1. Let _pattern_ be _dateTimeFormat_.[[pattern]].
+        1. Let _result_ be a new empty List.
+        1. Let _beginIndex_ be Call(*%StringProto_indexOf%*, _pattern_, "{", *0*).
+        1. Let _endIndex_ be 0.
+        1. Let _nextIndex_ be 0.
+        1. Let _length_ be the number of code units in _pattern_.
+        1. Repeat while _beginIndex_ is an integer index into _pattern_:
+          1. Set _endIndex_ to Call(*%StringProto_indexOf%*, _pattern_, "}", _beginIndex_)
+          1. If _endIndex_ = -1, throw new Error exception.
+          1. If _beginIndex_ is greater than _nextIndex_, then:
+            1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
+            1. Add new part record { [[type]]: *"literal"*, [[value]]: _literal_ } as a new element of the list _result_.
+          1. Let _p_ be the substring of _pattern_ from position _beginIndex_, exclusive, to position _endIndex_, exclusive.
+          1. If _p_ matches a Property column of the row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, then:
+
             1. Let _f_ be _dateTimeFormat_.[[<_p_>]].
             1. Let _v_ be _tm_.[[<_p_>]].
             1. If _p_ is *"year"* and _v_ ≤ 0, let _v_ be 1 - _v_.
             1. If _p_ is *"month"*, increase _v_ by 1.
             1. If _p_ is *"hour"* and _dateTimeFormat_.[[hour12]] is *true*, then
               1. Let _v_ be _v_ modulo 12.
-              1. If _v_ is equal to _tm_.[[<_p_>]], let _pm_ be *false*; else let _pm_ be *true*.
               1. If _v_ is 0 and _dateTimeFormat_.[[hourNo0]] is *true*, let _v_ be 12.
             1. If _f_ is *"numeric"*, then
               1. Let _fv_ be FormatNumber(_nf_, _v_).
@@ -265,19 +279,71 @@
               1. Let _fv_ be FormatNumber(_nf2_, _v_).
               1. If the *length* property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
             1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _f_ in the desired form; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _dateTimeFormat_ has a [[day]] internal slot. If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[inDST]] field of _tm_. If _p_ is *"era"*, then the String value may also depend on whether _dateTimeFormat_ has a [[era]] internal slot and if the implementation does not have a localized representation of _f_, then use _f_ itself.
-            1. Replace the substring of _result_ that consists of *"{"*, _p_, and *"}"*, with _fv_.
-        1. If _dateTimeFormat_.[[hour12]] is *true*, then
-          1. If _pm_ is *true*, then
-            1. Let _fv_ be an implementation and locale dependent String value representing "post meridiem".
-          1. Else,
-            1. Let _fv_ be an implementation and locale dependent String value representing "ante meridiem".
-          1. Replace the substring of _result_ that consists of *"{ampm}"*, with _fv_.
+            1. Add new part record { [[type]]: _p_, [[value]]: _fv_ } as a new element of the list _result_.
+          1. Else if _p_ is equal "ampm", then:
+            1. Let _v_ be the value of _tm_.[[hour]].
+            1. If _v_ is greater than 11, then:
+              1. Let _fv_ be an implementation and locale dependent String value representing "post meridiem";
+            1. Else,
+              1. Let _fv_ be an implementation and locale dependent String value representing "ante meridiem".
+            1. Add new part record { [[type]]: *"dayPeriod"*, [[value]]: _fv_ } as a new element of the list _result_.
+            1. Let _literal_ be the substring of _pattern_ from position _beginIndex_, inclusive, to position _endIndex_, inclusive.
+            1. Add new part record { [[type]]: *"literal"*, [[value]]: _literal_ } as a new element of the list _result_.
+          1. Set _nextIndex_ to _endIndex_ + 1.
+          1. Set _beginIndex_ to Call(*%StringProto_indexOf%*, _pattern_, "}", _nextIndex_)
+        1. If _nextIndex_ is less than _length_, then:
+          1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, exclusive, to position _length_, exclusive.
+          1. Add new part record { [[type]]: *"literal"*, [[value]]: _literal_ } as a new element of the list _result_.
         1. Return _result_.
       </emu-alg>
 
       <emu-note>
         It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>), and use CLDR "abbreviated" strings for DateTimeFormat "short" strings, and CLDR "wide" strings for DateTimeFormat "long" strings.
       </emu-note>
+
+      <emu-note>
+        It is recommended that implementations use the time zone information of the IANA Time Zone Database.
+      </emu-note>
+
+    </emu-clause>
+
+    <emu-clause id="sec-formatdatetime" aoid="FormatDateTime">
+      <h1>FormatDateTime(dateTimeFormat, x)</h1>
+
+      <p>
+        The FormatDateTime abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), and performs the following steps:
+      </p>
+
+      <emu-alg>
+        1. Let _parts_ be ? PartitionDateTimePattern(_dateTimeFormat_, _x_).
+        1. Let _result_ be an empty String.
+        1. For each _part_ in _parts_, do:
+          1. Set _result_ to a String value produced by concatenating _result_ and _part_.[[value]].
+        1. Return _result_.
+      </emu-alg>
+
+    </emu-clause>
+
+    <emu-clause id="sec-formatdatetimetoparts" aoid="FormatDateTimeToparts">
+      <h1>FormatDateTimeToParts(dateTimeFormat, x)</h1>
+
+      <p>
+        The FormatDateTimeToParts abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), and performs the following steps:
+      </p>
+
+      <emu-alg>
+        1. Let _parts_ be ? PartitionDateTimePattern(_dateTimeFormat_, _x_).
+        1. Let _result_ be ArrayCreate(0).
+        1. Let _n_ be 0.
+        1. For each _part_ in _parts_, do:
+          1. Let _O_ be ObjectCreate(%ObjectPrototype%).
+          1. Perform ? CreateDataPropertyOrThrow(_O_, "type", _part_.[[type]]).
+          1. Perform ? CreateDataPropertyOrThrow(_O_, "value", _part_.[[value]]).
+          1. Perform ? CreateDataProperty(_result_, ? ToString(_n_), _O_).
+          1. Increment _n_ by 1.
+        1. Return _result_.
+      </emu-alg>
+
     </emu-clause>
 
     <emu-clause id="sec-tolocaltime" aoid="ToLocalTime">
@@ -455,6 +521,25 @@
           1. Perform ! DefinePropertyOrThrow(_bf_, `"length"`, PropertyDescriptor {[[Value]]: 1, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
           1. Set _dtf_.[[boundFormat]] to _bf_.
         1. Return _dtf_.[[boundFormat]].
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DateTimeFormat.prototype.formatToParts">
+      <h1>Intl.DateTimeFormat.prototype.formatToParts ([ date ])</h1>
+
+      <p>
+        When the *Intl.DateTimeFormat.prototype.formatToParts* is called with an optional argument _date_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _dtf_ be *this* value.
+        1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
+        1. If _dtf_ does not have an [[initializedDateTimeFormat]] internal slot, throw a *TypeError* exception.
+        1. If _date_ is not provided or is *undefined*, then
+          1. Let _x_ be *%Date_now%*().
+        1. Else,
+          1. Let _x_ be ? ToNumber(_date_).
+        1. Return ? FormatDateTimeToParts(_dtf_, _x_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Issue: https://github.com/tc39/ecma402/issues/30

## Features

* `CreateDateTimeParts` is a new abstract that powers `format()` and `formatToParts()` for `dataTimeFormat` instances.
* Moving all abstracts to the new Abstract section.
