### PR TITLE
Editorial: Fixes to align with ES2016 Draft 2016-01-20

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "repository": "tc39/ecma402",
   "author": "ECMA TC39",
-  "license": "SEE LICENSE IN https://tc39.github.io/ecma262/#sec-copyright-and-software-license",
+  "license": "SEE LICENSE IN https://tc39.github.io/ecma402/#sec-copyright-and-software-license",
   "homepage": "https://tc39.github.io/ecma402/",
   "dependencies": {
-    "ecmarkup": "^2.5.4"
+    "ecmarkup": "^3.0.0"
   }
 }

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -55,14 +55,14 @@
           1. Let _options_ be ObjectCreate(*%ObjectPrototype%*).
         1. Else,
           1. Let _options_ be ? ToObject(_options_).
-        1. Let _u_ be ? GetOption(_options_, *"usage"*, *"string"*, «*"sort"*, *"search"*», *"sort"*).
+        1. Let _u_ be ? GetOption(_options_, *"usage"*, *"string"*, « *"sort"*, *"search"* », *"sort"*).
         1. Set _collator_.[[usage]] to _u_.
         1. If _u_ is *"sort"*, then
           1. Let _localeData_ be the value of *%Collator%*.[[sortLocaleData]].
         1. Else,
           1. Let _localeData_ be the value of *%Collator%*.[[searchLocaleData]].
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, «*"lookup"*, *"best fit"*», *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. For each row in <emu-xref href="#table-1">Table 1</emu-xref>, except the header row, do:
           1. Let _key_ be the name given in the Key column of the row.
@@ -92,7 +92,7 @@
             1. If the name given in the Type column of the row is *"boolean"*, let _value_ be the result of comparing value with *"true"*.
           1. Set _collator_.[[&lt;_property_&gt;]] to _value_.
           1. Increase _k_ by 1.
-        1. Let _s_ be ? GetOption(_options_, *"sensitivity"*, *"string"*, «*"base"*, *"accent"*, *"case"*, *"variant"*», *undefined*).
+        1. Let _s_ be ? GetOption(_options_, *"sensitivity"*, *"string"*, « *"base"*, *"accent"*, *"case"*, *"variant"* », *undefined*).
         1. If _s_ is *undefined*, then
           1. If _u_ is *"sort"*, then
             1. Let _s_ be *"variant"*.
@@ -111,7 +111,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.Collator">
-      <h1>Intl.Collator([ locales [, options]])</h1>
+      <h1>Intl.Collator ([ locales [ , options ]])</h1>
 
       <p>
         When the *Intl.Collator* function is called with optional arguments locales and options the following steps are taken:
@@ -145,7 +145,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.Collator.supportedLocalesOf">
-      <h1>Intl.Collator.supportedLocalesOf (locales [, options ])</h1>
+      <h1>Intl.Collator.supportedLocalesOf (locales [ , options ])</h1>
 
       <p>
         When the *supportedLocalesOf* method of Intl.Collator is called, the following steps are taken:
@@ -205,7 +205,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.Collator.prototype-toStringTag">
-      <h1>Intl.Collator.prototype[@@toStringTag]</h1>
+      <h1>Intl.Collator.prototype [ @@toStringTag ]</h1>
 
       <p>
         The initial value of the @@toStringTag property is the string value *"Object"*.

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -129,7 +129,7 @@
     <h1>Properties of the Intl.Collator Constructor</h1>
 
     <p>
-      Besides the internal slots and the *length* property (whose value is 0), the Intl.Collator constructor has the following properties:
+      The Intl.Collator constructor has the following properties:
     </p>
 
     <emu-clause id="sec-Intl.Collator.prototype">

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -222,7 +222,7 @@
     <h1>Properties of the Intl.DateTimeFormat Constructor</h1>
 
     <p>
-      Besides the internal slots and the *length* property (whose value is 0), the Intl.DateTimeFormat constructor has the following properties:
+      The Intl.DateTimeFormat constructor has the following properties:
     </p>
 
     <emu-clause id="sec-Intl.DateTimeFormat.prototype">

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -77,7 +77,7 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Let _options_ be ? ToDateTimeOptions(_options_, *"any"*, *"date"*).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, «*"lookup"*, *"best fit"*», *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be the value of *%DateTimeFormat%*.[[localeData]].
         1. Let _r_ be ResolveLocale( *%DateTimeFormat%*.[[availableLocales]], _requestedLocales_, _opt_, *%DateTimeFormat%*.[[relevantExtensionKeys]], _localeData_).
@@ -97,11 +97,11 @@
         1. Let _opt_ be a new Record.
         1. For each row of <emu-xref href="#table-3">Table 3</emu-xref>, except the header row, do:
           1. Let _prop_ be the name given in the Property column of the row.
-          1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, «the strings given in the Values column of the row», *undefined*).
+          1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, « the strings given in the Values column of the row », *undefined*).
           1. Set _opt_.[[<_prop_>]] to _value_.
         1. Let _dataLocaleData_ be Get(_localeData_, _dataLocale_).
         1. Let _formats_ be Get(_dataLocaleData_, *"formats"*).
-        1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, «*"basic"*, *"best fit"*», *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, « *"basic"*, *"best fit"* », *"best fit"*).
         1. If _matcher_ is *"basic"*, then
           1. Let _FormatMatcher_ be the abstract operation BasicFormatMatcher.
         1. Else,
@@ -204,7 +204,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.DateTimeFormat">
-      <h1>Intl.DateTimeFormat([ locales [, options ]])</h1>
+      <h1>Intl.DateTimeFormat ([ locales [ , options ]])</h1>
 
       <p>
         When the *Intl.DateTimeFormat* function is called with optional arguments _locales_ and _options_ the following steps are taken:
@@ -237,7 +237,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.DateTimeFormat.supportedLocalesOf">
-      <h1>Intl.DateTimeFormat.supportedLocalesOf (locales [, options ])</h1>
+      <h1>Intl.DateTimeFormat.supportedLocalesOf (locales [ , options ])</h1>
 
       <p>
         When the *supportedLocalesOf* method of Intl.DateTimeFormat is called, the following steps are taken:
@@ -325,7 +325,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.DateTimeFormat.prototype-toStringTag">
-      <h1>Intl.DateTimeFormat.prototype[@@toStringTag]</h1>
+      <h1>Intl.DateTimeFormat.prototype [ @@toStringTag ]</h1>
 
       <p>
         The initial value of the @@toStringTag property is the string value *"Object"*.
@@ -392,8 +392,8 @@
       <emu-alg aoid="FormatDateTime">
         1. If _x_ is not a finite Number, throw a *RangeError* exception.
         1. Let _locale_ be the value of _dateTimeFormat_.[[locale]].
-        1. Let _nf_ be ? Construct(%NumberFormat%, «[locale], {useGrouping: *false*}»).
-        1. Let _nf2_ be ? Construct(%NumberFormat%, «[locale], {minimumIntegerDigits: 2, useGrouping: *false*}»).
+        1. Let _nf_ be ? Construct(%NumberFormat%, « [locale], {useGrouping: *false*} »).
+        1. Let _nf2_ be ? Construct(%NumberFormat%, « [locale], {minimumIntegerDigits: 2, useGrouping: *false*} »).
         1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[calendar]], _dateTimeFormat_.[[timeZone]]).
         1. Let _result_ be the value of the _dateTimeFormat_.[[pattern]].
         1. For each row of <emu-xref href="#table-3">Table 3</emu-xref>, except the header row, do:

--- a/spec/index.html
+++ b/spec/index.html
@@ -6,6 +6,11 @@
     <link href="ecmarkup.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
     <script src="ecmarkup.js"></script>
+    <script>
+      if (location.hostname === 'tc39.github.io' && location.protocol !== 'https:') {
+        location.protocol = 'https:';
+      }
+    </script>
     <style>
       h1.orange {
         font-size: 2em;

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -13,7 +13,7 @@
     <h1>Properties of the String Prototype Object</h1>
 
     <emu-clause id="sec-String.prototype.localeCompare">
-      <h1>String.prototype.localeCompare (that [, locales [, options ]])</h1>
+      <h1>String.prototype.localeCompare (that [ , locales [ , options ]])</h1>
 
       <p>
         This definition supersedes the definition provided in ES2015, 21.1.3.10.
@@ -27,7 +27,7 @@
         1. Let _O_ be RequireObjectCoercible(*this* value).
         1. Let _S_ be ? ToString(_O_).
         1. Let _That_ be ? ToString(_that_).
-        1. Let _collator_ be ? Construct(*%Collator%*, «*locales*, *options*»).
+        1. Let _collator_ be ? Construct(*%Collator%*, « *locales*, *options* »).
         1. Return CompareStrings(_collator_, _S_, _That_)
       </emu-alg>
 
@@ -130,7 +130,7 @@
     </p>
 
     <emu-clause id="sec-Number.prototype.toLocaleString">
-      <h1>Number.prototype.toLocaleString ([locales [, options ]])</h1>
+      <h1>Number.prototype.toLocaleString ([ locales [ , options ]])</h1>
 
       <p>
         This definition supersedes the definition provided in ES2015, 20.1.3.4.
@@ -142,7 +142,7 @@
 
       <emu-alg>
         1. Let _x_ be ? thisNumberValue(*this* value).
-        1. Let _numberFormat_ be ? Construct(*%NumberFormat%*, «*locales*, *options*»).
+        1. Let _numberFormat_ be ? Construct(*%NumberFormat%*, « *locales*, *options* »).
         1. Return FormatNumber(_numberFormat_, _x_).
       </emu-alg>
 
@@ -161,7 +161,7 @@
     </p>
 
     <emu-clause id="sec-Date.prototype.toLocaleString">
-      <h1>Date.prototype.toLocaleString ([locales [, options ]])</h1>
+      <h1>Date.prototype.toLocaleString ([ locales [ , options ]])</h1>
 
       <p>
         This definition supersedes the definition provided in ES2015, 20.3.4.39.
@@ -175,7 +175,7 @@
         1. Let _x_ be ? thisTimeValue(*this* value).
         1. If _x_ is *NaN*, return *"Invalid Date"*.
         1. Let _options_ be ? ToDateTimeOptions(_options_, *"any"*, *"all"*).
-        1. Let _dateFormat_ be ? Construct(*%DateTimeFormat%*, «*locales*, *options*»).
+        1. Let _dateFormat_ be ? Construct(*%DateTimeFormat%*, « *locales*, *options* »).
         1. Return FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
 
@@ -186,7 +186,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Date.prototype.toLocaleDateString">
-      <h1>Date.prototype.toLocaleDateString ([locales [, options ]])</h1>
+      <h1>Date.prototype.toLocaleDateString ([ locales [ , options ]])</h1>
 
       <p>
         This definition supersedes the definition provided in ES2015, 20.3.4.38.
@@ -200,7 +200,7 @@
         1. Let _x_ be ? thisTimeValue(*this* value).
         1. If _x_ is *NaN*, return *"Invalid Date"*.
         1. Let _options_ be ? ToDateTimeOptions(_options_, *"date"*, *"date"*).
-        1. Let _dateFormat_ be ? Construct(*%DateTimeFormat%*, «*locales*, *options*»).
+        1. Let _dateFormat_ be ? Construct(*%DateTimeFormat%*, « *locales*, *options* »).
         1. Return FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
 
@@ -211,7 +211,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Date.prototype.toLocaleTimeString">
-      <h1>Date.prototype.toLocaleTimeString ([locales [, options ]])</h1>
+      <h1>Date.prototype.toLocaleTimeString ([ locales [ , options ]])</h1>
 
       <p>
         This definition supersedes the definition provided in ES2015, 20.3.4.40.
@@ -225,7 +225,7 @@
         1. Let _x_ be ? thisTimeValue(*this* value).
         1. If _x_ is *NaN*, return *"Invalid Date"*.
         1. Let _options_ be ? ToDateTimeOptions(_options_, *"time"*, *"time"*).
-        1. Let _timeFormat_ be ? Construct(*%DateTimeFormat%*, «*locales*, *options*»).
+        1. Let _timeFormat_ be ? Construct(*%DateTimeFormat%*, « *locales*, *options* »).
         1. Return FormatDateTime(_timeFormat_, _x_).
       </emu-alg>
 
@@ -240,7 +240,7 @@
     <h1>Properties of the Array Prototype Object</h1>
 
     <emu-clause id="sec-Array.prototype.toLocaleString">
-      <h1>Array.prototype.toLocaleString([locales [, options ]])</h1>
+      <h1>Array.prototype.toLocaleString ([ locales [ , options ]])</h1>
 
       <p>
         This definition supersedes the definition provided in ES2015, 22.1.3.26.
@@ -259,7 +259,7 @@
         1. If _firstElement_ is *undefined* or *null*, then
           1. Let _R_ be an empty String.
         1. Else,
-          1. Let _R_ be ? ToString(Invoke(_firstElement_, *"toLocaleString"*, «*locales*, *options*»)).
+          1. Let _R_ be ? ToString(Invoke(_firstElement_, *"toLocaleString"*, « *locales*, *options* »)).
         1. Let _k_ be 1.
         1. Repeat, while _k_ < _len_
           1. Let _S_ be a String value produced by concatenating _R_ and _separator_.
@@ -267,7 +267,7 @@
           1. If _nextElement_ is *undefined* or *null*, then
             1. Let _R_ be the empty String.
           1. Else,
-            1. Let _R_ be ? ToString(Invoke(_nextElement_, *"toLocaleString"*, «*locales*, *options*»)).
+            1. Let _R_ be ? ToString(Invoke(_nextElement_, *"toLocaleString"*, « *locales*, *options* »)).
           1. Let _R_ be a String value produced by concatenating _S_ and _R_.
           1. Increase _k_ by 1.
         1. Return _R_.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -42,7 +42,7 @@
           1. Return a new empty List.
         1. Let _seen_ be an empty List.
         1. If Type(_locales_) is String, then
-          1. Let _aLocales_ be CreateArrayFromList(«_locales_»).
+          1. Let _aLocales_ be CreateArrayFromList(« _locales_ »).
         1. Let _O_ be ? ToObject(_aLocales_).
         1. Let _len_ be ToLength(Get(_O_, *"length"*)).
         1. Let _k_ be 0.
@@ -154,7 +154,7 @@
         1. If _r_ has an [[extension]] field, then
           1. Let _extension_ be the value of _r_.[[extension]].
           1. Let _extensionIndex_ be the value of _r_.[[extensionIndex]].
-          1. Let _extensionSubtags_ be Call(*%StringProto_split%*, extension, «*"-"*») .
+          1. Let _extensionSubtags_ be Call(*%StringProto_split%*, extension, « *"-"* ») .
           1. Let _extensionSubtagsLength_ be Get(CreateArrayFromList(_extensionSubtags_), *"length"*).
         1. Let _result_ be a new Record.
         1. Set _result_.[[dataLocale]] to _foundLocale_.
@@ -169,18 +169,18 @@
           1. Let _value_ be ? ToString(Get(_keyLocaleData_, *"0"*)).
           1. Let _supportedExtensionAddition_ be *""*.
           1. If _extensionSubtags_ is not *undefined*, then
-            1. Let _keyPos_ be Call(*%ArrayProto_indexOf%*, _extensionSubtags_, «_key_») .
+            1. Let _keyPos_ be Call(*%ArrayProto_indexOf%*, _extensionSubtags_, « _key_ ») .
             1. If _keyPos_ ≠ -1, then
               1. If _keyPos_ + 1 < _extensionSubtagsLength_ and the *length* property of the result of Get(_extensionSubtags_, ToString(_keyPos_ +1)) is greater than 2, then
                 1. Let _requestedValue_ be Get(_extensionSubtags_, ToString(_keyPos_ +1)).
-                1. If the result of Call(*%StringProto_includes%*, _keyLocaleData_, «_requestedValue_») is *true*, then
+                1. If the result of Call(*%StringProto_includes%*, _keyLocaleData_, « _requestedValue_ ») is *true*, then
                   1. Let _value_ be _requestedValue_.
                   1. Let _supportedExtensionAddition_ be the concatenation of *"-"*, _key_, *"-"*, and _value_.
-              1. Else if the result of Call(*%StringProto_includes%*, _keyLocaleData_, «*"true"*») is *true*, then
+              1. Else if the result of Call(*%StringProto_includes%*, _keyLocaleData_, « *"true"* ») is *true*, then
                 1. Let _value_ be *"true"*.
           1. If _options_ has a field [[<_key_>]], then
             1. Let _optionsValue_ be ? ToString(_options_.[[<_key_>]]).
-            1. If the result of Call(*%StringProto_includes%*, _keyLocaleData_, «_optionsValue_») is *true*, then
+            1. If the result of Call(*%StringProto_includes%*, _keyLocaleData_, « _optionsValue_ ») is *true*, then
               1. If _optionsValue_ is not equal to _value_, then
                 1. Let _value_ be _optionsValue_.
                 1. Let _supportedExtensionAddition_ be *""*.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -104,7 +104,7 @@
     <h1>Properties of the Intl.NumberFormat Constructor</h1>
 
     <p>
-      Besides the internal slots and the *length* property (whose value is 0), the Intl.NumberFormat constructor has the following properties:
+      The Intl.NumberFormat constructor has the following properties:
     </p>
 
     <emu-clause id="sec-Intl.NumberFormat.prototype">

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -28,14 +28,14 @@
         1. Else,
           1. Let _options_ be ? ToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, «*"lookup"*, *"best fit"*», *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be *%NumberFormat%*.[[localeData]].
         1. Let _r_ be ResolveLocale(*%NumberFormat%*.[[availableLocales]], _requestedLocales_, _opt_, *%NumberFormat%*.[[relevantExtensionKeys]], _localeData_).
         1. Set _numberFormat_.[[locale]] to the value of _r_.[[locale]].
         1. Set _numberFormat_.[[numberingSystem]] to the value of _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _s_ be ? GetOption(_options_, *"style"*, *"string"*, «*"decimal"*, *"percent"*, *"currency"*», *"decimal"*).
+        1. Let _s_ be ? GetOption(_options_, *"style"*, *"string"*, « *"decimal"*, *"percent"*, *"currency"* », *"decimal"*).
         1. Set _numberFormat_.[[style]] to _s_.
         1. Let _c_ be ? GetOption(_options_, *"currency"*, *"string"*, *undefined*, *undefined*).
         1. If _c_ is not *undefined*, then
@@ -45,7 +45,7 @@
           1. Let _c_ be converting _c_ to upper case as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
           1. Set _numberFormat_.[[currency]] to _c_.
           1. Let _cDigits_ be CurrencyDigits(_c_)
-        1. Let _cd_ be ? GetOption(_options_, *"currencyDisplay"*, *"string"*, «*"code"*, *"symbol"*, *"name"*», *"symbol"*).
+        1. Let _cd_ be ? GetOption(_options_, *"currencyDisplay"*, *"string"*, « *"code"*, *"symbol"*, *"name"* », *"symbol"*).
         1. If _s_ is *"currency"*, set _numberFormat_.[[currencyDisplay]] to _cd_.
         1. Let _mnid_ be ? GetNumberOption(_options_, *"minimumIntegerDigits"*, 1, 21, 1).
         1. Set _numberFormat_.[[minimumIntegerDigits]] to _mnid_.
@@ -86,7 +86,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.NumberFormat">
-      <h1>Intl.NumberFormat([ locales [, options]])</h1>
+      <h1>Intl.NumberFormat ([ locales [ , options ]])</h1>
 
       <p>
         When the *Intl.NumberFormat* function is called with optional arguments the following steps are taken:
@@ -119,7 +119,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.NumberFormat.supportedLocalesOf">
-      <h1>Intl.NumberFormat.supportedLocalesOf (locales [, options ])</h1>
+      <h1>Intl.NumberFormat.supportedLocalesOf (locales [ , options ])</h1>
 
       <p>
         When the *supportedLocalesOf* method of *%NumberFormat%* is called, the following steps are taken:
@@ -185,7 +185,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.NumberFormat.prototype-toStringTag">
-      <h1>Intl.NumberFormat.prototype[@@toStringTag]</h1>
+      <h1>Intl.NumberFormat.prototype [ @@toStringTag ]</h1>
 
       <p>
         The initial value of the @@toStringTag property is the string value *"Object"*.


### PR DESCRIPTION
* function length and name clean-ups
* list argument should « _alway_ » have spaces.
* update headers to use spaces
* update optional arguments to have spaces
* https for `tc39.github.io`

Other changes:
* update ecmarkup
* fix link to license