### PR TITLE
Refactor to group abstract operations per section for `NumberFormat` and `DateTimeFormat`

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1,74 +1,66 @@
 <emu-clause id="datetimeformat-objects">
   <h1>DateTimeFormat Objects</h1>
 
-  <emu-clause id="sec-intl-datetimeformat-constructor">
-    <h1>The Intl.DateTimeFormat Constructor</h1>
+  <emu-clause id="sec-datetimeformat-abstracts">
+    <h1>Abstract Operations For DateTimeFormat Objects</h1>
 
     <p>
-      The Intl.DateTimeFormat constructor is a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      Several DateTimeFormat algorithms use values from the following table, which provides property names and allowable values for the components of date and time formats:
     </p>
+
+    <emu-table id="table-3">
+      <emu-caption>Components of date and time formats</emu-caption>
+      <table class="real-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Values</th>
+          </tr>
+        </thead>
+        <tr>
+          <td>weekday</td>
+          <td>"narrow", "short", "long"</td>
+        </tr>
+        <tr>
+          <td>era</td>
+          <td>"narrow", "short", "long"</td>
+        </tr>
+        <tr>
+          <td>year</td>
+          <td>"2-digit", "numeric"</td>
+        </tr>
+        <tr>
+          <td>month</td>
+          <td>"2-digit", "numeric", "narrow", "short", "long"</td>
+        </tr>
+        <tr>
+          <td>day</td>
+          <td>"2-digit", "numeric"</td>
+        </tr>
+        <tr>
+          <td>hour</td>
+          <td>"2-digit", "numeric"</td>
+        </tr>
+        <tr>
+          <td>minute</td>
+          <td>"2-digit", "numeric"</td>
+        </tr>
+        <tr>
+          <td>second</td>
+          <td>"2-digit", "numeric"</td>
+        </tr>
+        <tr>
+          <td>timeZoneName</td>
+          <td>"short", "long"</td>
+        </tr>
+      </table>
+    </emu-table>
 
     <emu-clause id="sec-InitializeDateTimeFormat" aoid="InitializeDateTimeFormat">
       <h1>InitializeDateTimeFormat (dateTimeFormat, locales, options)</h1>
 
       <p>
-        The abstract operation InitializeDateTimeFormat accepts the arguments _dateTimeFormat_ (which must be an object), _locales_, and _options_. It initializes _dateTimeFormat_ as a DateTimeFormat object.
-      </p>
-
-      <p>
-        Several DateTimeFormat algorithms use values from the following table, which provides property names and allowable values for the components of date and time formats:
-      </p>
-
-      <emu-table id="table-3">
-        <emu-caption>Components of date and time formats</emu-caption>
-        <table class="real-table">
-          <thead>
-            <tr>
-              <th>Property</th>
-              <th>Values</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>weekday</td>
-            <td>"narrow", "short", "long"</td>
-          </tr>
-          <tr>
-            <td>era</td>
-            <td>"narrow", "short", "long"</td>
-          </tr>
-          <tr>
-            <td>year</td>
-            <td>"2-digit", "numeric"</td>
-          </tr>
-          <tr>
-            <td>month</td>
-            <td>"2-digit", "numeric", "narrow", "short", "long"</td>
-          </tr>
-          <tr>
-            <td>day</td>
-            <td>"2-digit", "numeric"</td>
-          </tr>
-          <tr>
-            <td>hour</td>
-            <td>"2-digit", "numeric"</td>
-          </tr>
-          <tr>
-            <td>minute</td>
-            <td>"2-digit", "numeric"</td>
-          </tr>
-          <tr>
-            <td>second</td>
-            <td>"2-digit", "numeric"</td>
-          </tr>
-          <tr>
-            <td>timeZoneName</td>
-            <td>"short", "long"</td>
-          </tr>
-        </table>
-      </emu-table>
-
-      <p>
-        The following steps are taken:
+        The abstract operation InitializeDateTimeFormat accepts the arguments _dateTimeFormat_ (which must be an object), _locales_, and _options_. It initializes _dateTimeFormat_ as a DateTimeFormat object. This abstract operation functions as follows:
       </p>
 
       <emu-alg>
@@ -130,12 +122,16 @@
         1. Set _dateTimeFormat_.[[initializedDateTimeFormat]] to *true*.
         1. Return _dateTimeFormat_.
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-todatetimeoptions" aoid="ToDateTimeOptions">
+      <h1>ToDateTimeOptions (options, required, defaults)</h1>
 
       <p>
         When the ToDateTimeOptions abstract operation is called with arguments _options_, _required_, and _defaults_, the following steps are taken:
       </p>
 
-      <emu-alg aoid="ToDateTimeOptions">
+      <emu-alg>
         1. If _options_ is *undefined*, let _options_ be *null*; otherwise let _options_ be ? ToObject(_options_).
         1. Let _options_ be ObjectCreate(_options_).
         1. Let _needDefaults_ be *true*.
@@ -157,12 +153,16 @@
             1. Perform ? CreateDataPropertyOrThrow(_options_, _prop_, *"numeric"*).
         1. Return _options_.
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-basicformatmatcher" aoid="BasicFormatMatcher">
+      <h1>BasicFormatMatcher (options, formats)</h1>
 
       <p>
         When the BasicFormatMatcher abstract operation is called with two arguments _options_ and _formats_, the following steps are taken:
       </p>
 
-      <emu-alg aoid="BasicFormatMatcher">
+      <emu-alg>
         1. Let _removalPenalty_ be 120.
         1. Let _additionPenalty_ be 20.
         1. Let _longLessPenalty_ be 8.
@@ -197,11 +197,112 @@
           1. Increase _k_ by 1.
         1. Return _bestFormat_.
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-bestfitformatmatcher" aoid="BestFitFormatMatcher">
+      <h1>BestFitFormatMatcher (options, formats)</h1>
 
       <p>
         When the BestFitFormatMatcher abstract operation is called with two arguments _options_ and _formats_, it performs implementation dependent steps, which should return a set of component representations that a typical user of the selected locale would perceive as at least as good as the one returned by BasicFormatMatcher.
       </p>
     </emu-clause>
+
+    <emu-clause id="sec-datetime-format-functions">
+      <h1>DateTime Format Functions</h1>
+
+      <p>
+        A DateTime format function is an anonymous built-in function that has [[dateTimeFormat]] internal slot.
+      <p>
+
+      <p>
+        When a DateTime format function _F_ is called with optional argument _date_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Assert: _F_ has an [[dateTimeFormat]] internal slot whose value is an Object.
+        1. Let _dtf_ be the value of _F_'s [[dateTimeFormat]] internal slot.
+        1. If _date_ is not provided or is *undefined*, then
+          1. Let _x_ be *%Date_now%*().
+        1. Else,
+          1. Let _x_ be ? ToNumber(_date_).
+        1. Return FormatDateTime(_dtf_, _x_).
+      </emu-alg>
+
+      <p>
+        The *length* property of a DateTime format function is 1.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-formatdatetime" aoid="FormatDateTime">
+      <h1>FormatDateTime (dateTimeFormat, x)</h1>
+
+      <p>
+        When the FormatDateTime abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), it returns a String value representing _x_ (interpreted as a time value as specified in ES2015, 20.3.1.1) according to the effective locale and the formatting options of _dateTimeFormat_. This abstract operation functions as follows:
+      </p>
+
+      <emu-alg>
+        1. If _x_ is not a finite Number, throw a *RangeError* exception.
+        1. Let _locale_ be the value of _dateTimeFormat_.[[locale]].
+        1. Let _nf_ be ? Construct(%NumberFormat%, « [locale], {useGrouping: *false*} »).
+        1. Let _nf2_ be ? Construct(%NumberFormat%, « [locale], {minimumIntegerDigits: 2, useGrouping: *false*} »).
+        1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[calendar]], _dateTimeFormat_.[[timeZone]]).
+        1. Let _result_ be the value of the _dateTimeFormat_.[[pattern]].
+        1. For each row of <emu-xref href="#table-3">Table 3</emu-xref>, except the header row, do:
+          1. If _dateTimeFormat_ has an internal slot with the name given in the Property column of the row, then
+            1. Let _p_ be the name given in the Property column of the row.
+            1. Let _f_ be the value of the [[<_p_>]] internal slot of _dateTimeFormat_.
+            1. Let _v_ be the value of _tm_.[[<_p_>]].
+            1. If _p_ is *"year"* and _v_ ≤ 0, let _v_ be 1 - _v_.
+            1. If _p_ is *"month"*, increase _v_ by 1.
+            1. If _p_ is *"hour"* and the value of _dateTimeFormat_.[[hour12]] is *true*, then
+              1. Let _v_ be _v_ modulo 12.
+              1. If _v_ is equal to the value of _tm_.[[<_p_>]], let _pm_ be *false*; else let _pm_ be *true*.
+              1. If _v_ is 0 and the value of _dateTimeFormat_.[[hourNo0]] is *true*, let _v_ be 12.
+            1. If _f_ is *"numeric"*, then
+              1. Let _fv_ be FormatNumber(_nf_, _v_).
+            1. Else if f is *"2-digit"*, then
+              1. Let _fv_ be FormatNumber(_nf2_, _v_).
+              1. If the *length* property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
+            1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _f_ in the desired form; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _dateTimeFormat_ has a [[day]] internal slot. If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[inDST]] field of _tm_, and if the implementation does not have a localized representation of _f_, then use _f_ itself.
+            1. Replace the substring of _result_ that consists of *"{"*, p, and *"}"*, with _fv_.
+        1. If _dateTimeFormat_.[[hour12]] is *true*, then
+          1. If _pm_ is *true*, then
+            1. Let _fv_ be an implementation and locale dependent String value representing "post meridiem";
+          1. Else,
+            1. Let _fv_ be an implementation and locale dependent String value representing "ante meridiem".
+          1. Replace the substring of _result_ that consists of *"{ampm}"*, with _fv_.
+        1. Return _result_.
+      </emu-alg>
+
+      <emu-note>
+        It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>), and use CLDR "abbreviated" strings for DateTimeFormat "short" strings, and CLDR "wide" strings for DateTimeFormat "long" strings.
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-tolocaltime" aoid="ToLocalTime">
+      <h1>ToLocalTime (date, calendar, timeZone)</h1>
+
+      <p>
+        When the ToLocalTime abstract operation is called with arguments _date_, _calendar_, and _timeZone_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Apply calendrical calculations on _date_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules. If the _calendar_ is "gregory", then the calculations must match the algorithms specified in ES2015, 20.3.1.
+        1. Return a Record with fields [[weekday]], [[era]], [[year]], [[month]], [[day]], [[hour]], [[minute]], [[second]], and [[inDST]], each with the corresponding calculated value.
+      </emu-alg>
+
+      <emu-note>
+        It is recommended that implementations use the time zone information of the IANA Time Zone Database.
+      </emu-note>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-intl-datetimeformat-constructor">
+    <h1>The Intl.DateTimeFormat Constructor</h1>
+
+    <p>
+      The Intl.DateTimeFormat constructor is a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+    </p>
 
     <emu-clause id="sec-Intl.DateTimeFormat">
       <h1>Intl.DateTimeFormat ([ locales [ , options ]])</h1>
@@ -337,14 +438,10 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.DateTimeFormat.prototype.format">
-      <h1>Intl.DateTimeFormat.prototype.format</h1>
+      <h1>get Intl.DateTimeFormat.prototype.format</h1>
 
       <p>
-        This named accessor property returns a function that formats a date according to the effective locale and the formatting options of this DateTimeFormat object.
-      </p>
-
-      <p>
-        The value of the [[Get]] attribute is a function that takes the following steps:
+        Intl.DateTimeFormat.prototype.format is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:
       </p>
 
       <emu-alg>
@@ -352,93 +449,11 @@
         1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
         1. If _dtf_ does not have a [[boundFormat]] internal slot, throw a *TypeError* exception.
         1. If the [[boundFormat]] internal slot of _dtf_ is *undefined*, then
-          1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-datetime-format-functions"></emu-xref>.
-          1. The value of _F_’s *length* property is 1.
-          1. Let _bf_ be BoundFunctionCreate(F, _dft_).
-          1. Set _dtf_.[[boundFormat]] to _bf_.
+          1. Let _F_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-format-functions"></emu-xref>).
+          1. Set the [[dateTimeFormat]] internal slot of _F_ to _dtf_.
+          1. Set _dtf_.[[boundFormat]] to _F_.
         1. Return _dtf_.[[boundFormat]].
       </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-datetime-format-functions">
-      <h1>DateTime Format Functions</h1>
-
-      <p>
-        A DateTime format function is an anonymous function that optionally takes an argument _date_. It performs the following steps:
-      </p>
-
-      <emu-alg>
-        1. Let _dtf_ be the *this* value.
-        1. Assert: Type(_dtf_) is Object and _dtf_ has an [[initializedDateTimeFormat]] internal slot whose value is *true*.
-        1. If _date_ is not provided or is *undefined*, then
-          1. Let _x_ be *%Date_now%*().
-        1. Else,
-          1. Let _x_ be ? ToNumber(_date_).
-        1. Return FormatDateTime(_dtf_, _x_).
-      </emu-alg>
-
-      <emu-note>
-        The function returned by [[Get]] is bound to this DateTimeFormat object so that it can be passed directly to Array.prototype.map or other functions.
-      </emu-note>
-
-      <p>
-        The value of the [[Set]] attribute is *undefined*.
-      </p>
-
-      <p>
-        When the FormatDateTime abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), it returns a String value representing _x_ (interpreted as a time value as specified in ES2015, 20.3.1.1) according to the effective locale and the formatting options of _dateTimeFormat_.
-      </p>
-
-      <emu-alg aoid="FormatDateTime">
-        1. If _x_ is not a finite Number, throw a *RangeError* exception.
-        1. Let _locale_ be the value of _dateTimeFormat_.[[locale]].
-        1. Let _nf_ be ? Construct(%NumberFormat%, « [locale], {useGrouping: *false*} »).
-        1. Let _nf2_ be ? Construct(%NumberFormat%, « [locale], {minimumIntegerDigits: 2, useGrouping: *false*} »).
-        1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[calendar]], _dateTimeFormat_.[[timeZone]]).
-        1. Let _result_ be the value of the _dateTimeFormat_.[[pattern]].
-        1. For each row of <emu-xref href="#table-3">Table 3</emu-xref>, except the header row, do:
-          1. If _dateTimeFormat_ has an internal slot with the name given in the Property column of the row, then
-            1. Let _p_ be the name given in the Property column of the row.
-            1. Let _f_ be the value of the [[<_p_>]] internal slot of _dateTimeFormat_.
-            1. Let _v_ be the value of _tm_.[[<_p_>]].
-            1. If _p_ is *"year"* and _v_ ≤ 0, let _v_ be 1 - _v_.
-            1. If _p_ is *"month"*, increase _v_ by 1.
-            1. If _p_ is *"hour"* and the value of _dateTimeFormat_.[[hour12]] is *true*, then
-              1. Let _v_ be _v_ modulo 12.
-              1. If _v_ is equal to the value of _tm_.[[<_p_>]], let _pm_ be *false*; else let _pm_ be *true*.
-              1. If _v_ is 0 and the value of _dateTimeFormat_.[[hourNo0]] is *true*, let _v_ be 12.
-            1. If _f_ is *"numeric"*, then
-              1. Let _fv_ be FormatNumber(_nf_, _v_).
-            1. Else if f is *"2-digit"*, then
-              1. Let _fv_ be FormatNumber(_nf2_, _v_).
-              1. If the *length* property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
-            1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _f_ in the desired form; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _dateTimeFormat_ has a [[day]] internal slot. If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[inDST]] field of _tm_, and if the implementation does not have a localized representation of _f_, then use _f_ itself.
-            1. Replace the substring of _result_ that consists of *"{"*, p, and *"}"*, with _fv_.
-        1. If _dateTimeFormat_.[[hour12]] is *true*, then
-          1. If _pm_ is *true*, then
-            1. Let _fv_ be an implementation and locale dependent String value representing "post meridiem";
-          1. Else,
-            1. Let _fv_ be an implementation and locale dependent String value representing "ante meridiem".
-          1. Replace the substring of _result_ that consists of *"{ampm}"*, with _fv_.
-        1. Return _result_.
-      </emu-alg>
-
-      <emu-note>
-        It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>), and use CLDR "abbreviated" strings for DateTimeFormat "short" strings, and CLDR "wide" strings for DateTimeFormat "long" strings.
-      </emu-note>
-
-      <p>
-        When the ToLocalTime abstract operation is called with arguments _date_, _calendar_, and _timeZone_, the following steps are taken:
-      </p>
-
-      <emu-alg aoid="ToLocalTime">
-        1. Apply calendrical calculations on _date_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules. If the _calendar_ is "gregory", then the calculations must match the algorithms specified in ES2015, 20.3.1.
-        1. Return a Record with fields [[weekday]], [[era]], [[year]], [[month]], [[day]], [[hour]], [[minute]], [[second]], and [[inDST]], each with the corresponding calculated value.
-      </emu-alg>
-
-      <emu-note>
-        It is recommended that implementations use the time zone information of the IANA Time Zone Database.
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DateTimeFormat.prototype.resolvedOptions">

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -211,16 +211,12 @@
       <h1>DateTime Format Functions</h1>
 
       <p>
-        A DateTime format function is an anonymous built-in function that has [[dateTimeFormat]] internal slot.
-      <p>
-
-      <p>
-        When a DateTime format function _F_ is called with optional argument _date_, the following steps are taken:
+        When a DateTime format function is called with optional argument _date_, the following steps are taken:
       </p>
 
       <emu-alg>
-        1. Assert: _F_ has an [[dateTimeFormat]] internal slot whose value is an Object.
-        1. Let _dtf_ be the value of _F_'s [[dateTimeFormat]] internal slot.
+        1. Let _dtf_ be the *this* value.
+        1. Assert: Type(_dtf_) is Object and _dtf_ has an [[initializedDateTimeFormat]] internal slot whose value is *true*.
         1. If _date_ is not provided or is *undefined*, then
           1. Let _x_ be *%Date_now%*().
         1. Else,
@@ -450,8 +446,8 @@
         1. If _dtf_ does not have a [[boundFormat]] internal slot, throw a *TypeError* exception.
         1. If the [[boundFormat]] internal slot of _dtf_ is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-format-functions"></emu-xref>).
-          1. Set the [[dateTimeFormat]] internal slot of _F_ to _dtf_.
-          1. Set _dtf_.[[boundFormat]] to _F_.
+          1. Let _bf_ be BoundFunctionCreate(_F_, _dft_).
+          1. Set _dtf_.[[boundFormat]] to _bf_.
         1. Return _dtf_.[[boundFormat]].
       </emu-alg>
     </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1,12 +1,8 @@
 <emu-clause id="numberformat-objects">
   <h1>NumberFormat Objects</h1>
 
-  <emu-clause id="sec-intl-numberformat-constructor">
-    <h1>The Intl.NumberFormat Constructor</h1>
-
-    <p>
-      The NumberFormat constructor is a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
-    </p>
+  <emu-clause id="sec-numberformat-abstracts">
+    <h1>Abstract Operations For NumberFormat Objects</h1>
 
     <emu-clause id="sec-InitializeNumberFormat" aoid="InitializeNumberFormat">
       <h1>InitializeNumberFormat (numberFormat, locales, options)</h1>
@@ -74,16 +70,276 @@
         1. Set _numberFormat_.[[initializedNumberFormat]] to *true*.
         1. Return _numberFormat_.
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-currencydigits" aoid="CurrencyDigits">
+      <h1>CurrencyDigits (currency)</h1>
 
       <p>
         When the abstract operation CurrencyDigits is called with an argument _currency_ (which must be an upper case String value), the following steps are taken:
       </p>
 
-      <emu-alg aoid="CurrencyDigits">
+      <emu-alg>
         1. If the ISO 4217 currency and funds code list contains _currency_ as an alphabetic code, return the minor unit value corresponding to the _currency_ from the list; otherwise, return 2.
       </emu-alg>
-
     </emu-clause>
+
+    <emu-clause id="sec-number-format-functions">
+      <h1>Number Format Functions</h1>
+
+      <p>
+        A Number format function is an anonymous built-in function that has [[numberFormat]] internal slot.
+      <p>
+
+      <p>
+        When a Number format function _F_ is called with optional argument _value_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Assert: _F_ has an [[numberFormat]] internal slot whose value is an Object.
+        1. Let _nf_ be the value of _F_'s [[numberFormat]] internal slot.
+        1. If _value_ is not provided, let _value_ be *undefined*.
+        1. Let _x_ be ? ToNumber(_value_).
+        1. Return FormatNumber(_nf_, _x_).
+      </emu-alg>
+
+      <p>
+        The *length* property of a Number format function is 1.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-formatnumber" aoid="FormatNumber">
+      <h1>FormatNumber(numberFormat, x)</h1>
+
+      <p>
+        When the FormatNumber abstract operation is called with arguments _numberFormat_ (which must be an object initialized as a NumberFormat) and _x_ (which must be a Number value), it returns a String value representing _x_ according to the effective locale and the formatting options of _numberFormat_. This abstract operation functions as follows:
+      </p>
+
+      <emu-alg>
+        1. Let _negative_ be *false*.
+        1. If the _result_ of isFinite(_x_) is *false*, then
+          1. If _x_ is *NaN*,
+            1. Let _n_ be an ILD String value indicating the *NaN* value.
+          1. Else,
+            1. Let _n_ be an ILD String value indicating infinity.
+            1. If _x_ < 0, let _negative_ be *true*.
+        1. Else,
+          1. If _x_ < 0, then
+            1. Let _negative_ be *true*.
+            1. Let _x_ be -_x_.
+          1. If the value of _numberFormat_.[[style]] is *"percent"*, let _x_ be 100 × _x_.
+          1. If the _numberFormat_.[[minimumSignificantDigits]] and _numberFormat_.[[maximumSignificantDigits]] are present, then
+            1. Let _n_ be ToRawPrecision(_x_, _numberFormat_.[[minimumSignificantDigits]], _numberFormat_.[[maximumSignificantDigits]]).
+          1. Else,
+            1. Let _n_ be ToRawFixed(_x_, _numberFormat_.[[minimumIntegerDigits]], _numberFormat_.[[minimumFractionDigits]], _numberFormat_.[[maximumFractionDigits]]).
+          1. If the value of the _numberFormat_.[[numberingSystem]] matches one of the values in the "Numbering System" column of <emu-xref href="#table-2">Table 2</emu-xref> below, then
+            1. Let _digits_ be an array whose 10 String valued elements are the UTF-16 string representations of the 10 _digits_ specified in the "Digits" column of the matching row in <emu-xref href="#table-2">Table 2</emu-xref>.
+            1. Replace each _digit_ in _n_ with the value of _digits_[_digit_].
+          1. Else use an implementation dependent algorithm to map _n_ to the appropriate representation of _n_ in the given numbering system.
+          1. If _n_ contains the character *"."*, replace it with an ILND String representing the decimal separator.
+          1. If the value of the _numberFormat_.[[useGrouping]] is *true*, insert an ILND String representing a grouping separator into an ILND set of locations within the integer part of _n_.
+        1. If _negative_ is *true*, then
+          1. Let _result_ be the value of _numberFormat_.[[negativePattern]].
+        1. Else,
+          1. Let _result_ be the value of _numberFormat_.[[positivePattern]].
+        1. Replace the substring *"{number}"* within _result_ with n.
+        1. If the value of the _numberFormat_.[[style]] is *"currency"*, then
+          1. Let _currency_ be the value of _numberFormat_.[[currency]].
+          1. If _numberFormat_.[[currencyDisplay]] is *"code"*, then
+            1. Let _cd_ be _currency_.
+          1. Else if _numberFormat_.[[currencyDisplay]] is *"symbol"*, then
+            1. Let _cd_ be an ILD string representing _currency_ in short form. If the implementation does not have such a representation of _currency_, use _currency_ itself.
+          1. Else if _numberFormat_.[[currencyDisplay]] is *"name"*, then
+            1. Let _cd_ be an ILD string representing _currency_ in long form. If the implementation does not have such a representation of _currency_, then use _currency_ itself.
+          1. Replace the substring *"{currency}"* within _result_ with _cd_.
+        1. Return _result_.
+      </emu-alg>
+
+
+      <emu-table id="table-2">
+        <emu-caption>Numbering systems with simple digit mappings</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Numbering System</th>
+              <th>Digits</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>arab</td>
+            <td>U+0660 to U+0669</td>
+          </tr>
+          <tr>
+            <td>arabext</td>
+            <td>U+06F0 to U+06F9</td>
+          </tr>
+          <tr>
+            <td>bali</td>
+            <td>U+1B50 to U+1B59</td>
+          </tr>
+          <tr>
+            <td>beng</td>
+            <td>U+09E6 to U+09EF</td>
+          </tr>
+          <tr>
+            <td>deva</td>
+            <td>U+0966 to U+096F</td>
+          </tr>
+          <tr>
+            <td>fullwide</td>
+            <td>U+FF10 to U+FF19</td>
+          </tr>
+          <tr>
+            <td>gujr</td>
+            <td>U+0AE6 to U+0AEF</td>
+          </tr>
+          <tr>
+            <td>guru</td>
+            <td>U+0A66 to U+0A6F</td>
+          </tr>
+          <tr>
+            <td>hanidec</td>
+            <td>U+3007, U+4E00, U+4E8C, U+4E09, U+56DB, U+4E94, U+516D, U+4E03, U+516B, U+4E5D</td>
+          </tr>
+          <tr>
+            <td>khmr</td>
+            <td>U+17E0 to U+17E9</td>
+          </tr>
+          <tr>
+            <td>knda</td>
+            <td>U+0CE6 to U+0CEF</td>
+          </tr>
+          <tr>
+            <td>laoo</td>
+            <td>U+0ED0 to U+0ED9</td>
+          </tr>
+          <tr>
+            <td>latn</td>
+            <td>U+0030 to U+0039</td>
+          </tr>
+          <tr>
+            <td>limb</td>
+            <td>U+1946 to U+194F</td>
+          </tr>
+          <tr>
+            <td>mlym</td>
+            <td>U+0D66 to U+0D6F</td>
+          </tr>
+          <tr>
+            <td>mong</td>
+            <td>U+1810 to U+1819</td>
+          </tr>
+          <tr>
+            <td>mymr</td>
+            <td>U+1040 to U+1049</td>
+          </tr>
+          <tr>
+            <td>orya</td>
+            <td>U+0B66 to U+0B6F</td>
+          </tr>
+          <tr>
+            <td>tamldec</td>
+            <td>U+0BE6 to U+0BEF</td>
+          </tr>
+          <tr>
+            <td>telu</td>
+            <td>U+0C66 to U+0C6F</td>
+          </tr>
+          <tr>
+            <td>thai</td>
+            <td>U+0E50 to U+0E59</td>
+          </tr>
+          <tr>
+            <td>tibt</td>
+            <td>U+0F20 to U+0F29</td>
+          </tr>
+        </table>
+      </emu-table>
+
+      <emu-note>
+        The computations rely on String values and locations within numeric strings that are dependent upon the implementation and the effective locale of _numberFormat_ (“ILD") or upon the implementation, the effective locale, and the numbering system of _numberFormat_ (“ILND"). The ILD and ILND Strings mentioned, other than those for currency names, must not contain any characters in the General Category “Number, decimal digit" as specified by the Unicode Standard.
+      </emu-note>
+
+      <emu-note>
+        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-torawprecision" aoid="ToRawPrecision">
+      <h1>ToRawPrecision(x, minPrecision, maxPrecision)</h1>
+
+      <p>
+        When the ToRawPrecision abstract operation is called with arguments _x_ (which must be a finite non-negative number), _minPrecision_, and _maxPrecision_ (both must be integers between 1 and 21) the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _p_ be _maxPrecision_.
+        1. If _x_ = 0, then
+          1. Let _m_ be the String consisting of _p_ occurrences of the character *"0"*.
+          1. Let _e_ be 0.
+        1. Else,
+          1. Let _e_ and _n_ be integers such that 10<sup>_p_–1</sup> ≤ _n_ < 10<sup>_p_</sup> and for which the exact mathematical value of _n_ × 10<sup>_e_–_p_+1</sup> – _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ × 10<sup>_e_–_p_+1</sup> is larger.
+          1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
+        1. If _e_ ≥ _p_, then
+          1. Return the concatenation of _m_ and _e_-_p_+1 occurrences of the character *"0"*.
+        1. If _e_ = _p_-1, then
+          1. Return _m_.
+        1. If _e_ ≥ 0, then
+          1. Let _m_ be the concatenation of the first _e_+1 characters of _m_, the character *"."*, and the remaining _p_–(_e_+1) characters of _m_.
+        1. If _e_ < 0, then
+          1. Let _m_ be the concatenation of the String *"0."*, –(_e_+1) occurrences of the character *"0"*, and the string _m_.
+        1. If _m_ contains the character *"."*, and _maxPrecision_ > _minPrecision_, then
+          1. Let _cut_ be _maxPrecision_ – _minPrecision_.
+          1. Repeat while _cut_ > 0 and the last character of _m_ is *"0"*:
+            1. Remove the last character from _m_.
+            1. Decrease _cut_ by 1.
+          1. If the last character of _m_ is *"."*, then
+            1. Remove the last character from _m_.
+        1. Return _m_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-torawfixed" aoid="ToRawFixed">
+      <h1>ToRawFixed(x, minInteger, minFraction, maxFraction)</h1>
+
+      <p>
+        When the ToRawFixed abstract operation is called with arguments _x_ (which must be a finite non-negative number), _minInteger_ (which must be an integer between 1 and 21), _minFraction_, and _maxFraction_ (which must be integers between 0 and 20) the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _f_ be _maxFraction_.
+        1. Let _n_ be an integer for which the exact mathematical value of _n_ ÷ 10<sup>_f_</sup> – _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
+        1. If _n_ = 0, let _m_ be the String *"0"*. Otherwise, let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
+        1. If _f_ ≠ 0, then
+          1. Let _k_ be the number of characters in _m_.
+          1. If _k_ ≤ _f_, then
+            1. Let _z_ be the String consisting of _f_+1–_k_ occurrences of the character *"0"*.
+            1. Let _m_ be the concatenation of Strings _z_ and _m_.
+            1. Let _k_=_f_+1.
+          1. Let _a_ be the first _k_–_f_ characters of _m_, and let _b_ be the remaining _f_ characters of _m_.
+          1. Let _m_ be the concatenation of the three Strings _a_, *"."*, and _b_.
+          1. Let _int_ be the number of characters in _a_.
+        1. Else let _int_ be the number of characters in _m_.
+        1. Let _cut_ be _maxFraction_ – _minFraction_.
+        1. Repeat while _cut_ > 0 and the last character of _m_ is *"0"*:
+          1. Remove the last character from _m_.
+          1. Decrease _cut_ by 1.
+        1. If the last character of _m_ is ".", then
+          1. Remove the last character from _m_.
+        1. If _int_ < _minInteger_, then
+          1. Let _z_ be the String consisting of _minInteger_–_int_ occurrences of the character *"0"*.
+          1. Let _m_ be the concatenation of Strings _z_ and _m_.
+        1. Return _m_.
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-intl-numberformat-constructor">
+    <h1>The Intl.NumberFormat Constructor</h1>
+
+    <p>
+      The NumberFormat constructor is a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+    </p>
 
     <emu-clause id="sec-Intl.NumberFormat">
       <h1>Intl.NumberFormat ([ locales [ , options ]])</h1>
@@ -196,13 +452,10 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.NumberFormat.prototype.format">
-      <h1>Intl.NumberFormat.prototype.format</h1>
+      <h1>get Intl.NumberFormat.prototype.format</h1>
 
       <p>
-        This named accessor property returns a function that formats a number according to the effective locale and the formatting options of this NumberFormat object.
-      </p>
-      <p>
-        The value of the [[Get]] attribute is a function that takes the following steps:
+        Intl.NumberFormat.prototype.format is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:
       </p>
 
       <emu-alg>
@@ -210,252 +463,11 @@
         1. If Type(_nf_) is not Object, throw a *TypeError* exception.
         1. If _nf_ does not have a [[boundFormat]] internal slot, throw a *TypeError* exception.
         1. If _nf_.[[boundFormat]] is *undefined*, then
-          1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-number-format-functions"></emu-xref>.
-          1. The value of _F_’s *length* property is 1.
-          1. Let _bf_ be BoundFunctionCreate(_F_, _nf_).
-          1. Set _nf_.[[boundFormat]] to _bf_.
+          1. Let _F_ be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions"></emu-xref>).
+          1. Set the [[numberFormat]] internal slot of _F_ to _nf_.
+          1. Set _nf_.[[boundFormat]] to _F_.
         1. Return _nf_.[[boundFormat]].
       </emu-alg>
-
-      <emu-note>
-        The function returned by [[Get]] is bound to this NumberFormat object so that it can be passed directly to Array.prototype.map or other functions.
-      </emu-note>
-
-      <p>
-        The value of the [[Set]] attribute is *undefined*.
-      </p>
-    </emu-clause>
-
-    <emu-clause id="sec-number-format-functions">
-      <h1>Number Format Functions</h1>
-
-      <p>
-        A NumberFormat format function is an anonymous function that takes one argument value, and performs the following steps:
-      </p>
-
-      <emu-alg>
-        1. Let _nf_ be the *this* value.
-        1. Assert: Type(_nf_) is Object and _nf_ has an [[initializedNumberFormat]] internal slot whose value is *true*.
-        1. If _value_ is not provided, let _value_ be *undefined*.
-        1. Let _x_ be ? ToNumber(_value_).
-        1. Return FormatNumber(_nf_, _x_).
-      </emu-alg>
-
-      <p>
-        When the FormatNumber abstract operation is called with arguments _numberFormat_ (which must be an object initialized as a NumberFormat) and _x_ (which must be a Number value), it returns a String value representing _x_ according to the effective locale and the formatting options of _numberFormat_.
-      </p>
-
-      <p>
-        The computations rely on String values and locations within numeric strings that are dependent upon the implementation and the effective locale of _numberFormat_ (“ILD") or upon the implementation, the effective locale, and the numbering system of _numberFormat_ (“ILND"). The ILD and ILND Strings mentioned, other than those for currency names, must not contain any characters in the General Category “Number, decimal digit" as specified by the Unicode Standard.
-      </p>
-
-      <emu-note>
-        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
-      </emu-note>
-
-      <p>
-        The following steps are taken:
-      </p>
-
-      <emu-alg aoid="FormatNumber">
-        1. Let _negative_ be *false*.
-        1. If the _result_ of isFinite(_x_) is *false*, then
-          1. If _x_ is *NaN*,
-            1. Let _n_ be an ILD String value indicating the *NaN* value.
-          1. Else,
-            1. Let _n_ be an ILD String value indicating infinity.
-            1. If _x_ < 0, let _negative_ be *true*.
-        1. Else,
-          1. If _x_ < 0, then
-            1. Let _negative_ be *true*.
-            1. Let _x_ be -_x_.
-          1. If the value of _numberFormat_.[[style]] is *"percent"*, let _x_ be 100 × _x_.
-          1. If the _numberFormat_.[[minimumSignificantDigits]] and _numberFormat_.[[maximumSignificantDigits]] are present, then
-            1. Let _n_ be ToRawPrecision(_x_, _numberFormat_.[[minimumSignificantDigits]], _numberFormat_.[[maximumSignificantDigits]]).
-          1. Else,
-            1. Let _n_ be ToRawFixed(_x_, _numberFormat_.[[minimumIntegerDigits]], _numberFormat_.[[minimumFractionDigits]], _numberFormat_.[[maximumFractionDigits]]).
-          1. If the value of the _numberFormat_.[[numberingSystem]] matches one of the values in the "Numbering System" column of <emu-xref href="#table-2">Table 2</emu-xref> below, then
-            1. Let _digits_ be an array whose 10 String valued elements are the UTF-16 string representations of the 10 _digits_ specified in the "Digits" column of the matching row in <emu-xref href="#table-2">Table 2</emu-xref>.
-            1. Replace each _digit_ in _n_ with the value of _digits_[_digit_].
-          1. Else use an implementation dependent algorithm to map _n_ to the appropriate representation of _n_ in the given numbering system.
-          1. If _n_ contains the character *"."*, replace it with an ILND String representing the decimal separator.
-          1. If the value of the _numberFormat_.[[useGrouping]] is *true*, insert an ILND String representing a grouping separator into an ILND set of locations within the integer part of _n_.
-        1. If _negative_ is *true*, then
-          1. Let _result_ be the value of _numberFormat_.[[negativePattern]].
-        1. Else,
-          1. Let _result_ be the value of _numberFormat_.[[positivePattern]].
-        1. Replace the substring *"{number}"* within _result_ with n.
-        1. If the value of the _numberFormat_.[[style]] is *"currency"*, then
-          1. Let _currency_ be the value of _numberFormat_.[[currency]].
-          1. If _numberFormat_.[[currencyDisplay]] is *"code"*, then
-            1. Let _cd_ be _currency_.
-          1. Else if _numberFormat_.[[currencyDisplay]] is *"symbol"*, then
-            1. Let _cd_ be an ILD string representing _currency_ in short form. If the implementation does not have such a representation of _currency_, use _currency_ itself.
-          1. Else if _numberFormat_.[[currencyDisplay]] is *"name"*, then
-            1. Let _cd_ be an ILD string representing _currency_ in long form. If the implementation does not have such a representation of _currency_, then use _currency_ itself.
-          1. Replace the substring *"{currency}"* within _result_ with _cd_.
-        1. Return _result_.
-      </emu-alg>
-
-      <p>
-        When the ToRawPrecision abstract operation is called with arguments _x_ (which must be a finite non-negative number), _minPrecision_, and _maxPrecision_ (both must be integers between 1 and 21) the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _p_ be _maxPrecision_.
-        1. If _x_ = 0, then
-          1. Let _m_ be the String consisting of _p_ occurrences of the character *"0"*.
-          1. Let _e_ be 0.
-        1. Else,
-          1. Let _e_ and _n_ be integers such that 10<sup>_p_–1</sup> ≤ _n_ < 10<sup>_p_</sup> and for which the exact mathematical value of _n_ × 10<sup>_e_–_p_+1</sup> – _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ × 10<sup>_e_–_p_+1</sup> is larger.
-          1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
-        1. If _e_ ≥ _p_, then
-          1. Return the concatenation of _m_ and _e_-_p_+1 occurrences of the character *"0"*.
-        1. If _e_ = _p_-1, then
-          1. Return _m_.
-        1. If _e_ ≥ 0, then
-          1. Let _m_ be the concatenation of the first _e_+1 characters of _m_, the character *"."*, and the remaining _p_–(_e_+1) characters of _m_.
-        1. If _e_ < 0, then
-          1. Let _m_ be the concatenation of the String *"0."*, –(_e_+1) occurrences of the character *"0"*, and the string _m_.
-        1. If _m_ contains the character *"."*, and _maxPrecision_ > _minPrecision_, then
-          1. Let _cut_ be _maxPrecision_ – _minPrecision_.
-          1. Repeat while _cut_ > 0 and the last character of _m_ is *"0"*:
-            1. Remove the last character from _m_.
-            1. Decrease _cut_ by 1.
-          1. If the last character of _m_ is *"."*, then
-            1. Remove the last character from _m_.
-        1. Return _m_.
-      </emu-alg>
-
-      <p>
-        When the ToRawFixed abstract operation is called with arguments _x_ (which must be a finite non-negative number), _minInteger_ (which must be an integer between 1 and 21), _minFraction_, and _maxFraction_ (which must be integers between 0 and 20) the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _f_ be _maxFraction_.
-        1. Let _n_ be an integer for which the exact mathematical value of _n_ ÷ 10<sup>_f_</sup> – _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
-        1. If _n_ = 0, let _m_ be the String *"0"*. Otherwise, let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
-        1. If _f_ ≠ 0, then
-          1. Let _k_ be the number of characters in _m_.
-          1. If _k_ ≤ _f_, then
-            1. Let _z_ be the String consisting of _f_+1–_k_ occurrences of the character *"0"*.
-            1. Let _m_ be the concatenation of Strings _z_ and _m_.
-            1. Let _k_=_f_+1.
-          1. Let _a_ be the first _k_–_f_ characters of _m_, and let _b_ be the remaining _f_ characters of _m_.
-          1. Let _m_ be the concatenation of the three Strings _a_, *"."*, and _b_.
-          1. Let _int_ be the number of characters in _a_.
-        1. Else let _int_ be the number of characters in _m_.
-        1. Let _cut_ be _maxFraction_ – _minFraction_.
-        1. Repeat while _cut_ > 0 and the last character of _m_ is *"0"*:
-          1. Remove the last character from _m_.
-          1. Decrease _cut_ by 1.
-        1. If the last character of _m_ is ".", then
-          1. Remove the last character from _m_.
-        1. If _int_ < _minInteger_, then
-          1. Let _z_ be the String consisting of _minInteger_–_int_ occurrences of the character *"0"*.
-          1. Let _m_ be the concatenation of Strings _z_ and _m_.
-        1. Return _m_.
-      </emu-alg>
-
-      <emu-table id="table-2">
-        <emu-caption>Numbering systems with simple digit mappings</emu-caption>
-        <table class="real-table">
-          <thead>
-            <tr>
-              <th>Numbering System</th>
-              <th>Digits</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>arab</td>
-            <td>U+0660 to U+0669</td>
-          </tr>
-          <tr>
-            <td>arabext</td>
-            <td>U+06F0 to U+06F9</td>
-          </tr>
-          <tr>
-            <td>bali</td>
-            <td>U+1B50 to U+1B59</td>
-          </tr>
-          <tr>
-            <td>beng</td>
-            <td>U+09E6 to U+09EF</td>
-          </tr>
-          <tr>
-            <td>deva</td>
-            <td>U+0966 to U+096F</td>
-          </tr>
-          <tr>
-            <td>fullwide</td>
-            <td>U+FF10 to U+FF19</td>
-          </tr>
-          <tr>
-            <td>gujr</td>
-            <td>U+0AE6 to U+0AEF</td>
-          </tr>
-          <tr>
-            <td>guru</td>
-            <td>U+0A66 to U+0A6F</td>
-          </tr>
-          <tr>
-            <td>hanidec</td>
-            <td>U+3007, U+4E00, U+4E8C, U+4E09, U+56DB, U+4E94, U+516D, U+4E03, U+516B, U+4E5D</td>
-          </tr>
-          <tr>
-            <td>khmr</td>
-            <td>U+17E0 to U+17E9</td>
-          </tr>
-          <tr>
-            <td>knda</td>
-            <td>U+0CE6 to U+0CEF</td>
-          </tr>
-          <tr>
-            <td>laoo</td>
-            <td>U+0ED0 to U+0ED9</td>
-          </tr>
-          <tr>
-            <td>latn</td>
-            <td>U+0030 to U+0039</td>
-          </tr>
-          <tr>
-            <td>limb</td>
-            <td>U+1946 to U+194F</td>
-          </tr>
-          <tr>
-            <td>mlym</td>
-            <td>U+0D66 to U+0D6F</td>
-          </tr>
-          <tr>
-            <td>mong</td>
-            <td>U+1810 to U+1819</td>
-          </tr>
-          <tr>
-            <td>mymr</td>
-            <td>U+1040 to U+1049</td>
-          </tr>
-          <tr>
-            <td>orya</td>
-            <td>U+0B66 to U+0B6F</td>
-          </tr>
-          <tr>
-            <td>tamldec</td>
-            <td>U+0BE6 to U+0BEF</td>
-          </tr>
-          <tr>
-            <td>telu</td>
-            <td>U+0C66 to U+0C6F</td>
-          </tr>
-          <tr>
-            <td>thai</td>
-            <td>U+0E50 to U+0E59</td>
-          </tr>
-          <tr>
-            <td>tibt</td>
-            <td>U+0F20 to U+0F29</td>
-          </tr>
-        </table>
-      </emu-table>
     </emu-clause>
 
     <emu-clause id="sec-Intl.NumberFormat.prototype.resolvedOptions">

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -88,16 +88,12 @@
       <h1>Number Format Functions</h1>
 
       <p>
-        A Number format function is an anonymous built-in function that has [[numberFormat]] internal slot.
-      <p>
-
-      <p>
-        When a Number format function _F_ is called with optional argument _value_, the following steps are taken:
+        When a Number format function is called with optional argument _value_, the following steps are taken:
       </p>
 
       <emu-alg>
-        1. Assert: _F_ has an [[numberFormat]] internal slot whose value is an Object.
-        1. Let _nf_ be the value of _F_'s [[numberFormat]] internal slot.
+        1. Let _nf_ be the *this* value.
+        1. Assert: Type(_nf_) is Object and _nf_ has an [[initializedNumberFormat]] internal slot whose value is *true*.
         1. If _value_ is not provided, let _value_ be *undefined*.
         1. Let _x_ be ? ToNumber(_value_).
         1. Return FormatNumber(_nf_, _x_).
@@ -464,8 +460,8 @@
         1. If _nf_ does not have a [[boundFormat]] internal slot, throw a *TypeError* exception.
         1. If _nf_.[[boundFormat]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions"></emu-xref>).
-          1. Set the [[numberFormat]] internal slot of _F_ to _nf_.
-          1. Set _nf_.[[boundFormat]] to _F_.
+          1. Let _bf_ be BoundFunctionCreate(_F_, _nf_).
+          1. Set _nf_.[[boundFormat]] to bf.
         1. Return _nf_.[[boundFormat]].
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
__Disclaimer: This PR does not modify any algo, we just reshuffle them for organizational purposes.__

### Reasoning

* "Number Format Functions" holds several abstract operations, and it was a sub-section under "Properties of the Intl.NumberFormat Prototype Object", which is confusing, specially once we add more properties to those objects that could call the same abstract operations. The same applies to "DateTime Format Functions".
* `InitializeNumberFormat()` and `InitializeDateTimeFormat()` abstract operations were under the corresponding constructor section.

### Notes
* moving all abstract operations of NumberFormat Objects into an abstract sub-section
* moving all abstract operations of DateTimeFormat Objects into an abstract sub-section.

### Render Version: 

* https://rawgit.com/caridy/c80267817f2736db7de8/raw/f7df1b2c9de232a69dbcf9e6e4eceb6966fb9eeb/ecma-402-pr1.html#numberformat-objects