### PR TITLE
Exposing `CanonicalizeLocaleList()` abstract operation via `Intl.getCanonicalLocales()`

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -12,12 +12,48 @@
     The Intl object is not a function object. It does not have a [[Construct]] internal method; it is not possible to use the Intl object as a constructor with the *new* operator. The Intl object does not have a [[Call]] internal method; it is not possible to invoke the Intl object as a function.
   </p>
 
-  <emu-clause id="sec-properties-of-the-intl-object">
-    <h1>Properties of the Intl Object</h1>
+  <emu-clause id="sec-constructor-properties-of-the-intl-object">
+    <h1>Constructor Properties of the Intl Object</h1>
 
-    <p>
-      The value of each of the standard built-in properties of the Intl object is a constructor. The behaviour of these constructors is specified in the following clauses: Collator (<emu-xref href="#collator-objects"></emu-xref>), NumberFormat (<emu-xref href="#numberformat-objects"></emu-xref>), and DateTimeFormat (<emu-xref href="#datetimeformat-objects"></emu-xref>).
-    </p>
+    <emu-clause id="sec-intl.collator">
+      <h1>Intl.Collator (...)</h1>
+      <p>
+        See <emu-xref href="#collator-objects"></emu-xref>.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.numberformat">
+      <h1>Intl.NumberFormat (...)</h1>
+      <p>
+        See <emu-xref href="#numberformat-objects"></emu-xref>.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.datetimeformat">
+      <h1>Intl.DateTimeFormat (...)</h1>
+      <p>
+        See <emu-xref href="#datetimeformat-objects"></emu-xref>.
+      </p>
+    </emu-clause>
+
+  </emu-clause>
+
+  <emu-clause id="sec-function-properties-of-the-intl-object">
+    <h1>Function Properties of the Intl Object</h1>
+
+    <emu-clause id="sec-intl.getcanonicallocales">
+      <h1>Intl.getCanonicalLocales (locales)</h1>
+
+      <p>
+        When the *getCanonicalLocales* method of Intl is called with argument _locales_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _ll_ be ? CanonicalizeLocaleList(_locales_).
+        1. Return CreateArrayFromList(_ll_).
+      </emu-alg>
+    </emu-clause>
+
   </emu-clause>
 
 </emu-clause>


### PR DESCRIPTION
Feature from https://github.com/tc39/ecma402/issues/46

This is probably the only new feature we will be able to get into 3rd edition.

This PR also opens the door for adding more function properties to `Intl` in the future, very similar to `Math` in 262.

/cc @littledan @zbraniecki @ericf @rwaldron 