### PR TITLE
[Editorial] improving cross linking and other small things

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "version": "3.0.0-draft",
   "description": "ECMAScript Internationalization API Specification",
   "scripts": {
-    "clean": "rm -rf out",
     "build": "npm run clean && mkdir out && ecmarkup --verbose spec/index.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
+    "clean": "rm -rf out",
+    "test": "exit 0",
     "watch": "npm run clean && mkdir out && ecmarkup --watch --verbose spec/index.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
     "update-pages": "ecmarkup spec/index.html _index.html --css _ecmarkup.css --js _ecmarkup.js --verbose && git checkout gh-pages && rm -f index.html ecmarkup.css ecmarkup.js && mv _index.html index.html && mv _ecmarkup.css ecmarkup.css && mv _ecmarkup.js ecmarkup.js && git add index.html ecmarkup.js ecmarkup.css && git commit -m \"update pages\" && git checkout master"
   },
@@ -14,6 +15,6 @@
   "license": "SEE LICENSE IN https://tc39.github.io/ecma402/#sec-copyright-and-software-license",
   "homepage": "https://tc39.github.io/ecma402/",
   "dependencies": {
-    "ecmarkup": "^3.0.0"
+    "ecmarkup": "^3.1.1"
   }
 }

--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -25,10 +25,10 @@
           The set of available locales for each constructor (<emu-xref href="#sec-internal-slots"></emu-xref>)
         </li>
         <li>
-          The BestFitMatcher algorithm (<emu-xref href="#sec-BestFitMatcher"></emu-xref>)
+          The BestFitMatcher algorithm (<emu-xref href="#sec-bestfitmatcher"></emu-xref>)
         </li>
         <li>
-          The BestFitSupportedLocales algorithm (<emu-xref href="#sec-BestFitSupportedLocales"></emu-xref>)
+          The BestFitSupportedLocales algorithm (<emu-xref href="#sec-bestfitsupportedlocales"></emu-xref>)
         </li>
       </ul>
     </li>
@@ -36,7 +36,7 @@
       In Collator:
       <ul>
         <li>
-          Support for the Unicode extensions keys kn, kf and the parallel options properties numeric, caseFirst (<emu-xref href="#sec-InitializeCollator"></emu-xref>)
+          Support for the Unicode extensions keys kn, kf and the parallel options properties numeric, caseFirst (<emu-xref href="#sec-initializecollator"></emu-xref>)
         </li>
         <li>
           The set of supported *"co"* key values (collations) per locale beyond a default collation (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
@@ -59,7 +59,7 @@
       In NumberFormat:
       <ul>
         <li>
-          The set of supported *"nu"* key values (numbering systems) per locale (<emu-xref href="#sec-Intl.NumberFormat-internal-slots"></emu-xref>)
+          The set of supported *"nu"* key values (numbering systems) per locale (<emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>)
         </li>
         <li>
           The patterns used for formatting positive and negative values as decimal, percent, or currency values per locale (<emu-xref href="#sec-formatnumber"></emu-xref>)
@@ -84,19 +84,19 @@
     <li>In DateTimeFormat:
       <ul>
         <li>
-          The BestFitFormatMatcher algorithm (<emu-xref href="#sec-InitializeDateTimeFormat"></emu-xref>)
+          The BestFitFormatMatcher algorithm (<emu-xref href="#sec-initializedatetimeformat"></emu-xref>)
         </li>
         <li>
-          The set of supported *"ca"* key values (calendars) per locale (<emu-xref href="#sec-Intl.DateTimeFormat-internal-slots"></emu-xref>)
+          The set of supported *"ca"* key values (calendars) per locale (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
         </li>
         <li>
-          The set of supported *"nu"* key values (numbering systems) per locale (<emu-xref href="#sec-Intl.DateTimeFormat-internal-slots"></emu-xref>)
+          The set of supported *"nu"* key values (numbering systems) per locale (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
         </li>
         <li>
-          The default hour12 and hourNo0 settings per locale (<emu-xref href="#sec-Intl.DateTimeFormat-internal-slots"></emu-xref>)
+          The default hour12 and hourNo0 settings per locale (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
         </li>
         <li>
-          The set of supported date-time formats per locale beyond a core set, including the representations used for each component and the associated patterns (<emu-xref href="#sec-Intl.DateTimeFormat-internal-slots"></emu-xref>)
+          The set of supported date-time formats per locale beyond a core set, including the representations used for each component and the associated patterns (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
         </li>
         <li>
           Localized weekday names, era names, month names, am/pm indicators, and time zone names (<emu-xref href="#sec-formatdatetime"></emu-xref>)

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -7,7 +7,7 @@
       The Intl.Collator constructor is the <dfn>%Collator%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in 9.1.
     </p>
 
-    <emu-clause id="sec-InitializeCollator" aoid="InitializeCollator">
+    <emu-clause id="sec-initializecollator" aoid="InitializeCollator">
       <h1>InitializeCollator (collator, locales, options)</h1>
 
       <p>
@@ -109,7 +109,7 @@
 
     </emu-clause>
 
-    <emu-clause id="sec-Intl.Collator">
+    <emu-clause id="sec-intl.collator">
       <h1>Intl.Collator ([ locales [ , options ]])</h1>
 
       <p>
@@ -136,7 +136,7 @@
       The Intl.Collator constructor has the following properties:
     </p>
 
-    <emu-clause id="sec-Intl.Collator.prototype">
+    <emu-clause id="sec-intl.collator.prototype">
       <h1>Intl.Collator.prototype</h1>
 
       <p>
@@ -148,7 +148,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.Collator.supportedLocalesOf">
+    <emu-clause id="sec-intl.collator.supportedlocalesof">
       <h1>Intl.Collator.supportedLocalesOf (locales [ , options ])</h1>
 
       <p>
@@ -200,7 +200,7 @@
       In the following descriptions of functions that are properties or [[Get]] attributes of properties of *%CollatorPrototype%*, the phrase "this Collator object" refers to the object that is the *this* value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[initializedCollator]] internal slot with value *true*.
     </p>
 
-    <emu-clause id="sec-Intl.Collator.prototype.constructor">
+    <emu-clause id="sec-intl.collator.prototype.constructor">
       <h1>Intl.Collator.prototype.constructor</h1>
 
       <p>
@@ -208,7 +208,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.Collator.prototype-toStringTag">
+    <emu-clause id="sec-intl.collator.prototype-@@tostringtag">
       <h1>Intl.Collator.prototype [ @@toStringTag ]</h1>
 
       <p>
@@ -220,7 +220,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.Collator.prototype.compare">
+    <emu-clause id="sec-intl.collator.prototype.compare">
       <h1>get Intl.Collator.prototype.compare</h1>
 
       <p>
@@ -297,7 +297,7 @@
       </p>
 
       <p>
-        The CompareStrings abstract operation with any given _collator_ argument, if considered as a function of the remaining two arguments _x_ and _y_, must be a consistent comparison function (as defined in ES2016, 22.1.3.25) on the set of all Strings.
+        The CompareStrings abstract operation with any given _collator_ argument, if considered as a function of the remaining two arguments _x_ and _y_, must be a consistent comparison function (as defined in ES2016, <emu-xref href="#sec-array.prototype.sort"></emu-xref>) on the set of all Strings.
       </p>
 
       <p>
@@ -314,7 +314,7 @@
 
     </emu-clause>
 
-    <emu-clause id="sec-Intl.Collator.prototype.resolvedOptions">
+    <emu-clause id="sec-intl.collator.prototype.resolvedoptions">
       <h1>Intl.Collator.prototype.resolvedOptions ()</h1>
 
       <p>
@@ -359,7 +359,7 @@
     </ul>
 
     <p>
-      Finally, objects that have been successfully initialized as a Collator have a [[boundCompare]] internal slot that caches the function returned by the compare accessor (<emu-xref href="#sec-Intl.Collator.prototype.compare"></emu-xref>).
+      Finally, objects that have been successfully initialized as a Collator have a [[boundCompare]] internal slot that caches the function returned by the compare accessor (<emu-xref href="#sec-intl.collator.prototype.compare"></emu-xref>).
     </p>
 
   </emu-clause>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -6,10 +6,10 @@
   </p>
 
   <ul>
-    <li>Object Internal Methods and Internal Slots, as described in ES2016, 6.1.7.2.</li>
-    <li>Algorithm conventions, including the use of abstract operations, as described in ES2016, 7.1, 7.2, 7.3.</li>
-    <li>Internal Slots, as described in ES2016, 9.1.</li>
-    <li>The List and Record Specification Type, as described in ES2016, 6.2.1.</li>
+    <li>Object Internal Methods and Internal Slots, as described in ES2016, <emu-xref href="#sec-object-internal-methods-and-internal-slots"></emu-xref>.</li>
+    <li>Algorithm conventions, including the use of abstract operations, as described in ES2016, <emu-xref href="#sec-type-conversion"></emu-xref>, <emu-xref href="#sec-testing-and-comparison-operations"></emu-xref>, <emu-xref href="#sec-operations-on-objects"></emu-xref>.</li>
+    <li>Internal Slots, as described in ES2016, <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.</li>
+    <li>The List and Record Specification Type, as described in ES2016, <emu-xref href="#sec-list-and-record-specification-type"></emu-xref>.</li>
   </ul>
 
   <emu-note>
@@ -28,7 +28,7 @@
     <h1>Well-Known Intrinsic Objects</h1>
 
     <p>
-      The following table extends the Well-Known Intrinsic Objects table defined in ES2016, 6.1.7.4.
+      The following table extends the Well-Known Intrinsic Objects table defined in ES2016, <emu-xref href="#sec-well-known-intrinsic-objects"></emu-xref>.
     </p>
 
     <figure>
@@ -44,7 +44,7 @@
         <tr>
           <td>%Date_now%</td>
           <td>"Date.now"</td>
-          <td>The initial value of the *"now"* data property of the intrinsic %Date% (ES2016, 20.3.3.1)</td>
+          <td>The initial value of the *"now"* data property of the intrinsic %Date% (ES2016, <emu-xref href="#sec-date.now"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%Intl%</td>
@@ -59,7 +59,7 @@
         <tr>
           <td>%CollatorPrototype%</td>
           <td>"Intl.Collator.prototype"</td>
-          <td>The initial value of the *"prototype"* data property of the intrinsic %Collator% (<emu-xref href="#sec-Intl.Collator.prototype"></emu-xref>).</td>
+          <td>The initial value of the *"prototype"* data property of the intrinsic %Collator% (<emu-xref href="#sec-intl.collator.prototype"></emu-xref>).</td>
         </tr>
         <tr>
           <td>%NumberFormat%</td>
@@ -69,7 +69,7 @@
         <tr>
           <td>%NumberFormatPrototype%</td>
           <td>"Intl.NumberFormat.prototype"</td>
-          <td>The initial value of the *"prototype"* data property of the intrinsic %NumberFormat% (<emu-xref href="#sec-Intl.NumberFormat.prototype"></emu-xref>).</td>
+          <td>The initial value of the *"prototype"* data property of the intrinsic %NumberFormat% (<emu-xref href="#sec-intl.numberformat.prototype"></emu-xref>).</td>
         </tr>
         <tr>
           <td>%DateTimeFormat%</td>
@@ -79,17 +79,17 @@
         <tr>
           <td>%DateTimeFormatPrototype%</td>
           <td>"Intl.DateTimeFormat.prototype"</td>
-          <td>The initial value of the *"prototype"* data property of the intrinsic %DateTimeFormat% (<emu-xref href="#sec-Intl.DateTimeFormat.prototype"></emu-xref>).</td>
+          <td>The initial value of the *"prototype"* data property of the intrinsic %DateTimeFormat% (<emu-xref href="#sec-intl.datetimeformat.prototype"></emu-xref>).</td>
         </tr>
         <tr>
           <td>%StringProto_includes%</td>
           <td>"String.prototype.includes"</td>
-          <td>The initial value of the *"includes"* data property of the intrinsic %StringPrototype% (ES2016, 21.1.3.7)</td>
+          <td>The initial value of the *"includes"* data property of the intrinsic %StringPrototype% (ES2016, <emu-xref href="#sec-string.prototype.includes"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%ArrayProto_indexOf%</td>
           <td>"Array.prototype.indexOf"</td>
-          <td>The initial value of the *"indexOf"* data property of the intrinsic %ArrayPrototype% (ES2016, 22.1.3.12)</td>
+          <td>The initial value of the *"indexOf"* data property of the intrinsic %ArrayPrototype% (ES2016, <emu-xref href="#sec-array.prototype.indexof"></emu-xref>)</td>
         </tr>
       </table>
     </figure>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -56,7 +56,7 @@
       </table>
     </emu-table>
 
-    <emu-clause id="sec-InitializeDateTimeFormat" aoid="InitializeDateTimeFormat">
+    <emu-clause id="sec-initializedatetimeformat" aoid="InitializeDateTimeFormat">
       <h1>InitializeDateTimeFormat (dateTimeFormat, locales, options)</h1>
 
       <p>
@@ -233,7 +233,7 @@
       <h1>FormatDateTime (dateTimeFormat, x)</h1>
 
       <p>
-        When the FormatDateTime abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), it returns a String value representing _x_ (interpreted as a time value as specified in ES2016, 20.3.1.1) according to the effective locale and the formatting options of _dateTimeFormat_. This abstract operation functions as follows:
+        When the FormatDateTime abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), it returns a String value representing _x_ (interpreted as a time value as specified in ES2016, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>) according to the effective locale and the formatting options of _dateTimeFormat_. This abstract operation functions as follows:
       </p>
 
       <emu-alg>
@@ -289,7 +289,7 @@
       </p>
 
       <emu-alg>
-        1. Apply calendrical calculations on _date_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules. If the _calendar_ is "gregory", then the calculations must match the algorithms specified in ES2016, 20.3.1.
+        1. Apply calendrical calculations on _date_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules. If the _calendar_ is "gregory", then the calculations must match the algorithms specified in ES2016, <emu-xref href="#sec-overview-of-date-objects-and-definitions-of-abstract-operations"></emu-xref>.
         1. Return a Record with fields [[weekday]], [[era]], [[year]], [[month]], [[day]], [[hour]], [[minute]], [[second]], and [[inDST]], each with the corresponding calculated value.
       </emu-alg>
 
@@ -306,7 +306,7 @@
       The Intl.DateTimeFormat constructor is the <dfn>%DateTimeFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
-    <emu-clause id="sec-Intl.DateTimeFormat">
+    <emu-clause id="sec-intl.datetimeformat">
       <h1>Intl.DateTimeFormat ([ locales [ , options ]])</h1>
 
       <p>
@@ -328,7 +328,7 @@
       The Intl.DateTimeFormat constructor has the following properties:
     </p>
 
-    <emu-clause id="sec-Intl.DateTimeFormat.prototype">
+    <emu-clause id="sec-intl.datetimeformat.prototype">
       <h1>Intl.DateTimeFormat.prototype</h1>
 
       <p>
@@ -339,7 +339,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.DateTimeFormat.supportedLocalesOf">
+    <emu-clause id="sec-intl.datetimeformat.supportedlocalesof">
       <h1>Intl.DateTimeFormat.supportedLocalesOf (locales [ , options ])</h1>
 
       <p>
@@ -357,7 +357,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.DateTimeFormat-internal-slots">
+    <emu-clause id="sec-intl.datetimeformat-internal-slots">
       <h1>Internal slots</h1>
 
       <p>
@@ -419,7 +419,7 @@
       In the following descriptions of functions that are properties or [[Get]] attributes of properties of the Intl.DateTimeFormat prototype object, the phrase "this DateTimeFormat object" refers to the object that is the this value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[initializedDateTimeFormat]] internal slot with value *true*.
     </p>
 
-    <emu-clause id="sec-Intl.DateTimeFormat.prototype.constructor">
+    <emu-clause id="sec-intl.datetimeformat.prototype.constructor">
       <h1>Intl.DateTimeFormat.prototype.constructor</h1>
 
       <p>
@@ -427,7 +427,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.DateTimeFormat.prototype-toStringTag">
+    <emu-clause id="sec-intl.datetimeformat.prototype-@@tostringtag">
       <h1>Intl.DateTimeFormat.prototype [ @@toStringTag ]</h1>
 
       <p>
@@ -439,7 +439,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.DateTimeFormat.prototype.format">
+    <emu-clause id="sec-intl.datetimeformat.prototype.format">
       <h1>get Intl.DateTimeFormat.prototype.format</h1>
 
       <p>
@@ -459,7 +459,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.DateTimeFormat.prototype.resolvedOptions">
+    <emu-clause id="sec-intl.datetimeformat.prototype.resolvedoptions">
       <h1>Intl.DateTimeFormat.prototype.resolvedOptions ()</h1>
 
       <p>
@@ -499,11 +499,11 @@
       <li>[[weekday]], [[era]], [[year]], [[month]], [[day]], [[hour]], [[minute]], [[second]], [[timeZoneName]] are each either *undefined*, indicating that the component is not used for formatting, or one of the String values given in <emu-xref href="#table-3">Table 3</emu-xref>, indicating how the component should be presented in the formatted output.</li>
       <li>[[hour12]] is a Boolean value indicating whether 12-hour format (*true*) or 24-hour format (*false*) should be used. It is only used when [[hour]] is not *undefined*.</li>
       <li>[[hourNo0]] is a Boolean value indicating whether hours from 1 to 12 (*true*) or from 0 to 11 (*false*) should be used. It is only used when [[hour12]] has the value *true*.</li>
-      <li>[[pattern]] is a String value as described in <emu-xref href="#sec-Intl.DateTimeFormat-internal-slots"></emu-xref>.</li>
+      <li>[[pattern]] is a String value as described in <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>.</li>
     </ul>
 
     <p>
-      Finally, objects that have been successfully initialized as a DateTimeFormat have a [[boundFormat]] internal slot that caches the function returned by the format accessor (<emu-xref href="#sec-Intl.DateTimeFormat.prototype.format"></emu-xref>).
+      Finally, objects that have been successfully initialized as a DateTimeFormat have a [[boundFormat]] internal slot that caches the function returned by the format accessor (<emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref>).
     </p>
   </emu-clause>
 </emu-clause>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1,58 +1,49 @@
 <!DOCTYPE html>
-<html lang="en-GB">
-  <head>
-    <meta charset="ascii">
-    <link rel="icon" href="favicon.ico">
-    <link href="ecmarkup.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <script src="ecmarkup.js"></script>
-    <script>
-      if (location.hostname === 'tc39.github.io' && location.protocol !== 'https:') {
-        location.protocol = 'https:';
-      }
-    </script>
-    <style>
-      h1.orange {
-        font-size: 2em;
-      }
-      .oldtoc {
-        padding: 5em;
-      }
-      .orange {
-        color: #ff6600;
-        margin: 0px;
-      }
-      .list-of-names {
-        list-style-type: none;
-        margin-bottom: 10px;
-        padding-left: 10px;
-      }
-    </style>
-    <pre class=metadata>
-      title: ECMAScript® 2016 Internationalization API Specification (3rd Edition)
-      shortname: ECMA-402
-      status: draft
-      location: https://tc39.github.io/ecma402
-    </pre>
-  </head>
-  <body>
-    <emu-placeholder for="title-page"></emu-placeholder>
-
-    <emu-import href="./introduction.html"></emu-import>
-    <emu-import href="./scope.html"></emu-import>
-    <emu-import href="./conformance.html"></emu-import>
-    <emu-import href="./normative-references.html"></emu-import>
-    <emu-import href="./overview.html"></emu-import>
-    <emu-import href="./conventions.html"></emu-import>
-    <emu-import href="./locales-currencies-tz.html"></emu-import>
-    <emu-import href="./requirements.html"></emu-import>
-    <emu-import href="./intl.html"></emu-import>
-    <emu-import href="./negotiation.html"></emu-import>
-    <emu-import href="./collator.html"></emu-import>
-    <emu-import href="./numberformat.html"></emu-import>
-    <emu-import href="./datetimeformat.html"></emu-import>
-    <emu-import href="./locale-sensitive-functions.html"></emu-import>
-    <emu-import href="./annexes.html"></emu-import>
-
-  </body>
-</html>
+<meta charset="ascii">
+<link rel="icon" href="favicon.ico">
+<link href="ecmarkup.css" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
+<script src="ecmarkup.js"></script>
+<script>
+  if (location.hostname === 'tc39.github.io' && location.protocol !== 'https:') {
+    location.protocol = 'https:';
+  }
+</script>
+<style>
+  h1.orange {
+    font-size: 2em;
+  }
+  .oldtoc {
+    padding: 5em;
+  }
+  .orange {
+    color: #ff6600;
+    margin: 0px;
+  }
+  .list-of-names {
+    list-style-type: none;
+    margin-bottom: 10px;
+    padding-left: 10px;
+  }
+</style>
+<pre class=metadata>
+  title: ECMAScript&reg; 2016 Internationalization API Specification (3rd Edition)
+  shortname: ECMA-402
+  status: draft
+  location: https://tc39.github.io/ecma402
+</pre>
+<emu-import href="./introduction.html"></emu-import>
+<emu-import href="./scope.html"></emu-import>
+<emu-import href="./conformance.html"></emu-import>
+<emu-import href="./normative-references.html"></emu-import>
+<emu-import href="./overview.html"></emu-import>
+<emu-import href="./conventions.html"></emu-import>
+<emu-import href="./locales-currencies-tz.html"></emu-import>
+<emu-import href="./requirements.html"></emu-import>
+<emu-import href="./intl.html"></emu-import>
+<emu-import href="./negotiation.html"></emu-import>
+<emu-import href="./collator.html"></emu-import>
+<emu-import href="./numberformat.html"></emu-import>
+<emu-import href="./datetimeformat.html"></emu-import>
+<emu-import href="./locale-sensitive-functions.html"></emu-import>
+<emu-import href="./annexes.html"></emu-import>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -9,14 +9,14 @@
     The Collator, NumberFormat, or DateTimeFormat objects created in the algorithms in this clause are only used within these algorithms. They are never directly accessed by ECMAScript code and need not actually exist within an implementation.
   </emu-note>
 
-  <emu-clause id="sec-properties-of-the-string-prototype-object">
+  <emu-clause id="sup-properties-of-the-string-prototype-object">
     <h1>Properties of the String Prototype Object</h1>
 
-    <emu-clause id="sec-String.prototype.localeCompare">
+    <emu-clause id="sup-String.prototype.localeCompare">
       <h1>String.prototype.localeCompare (that [ , locales [ , options ]])</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2016, 21.1.3.10.
+        This definition supersedes the definition provided in ES2016, <emu-xref href="#sec-string.prototype.localecompare"></emu-xref>.
       </p>
 
       <p>
@@ -45,15 +45,15 @@
 
     </emu-clause>
 
-    <emu-clause id="sec-String.prototype.toLocaleLowerCase">
-      <h1>String.prototype.toLocaleLowerCase ([locales])</h1>
+    <emu-clause id="sup-string.prototype.tolocalelowercase">
+      <h1>String.prototype.toLocaleLowerCase ([ locales ])</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2016, 21.1.3.20.
+        This definition supersedes the definition provided in ES2016, <emu-xref href="#sec-string.prototype.tolocalelowercase"></emu-xref>.
       </p>
 
       <p>
-        This function interprets a string value as a sequence of code points, as described in ES2016, 6.1.4. The following steps are taken:
+        This function interprets a string value as a sequence of code points, as described in ES2016, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. The following steps are taken:
       </p>
 
       <emu-alg>
@@ -69,10 +69,10 @@
         1. Let _availableLocales_ be a List with the language tags of the languages for which the Unicode character database contains language sensitive case mappings.
         1. Let _locale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
         1. If _locale_ is *undefined*, let _locale_ be *"und"*.
-        1. Let _cpList_ be a List containing in order the code points of _S_ as defined in ES2016, 6.1.4, starting at the first element of _S_.
+        1. Let _cpList_ be a List containing in order the code points of _S_ as defined in ES2016, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, starting at the first element of _S_.
         1. For each code point _c_ in _cpList_, if the Unicode Character Database provides a lower case equivalent of _c_ that is either language insensitive or for the language _locale_, replace _c_ in _cpList_ with that/those equivalent code point(s).
         1. Let _cuList_ be a new List.
-        1. For each code point _c_ in _cpList_, in order, append to cuList the elements of the UTF-16 Encoding (defined in ES2016, 6.1.4) of _c_.
+        1. For each code point _c_ in _cpList_, in order, append to cuList the elements of the UTF-16 Encoding (defined in ES2016, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) of _c_.
         1. Let _L_ be a String whose elements are, in order, the elements of _cuList_.
         1. Return _L_.
       </emu-alg>
@@ -99,15 +99,15 @@
 
     </emu-clause>
 
-    <emu-clause id="sec-String.prototype.toLocaleUpperCase">
-      <h1>String.prototype.toLocaleUpperCase ([locales])</h1>
+    <emu-clause id="sup-string.prototype.tolocaleuppercase">
+      <h1>String.prototype.toLocaleUpperCase ([ locales ])</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2016, 21.1.3.21.
+        This definition supersedes the definition provided in ES2016, <emu-xref href="#sec-string.prototype.tolocaleuppercase"></emu-xref>.
       </p>
 
       <p>
-        This function interprets a string value as a sequence of code points, as described in ES2016, 6.1.4. This function behaves in exactly the same way as *String.prototype.toLocaleLowerCase*, except that characters are mapped to their _uppercase_ equivalents as specified in the Unicode character database.
+        This function interprets a string value as a sequence of code points, as described in ES2016, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. This function behaves in exactly the same way as *String.prototype.toLocaleLowerCase*, except that characters are mapped to their _uppercase_ equivalents as specified in the Unicode character database.
       </p>
 
       <p>
@@ -122,18 +122,18 @@
   </emu-clause>
 
 
-  <emu-clause id="sec-properties-of-the-number-prototype-object">
+  <emu-clause id="sup-properties-of-the-number-prototype-object">
     <h1>Properties of the Number Prototype Object</h1>
 
     <p>
-      The following definition(s) refer to the abstract operation thisNumberValue as defined in ES2016, 20.1.3.
+      The following definition(s) refer to the abstract operation thisNumberValue as defined in ES2016, <emu-xref href="#sec-properties-of-the-number-prototype-object"></emu-xref>.
     </p>
 
-    <emu-clause id="sec-Number.prototype.toLocaleString">
+    <emu-clause id="sup-number.prototype.tolocalestring">
       <h1>Number.prototype.toLocaleString ([ locales [ , options ]])</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2016, 20.1.3.4.
+        This definition supersedes the definition provided in ES2016, <emu-xref href="#sec-number.prototype.tolocalestring"></emu-xref>.
       </p>
 
       <p>
@@ -153,18 +153,18 @@
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-properties-of-the-date-prototype-object">
+  <emu-clause id="sup-properties-of-the-date-prototype-object">
     <h1>Properties of the Date Prototype Object</h1>
 
     <p>
-      The following definition(s) refer to the abstract operation thisTimeValue as defined in ES2016, 20.3.4.
+      The following definition(s) refer to the abstract operation thisTimeValue as defined in ES2016, <emu-xref href="#sec-properties-of-the-date-prototype-object"></emu-xref>.
     </p>
 
-    <emu-clause id="sec-Date.prototype.toLocaleString">
+    <emu-clause id="sup-date.prototype.tolocalestring">
       <h1>Date.prototype.toLocaleString ([ locales [ , options ]])</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2016, 20.3.4.39.
+        This definition supersedes the definition provided in ES2016, <emu-xref href="#sec-date.prototype.tolocalestring"></emu-xref>.
       </p>
 
       <p>
@@ -185,11 +185,11 @@
 
     </emu-clause>
 
-    <emu-clause id="sec-Date.prototype.toLocaleDateString">
+    <emu-clause id="sup-date.prototype.tolocaledatestring">
       <h1>Date.prototype.toLocaleDateString ([ locales [ , options ]])</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2016, 20.3.4.38.
+        This definition supersedes the definition provided in ES2016, <emu-xref href="#sec-date.prototype.tolocaledatestring"></emu-xref>.
       </p>
 
       <p>
@@ -210,11 +210,11 @@
 
     </emu-clause>
 
-    <emu-clause id="sec-Date.prototype.toLocaleTimeString">
+    <emu-clause id="sup-date.prototype.tolocaletimestring">
       <h1>Date.prototype.toLocaleTimeString ([ locales [ , options ]])</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2016, 20.3.4.40.
+        This definition supersedes the definition provided in ES2016, <emu-xref href="#sec-date.prototype.tolocaletimestring"></emu-xref>.
       </p>
 
       <p>
@@ -236,14 +236,14 @@
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-properties-of-the-array-prototype-object">
+  <emu-clause id="sup-properties-of-the-array-prototype-object">
     <h1>Properties of the Array Prototype Object</h1>
 
-    <emu-clause id="sec-Array.prototype.toLocaleString">
+    <emu-clause id="sup-array.prototype.tolocalestring">
       <h1>Array.prototype.toLocaleString ([ locales [ , options ]])</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2016, 22.1.3.27.
+        This definition supersedes the definition provided in ES2016, <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref>.
       </p>
 
       <p>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -13,13 +13,13 @@
     </p>
 
     <ul>
-      <li>[[availableLocales]] is a List that contains structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizelanguagetag"></emu-xref>) BCP 47 language tags identifying the locales for which the implementation provides the functionality of the constructed objects. Language tags on the list must not have a Unicode locale extension sequence. The list must include the value returned by the DefaultLocale abstract operation (<emu-xref href="#sec-defaultlocale"></emu-xref>), and must not include duplicates. Implementations must include in [[availableLocales]] locales that can serve as fallbacks in the algorithm used to resolve locales (see <emu-xref href="#sec-ResolveLocale"></emu-xref>). For example, implementations that provide a "de-DE" locale must include a "de" locale that can serve as a fallback for requests such as "de-AT" and "de-CH". For locales that in current usage would include a script subtag (such as Chinese locales), old-style language tags without script subtags must be included such that, for example, requests for "zh-TW" and "zh-HK" lead to output in traditional Chinese rather than the default simplified Chinese. The ordering of the locales within [[availableLocales]] is irrelevant.</li>
+      <li>[[availableLocales]] is a List that contains structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizelanguagetag"></emu-xref>) BCP 47 language tags identifying the locales for which the implementation provides the functionality of the constructed objects. Language tags on the list must not have a Unicode locale extension sequence. The list must include the value returned by the DefaultLocale abstract operation (<emu-xref href="#sec-defaultlocale"></emu-xref>), and must not include duplicates. Implementations must include in [[availableLocales]] locales that can serve as fallbacks in the algorithm used to resolve locales (see <emu-xref href="#sec-resolvelocale"></emu-xref>). For example, implementations that provide a "de-DE" locale must include a "de" locale that can serve as a fallback for requests such as "de-AT" and "de-CH". For locales that in current usage would include a script subtag (such as Chinese locales), old-style language tags without script subtags must be included such that, for example, requests for "zh-TW" and "zh-HK" lead to output in traditional Chinese rather than the default simplified Chinese. The ordering of the locales within [[availableLocales]] is irrelevant.</li>
       <li>[[relevantExtensionKeys]] is a List of keys of the language tag extensions defined in Unicode Technical Standard 35 that are relevant for the functionality of the constructed objects.</li>
       <li>[[sortLocaleData]] and [[searchLocaleData]] (for Intl.Collator) and [[localeData]] (for Intl.NumberFormat and Intl.DateTimeFormat) are objects that have properties for each locale contained in [[availableLocales]]. The value of each of these properties must be an object that has properties for each key contained in [[relevantExtensionKeys]]. The value of each of these properties must be a non-empty array of those values defined in Unicode Technical Standard 35 for the given key that are supported by the implementation for the given locale, with the first element providing the default value.</li>
     </ul>
 
     <p>
-      EXAMPLE     An implementation of DateTimeFormat might include the language tag "th" in its [[availableLocales]] internal slot, and must (according to <emu-xref href="#sec-Intl.DateTimeFormat-internal-slots"></emu-xref>) include the key "ca" in its [[relevantExtensionKeys]] internal slot. For Thai, the "buddhist" calendar is usually the default, but an implementation might also support the calendars "gregory", "chinese", and "islamicc" for the locale "th". The [[localeData]] internal slot would therefore at least include {"th": {ca: ["buddhist", "gregory", "chinese", "islamicc"]}}.
+      EXAMPLE     An implementation of DateTimeFormat might include the language tag "th" in its [[availableLocales]] internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>) include the key "ca" in its [[relevantExtensionKeys]] internal slot. For Thai, the "buddhist" calendar is usually the default, but an implementation might also support the calendars "gregory", "chinese", and "islamicc" for the locale "th". The [[localeData]] internal slot would therefore at least include {"th": {ca: ["buddhist", "gregory", "chinese", "islamicc"]}}.
     </p>
   </emu-clause>
 
@@ -30,7 +30,7 @@
       Where the following abstract operations take an _availableLocales_ argument, it must be an [[availableLocales]] List as specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
-    <emu-clause id="sec-CanonicalizeLocaleList" aoid="CanonicalizeLocaleList">
+    <emu-clause id="sec-canonicalizelocalelist" aoid="CanonicalizeLocaleList">
       <h1>CanonicalizeLocaleList (locales)</h1>
 
       <p>
@@ -70,7 +70,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-BestAvailableLocale" aoid="BestAvailableLocale">
+    <emu-clause id="sec-bestavailablelocale" aoid="BestAvailableLocale">
       <h1>BestAvailableLocale (availableLocales, locale)</h1>
 
       <p>
@@ -87,7 +87,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-LookupMatcher" aoid="LookupMatcher">
+    <emu-clause id="sec-lookupmatcher" aoid="LookupMatcher">
       <h1>LookupMatcher (availableLocales, requestedLocales)</h1>
 
       <p>
@@ -124,7 +124,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-BestFitMatcher" aoid="BestFitMatcher">
+    <emu-clause id="sec-bestfitmatcher" aoid="BestFitMatcher">
       <h1>BestFitMatcher (availableLocales, requestedLocales)</h1>
 
       <p>
@@ -132,7 +132,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-UnicodeExtensionSubtags" aoid="UnicodeExtensionSubtags">
+    <emu-clause id="sec-unicodeextensionsubtags" aoid="UnicodeExtensionSubtags">
       <h1>UnicodeExtensionSubtags (extension)</h1>
 
       <p>The abstract operation UnicodeExtensionSubtags splits _extension_, which must be a Unicode locale extension sequence, into its subtags. The following steps are taken:</p>
@@ -174,7 +174,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-ResolveLocale" aoid="ResolveLocale">
+    <emu-clause id="sec-resolvelocale" aoid="ResolveLocale">
       <h1>ResolveLocale (availableLocales, requestedLocales, options, relevantExtensionKeys, localeData)</h1>
 
       <p>
@@ -205,7 +205,7 @@
         1. Let _rExtensionKeys_ be CreateArrayFromList(_relevantExtensionKeys_).
         1. Let _len_ be ! ToLength(! Get(_rExtensionKeys_, *"length"*)).
         1. Repeat while _k_ < _len_
-          1. Let _key_ be ! Get(_rExtensionKeys_ , ! ToString(_k_)).
+          1. Let _key_ be ! Get(_rExtensionKeys_, ! ToString(_k_)).
           1. Let _foundLocaleData_ be ? Get(_localeData_, _foundLocale_).
           1. Let _keyLocaleData_ be ? ToObject(Get(_foundLocaleData_, _key_)).
           1. Let _value_ be ? ToString(Get(_keyLocaleData_, *"0"*)).
@@ -242,7 +242,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-LookupSupportedLocales" aoid="LookupSupportedLocales">
+    <emu-clause id="sec-lookupsupportedlocales" aoid="LookupSupportedLocales">
       <h1>LookupSupportedLocales (availableLocales, requestedLocales)</h1>
 
       <p>
@@ -264,7 +264,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-BestFitSupportedLocales" aoid="BestFitSupportedLocales">
+    <emu-clause id="sec-bestfitsupportedlocales" aoid="BestFitSupportedLocales">
       <h1>BestFitSupportedLocales (availableLocales, requestedLocales)</h1>
 
       <p>
@@ -272,7 +272,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-SupportedLocales" aoid="SupportedLocales">
+    <emu-clause id="sec-supportedlocales" aoid="SupportedLocales">
       <h1>SupportedLocales (availableLocales, requestedLocales, options)</h1>
 
       <p>
@@ -297,7 +297,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-GetOption" aoid="GetOption">
+    <emu-clause id="sec-getoption" aoid="GetOption">
       <h1>GetOption (options, property, type, values, fallback)</h1>
 
       <p>
@@ -320,7 +320,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-GetNumberOption" aoid="GetNumberOption">
+    <emu-clause id="sec-getnumberoption" aoid="GetNumberOption">
       <h1>GetNumberOption (options, property, minimum, maximum, fallback)</h1>
 
       <p>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -4,7 +4,7 @@
   <emu-clause id="sec-numberformat-abstracts">
     <h1>Abstract Operations For NumberFormat Objects</h1>
 
-    <emu-clause id="sec-InitializeNumberFormat" aoid="InitializeNumberFormat">
+    <emu-clause id="sec-initializenumberformat" aoid="InitializeNumberFormat">
       <h1>InitializeNumberFormat (numberFormat, locales, options)</h1>
 
       <p>
@@ -62,7 +62,7 @@
         1. Set _numberFormat_.[[useGrouping]] to _g_.
         1. Let _dataLocaleData_ be Get(_localeData_, _dataLocale_).
         1. Let _patterns_ be Get(_dataLocaleData_, *"patterns"*).
-        1. Assert: _patterns_ is an object (see <emu-xref href="#sec-Intl.NumberFormat-internal-slots"></emu-xref>).
+        1. Assert: _patterns_ is an object (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
         1. Let _stylePatterns_ be Get(_patterns_, s).
         1. Set _numberFormat_.[[positivePattern]] to Get(_stylePatterns_, *"positivePattern"*).
         1. Set _numberFormat_.[[negativePattern]] to Get(_stylePatterns_, *"negativePattern"*).
@@ -337,7 +337,7 @@
       The NumberFormat constructor is the <dfn>%NumberFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
-    <emu-clause id="sec-Intl.NumberFormat">
+    <emu-clause id="sec-intl.numberformat">
       <h1>Intl.NumberFormat ([ locales [ , options ]])</h1>
 
       <p>
@@ -359,7 +359,7 @@
       The Intl.NumberFormat constructor has the following properties:
     </p>
 
-    <emu-clause id="sec-Intl.NumberFormat.prototype">
+    <emu-clause id="sec-intl.numberformat.prototype">
       <h1>Intl.NumberFormat.prototype</h1>
 
       <p>
@@ -370,7 +370,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.NumberFormat.supportedLocalesOf">
+    <emu-clause id="sec-intl.numberformat.supportedlocalesof">
       <h1>Intl.NumberFormat.supportedLocalesOf (locales [ , options ])</h1>
 
       <p>
@@ -388,7 +388,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.NumberFormat-internal-slots">
+    <emu-clause id="sec-intl.numberformat-internal-slots">
       <h1>Internal slots</h1>
 
       <p>
@@ -428,7 +428,7 @@
       In the following descriptions of functions that are properties or [[Get]] attributes of properties of *%NumberFormatPrototype%*, the phrase "this NumberFormat object" refers to the object that is the this  value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[initializedNumberFormat]] internal slot with value *true*.
     </p>
 
-    <emu-clause id="sec-Intl.NumberFormat.prototype.constructor">
+    <emu-clause id="sec-intl.numberformat.prototype.constructor">
       <h1>Intl.NumberFormat.prototype.constructor</h1>
 
       <p>
@@ -436,7 +436,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.NumberFormat.prototype-toStringTag">
+    <emu-clause id="sec-intl.numberformat.prototype-@@tostringtag">
       <h1>Intl.NumberFormat.prototype [ @@toStringTag ]</h1>
 
       <p>
@@ -447,7 +447,7 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.NumberFormat.prototype.format">
+    <emu-clause id="sec-intl.numberformat.prototype.format">
       <h1>get Intl.NumberFormat.prototype.format</h1>
 
       <p>
@@ -467,7 +467,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.NumberFormat.prototype.resolvedOptions">
+    <emu-clause id="sec-intl.numberformat.prototype.resolvedoptions">
       <h1>Intl.NumberFormat.prototype.resolvedOptions ()</h1>
 
       <p>
@@ -504,11 +504,11 @@
       <li>[[minimumFractionDigits]] and [[maximumFractionDigits]] are non-negative integer Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
       <li>[[minimumSignificantDigits]] and [[maximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be shown. Either none or both of these properties are present; if they are, they override minimum and maximum integer and fraction digits – the formatter uses however many integer and fraction digits are required to display the specified number of significant digits.</li>
       <li>[[useGrouping]] is a Boolean value indicating whether a grouping separator should be used.</li>
-      <li>[[positivePattern]] and [[negativePattern]] are String values as described in <emu-xref href="#sec-Intl.NumberFormat-internal-slots"></emu-xref>.</li>
+      <li>[[positivePattern]] and [[negativePattern]] are String values as described in <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>.</li>
     </ul>
 
     <p>
-      Finally, objects that have been successfully initialized as a NumberFormat have a [[boundFormat]] internal slot that caches the function returned by the format accessor (<emu-xref href="#sec-Intl.NumberFormat.prototype.format"></emu-xref>).
+      Finally, objects that have been successfully initialized as a NumberFormat have a [[boundFormat]] internal slot that caches the function returned by the format accessor (<emu-xref href="#sec-intl.numberformat.prototype.format"></emu-xref>).
     </p>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
* all links to be lowercase (to match 262)
* all reference to ES2016 should use `<emu-xref>`
* supersede methods from 402 should be linkable (using "sup-" prefix instead of "sec-" for those)
* correct spacing on headers and invocations
* consistently use a comma before "the following steps are taken"