### PR TITLE
ECMA-402 v1 legacy constructor semantics compromise

### DIFF
--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -24,6 +24,10 @@
     For ECMAScript objects, this standard may use variable-named internal slots: The notation "[[&lt;_name_&gt;]]" denotes an internal slot whose name is given by the variable name, which must have a String value. For example, if a variable _s_ has the value *"a"*, then [[&lt;_s_&gt;]] denotes the [[&lt;_a_&gt;]] internal slot.
   </p>
 
+  <p>
+    This specification uses blocks demarcated as <span class="normative-optional">Normative Optional</span> to denote the sense of <a href="https://tc39.github.io/ecma262/#sec-additional-ecmascript-features-for-web-browsers">Annex B</a> in ECMA 262. That is, normative optional sections are required when the ECMAScript host is a web browser. The content of the section is normative but optional if the ECMAScript host is not a web browser.
+  </p>
+
   <emu-clause id="sec-402-well-known-intrinsic-objects">
     <h1>Well-Known Intrinsic Objects</h1>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -360,6 +360,27 @@
         It is recommended that implementations use the time zone information of the IANA Time Zone Database.
       </emu-note>
     </emu-clause>
+
+    <emu-clause id="sec-unwrapdatetimeformat" aoid="UnwrapDateTimeFormat">
+      <h1>UnwrapDateTimeFormat( dtf )</h1>
+      <p>
+        The UnwrapDateTimeFormat abstract operation gets the underlying DateTimeFormat operation
+        for various methods which implement ECMA-402 v1 semantics for supporting initializing
+        existing Intl objects.
+      </p>
+      <emu-normative-optional><span class="normative-optional">Normative Optional</span><div class="normative-optional-contents">
+      <emu-alg>
+        1. If _dtf_ does not have an [[initializedDateTimeFormat]] internal slot and ? InstanceofOperator(_dtf_, %DateTimeFormat%),
+          1. Let _dtf_ be ? RequireObjectCoercible(Get(_dtf_, Intl.[[FallbackSymbol]])).
+      </emu-alg>
+      </div></emu-normative-optional>
+      <emu-alg>
+        2. If _dtf_ does not have an [[initializedDateTimeFormat]] internal slot,
+          1. Throw a *TypeError* exception.
+        1. Return _dtf_.
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-intl-datetimeformat-constructor">
@@ -379,7 +400,18 @@
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
         1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%DateTimeFormatPrototype%"`, &laquo; [[initializedIntlObject]], [[initializedDateTimeFormat]], [[locale]], [[calendar]], [[numberingSystem]], [[timeZone]], [[weekday]], [[era]], [[year]], [[month]], [[day]], [[hour]], [[minute]], [[second]], [[timeZoneName]], [[hour12]], [[hourNo0]], [[pattern]], [[boundFormat]] &raquo;).
-        1. Return ? InitializeDateTimeFormat(_dateTimeFormat_, _locales_, _options_).
+        1. Perform ? InitializeDateTimeFormat(_dateTimeFormat_, _locales_, _options_).
+      </emu-alg>
+      <emu-normative-optional><span class="normative-optional">Normative Optional</span><div class="normative-optional-contents">
+      <emu-alg>
+        4. Let _this_ be the *this* value.
+        1. If NewTarget is *undefined* and ? InstanceofOperator(_this_, %NumberFormat%),
+          1. Perform ? DefineOwnPropertyOrThrow(_this_, Intl.[[FallbackSymbol]], { [[Value]]: _dateTimeFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Return _this_.
+      </emu-alg>
+      </div></emu-normative-optional>
+      <emu-alg>
+        1. Return _dateTimeFormat_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -512,7 +544,7 @@
       <emu-alg>
         1. Let _dtf_ be *this* value.
         1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
-        1. If _dtf_ does not have an [[initializedDateTimeFormat]] internal slot, throw a *TypeError* exception.
+        1. Let _dtf_ be ? UnwrapDateTimeFormat(_dtf_).
         1. If _dtf_.[[boundFormat]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-format-functions"></emu-xref>).
           1. Let _bf_ be BoundFunctionCreate(_F_, _dft_, &laquo; &raquo;).
@@ -545,7 +577,7 @@
       <h1>Intl.DateTimeFormat.prototype.resolvedOptions ()</h1>
 
       <p>
-        This function provides access to the locale and formatting options computed during initialization of the object.
+        This function provides access to the locale and formatting options computed during initialization of the object. This function initially invokes the internal algorithm UnwrapDateTimeFormat to get the %DateTimeFormat% object on which to operate.
       </p>
 
       <p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -25,6 +25,20 @@
     margin-bottom: 10px;
     padding-left: 10px;
   }
+
+emu-normative-optional {
+    margin: 1em 0;
+    border-left: 5px solid #ff6600;
+    display: block;
+    background: #ffeedd;
+}
+
+span.normative-optional {
+    padding-left: 5px;
+    text-transform: uppercase;
+    color: #884400;
+}
+
 </style>
 <img src="img/ecma-logo.jpg">
 <pre class=metadata>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -12,6 +12,10 @@
     The Intl object is not a function object. It does not have a [[Construct]] internal method; it is not possible to use the Intl object as a constructor with the *new* operator. The Intl object does not have a [[Call]] internal method; it is not possible to invoke the Intl object as a function.
   </p>
 
+  <p>
+    The Intl object has an internal slot, [[FallbackSymbol]], which is a new %Symbol% in the current realm.
+  </p>
+
   <emu-clause id="sec-constructor-properties-of-the-intl-object">
     <h1>Constructor Properties of the Intl Object</h1>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -448,6 +448,26 @@
         1. Return _m_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-unwrapnumberformat" aoid="UnwrapNumberFormat">
+      <h1>UnwrapNumberFormat(nf)</h1>
+      <p>
+        The UnwrapNumberFormat abstract operation gets the underlying NumberFormat operation
+        for various methods which implement ECMA-402 v1 semantics for supporting initializing
+        existing Intl objects.
+      </p>
+      <emu-normative-optional><span class="normative-optional">Normative Optional</span><div class="normative-optional-contents">
+      <emu-alg>
+        1. If _nf_ does not have an [[initializedNumberFormat]] internal slot and ? InstanceofOperator(_nf_, %NumberFormat%),
+          1. Let _nf_ be ? RequireObjectCoercible(Get(_nf_, Intl.[[FallbackSymbol]])).
+      </emu-alg>
+      </div></emu-normative-optional>
+      <emu-alg>
+        2. If _nf_ does not have an [[initializedNumberFormat]] internal slot,
+          1. Throw a *TypeError* exception.
+        1. Return _nf_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-intl-numberformat-constructor">
@@ -467,7 +487,18 @@
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
         1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%NumberFormatPrototype%"`, &laquo; [[initializedIntlObject]], [[initializedNumberFormat]], [[locale]], [[numberingSystem]], [[style]], [[currency]], [[currencyDisplay]], [[minimumIntegerDigits]], [[minimumFractionDigits]], [[maximumFractionDigits]], [[minimumSignificantDigits]], [[maximumSignificantDigits]], [[useGrouping]], [[positivePattern]], [[negativePattern]], [[boundFormat]] &raquo;).
-        1. Return ? InitializeNumberFormat(_numberFormat_, _locales_, _options_).
+        1. Perform ? InitializeNumberFormat(_numberFormat_, _locales_, _options_).
+      </emu-alg>
+      <emu-normative-optional><span class="normative-optional">Normative Optional</span><div class="normative-optional-contents">
+      <emu-alg>
+        4. Let _this_ be the *this* value.
+        1. If NewTarget is *undefined* and ? InstanceofOperator(_this_, %NumberFormat%),
+          1. Perform ? DefineOwnPropertyOrThrow(_this_, Intl.[[FallbackSymbol]], { [[Value]]: _numberFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Return _this_.
+      </emu-alg>
+      </div></emu-normative-optional>
+      <emu-alg>
+        6. Return _numberFormat_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -577,7 +608,7 @@
       <emu-alg>
         1. Let _nf_ be *this* value.
         1. If Type(_nf_) is not Object, throw a *TypeError* exception.
-        1. If _nf_.[[initializedNumberFormat]] is *true*, throw a *TypeError* exception.
+        1. Let _nf_ be ? UnwrapNumberFormat(_nf_);
         1. If _nf_.[[boundFormat]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions"></emu-xref>).
           1. Let _bf_ be BoundFunctionCreate(_F_, _nf_, &laquo; &raquo;).
@@ -591,7 +622,7 @@
       <h1>Intl.NumberFormat.prototype.resolvedOptions ()</h1>
 
       <p>
-        This function provides access to the locale and formatting options computed during initialization of the object.
+        This function provides access to the locale and formatting options computed during initialization of the object. This function initially invokes the internal algorithm UnwrapNumberFormat to get the %NumberFormat% object on which to operate.
       </p>
       <p>
         The function returns a new object whose properties and attributes are set as if constructed by an object literal assigning to each of the following properties the value of the corresponding internal slot of this NumberFormat object (see <emu-xref href="#sec-properties-of-intl-numberformat-instances"></emu-xref>): locale, numberingSystem, style, currency, currencyDisplay, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, and useGrouping. Properties whose corresponding internal slots have the value *undefined* are not assigned.


### PR DESCRIPTION
This patch addresses #57 by allowing certain legacy constructor
patterns to coexist with the new guarantees in ECMA-402 v2, which
allows for a pattern where all internal slots exist from the
beginning of the object's lifetime. The compromise is based on
storing a "real" object inside of a symbol-named property to allow
for object initialization in cases of the
Intl.<constructor>.call(Object.create(Intl.<constructor>) pattern.
Legacy methods have to forward their calls to this "real" object.

This patch specifies the change for Intl.NumberFormat, but an
analogous change would also be needed for Intl.DateTimeFormat and
Intl.Collator. This version is being sent out for review for feedback
from users and implementors. A sample implementation in V8 can
be found at
https://codereview.chromium.org/1828543007
