### PR TITLE
Move Array.prototype.toLocaleString's separator-computation step to just before the loop that first uses it

### DIFF
--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -253,13 +253,13 @@
       <emu-alg>
         1. Let _A_ be ? ToObject(*this* value).
         1. Let _len_ be ? ToLength(? Get(_A_, *"length"*)).
-        1. Let _separator_ be the String value for the list-separator String appropriate for the host environment’s current locale (this is derived in an implementation-defined way).
         1. If _len_ is zero, return the empty String.
         1. Let _firstElement_ be ? Get(_A_, *"0"*).
         1. If _firstElement_ is *undefined* or *null*, then
           1. Let _R_ be an empty String.
         1. Else,
           1. Let _R_ be ? ToString(? Invoke(_firstElement_, *"toLocaleString"*, « _locales_, _options_ »)).
+        1. Let _separator_ be the String value for the list-separator String appropriate for the host environment’s current locale (this is derived in an implementation-defined way).
         1. Let _k_ be 1.
         1. Repeat, while _k_ < _len_
           1. Let _S_ be a String value produced by concatenating _R_ and _separator_.


### PR DESCRIPTION
I was reviewing a SpiderMonkey patch that put the step in its current order, and I was going to tell the author to move the step out of order, then I realized I could just change the spec.  :-)  (Theoretically we could bikeshed the step even one later, but I prefer to view "Let k be 1" and the loop on k as a single logical step.)

I'm also filing a PR against ecma262 for the same issue there.