### PR TITLE
Editorial: use dot notation for accessing internal slots & co.

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -48,7 +48,7 @@
       </p>
 
       <emu-alg>
-        1. If _collator_ has an [[initializedIntlObject]] internal slot with value *true*, throw a *TypeError* exception.
+        1. If _collator_.[[initializedIntlObject]] is *true*, throw a *TypeError* exception.
         1. Set _collator_.[[initializedIntlObject]] to *true*.
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
@@ -261,7 +261,7 @@
 
       <emu-alg>
         1. Let _collator_ be the *this* value.
-        1. Assert: Type(_collator_) is Object and _collator_ has an [[initializedCollator]] internal slot whose value is *true*.
+        1. Assert: Type(_collator_) is Object and _collator_ .[[initializedCollator]] is *true*.
         1. If _x_ is not provided, let _x_ be *undefined*.
         1. If _y_ is not provided, let _y_ be *undefined*.
         1. Let _X_ be ? ToString(_x_).

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -58,9 +58,9 @@
         1. Let _u_ be ? GetOption(_options_, *"usage"*, *"string"*, « *"sort"*, *"search"* », *"sort"*).
         1. Set _collator_.[[usage]] to _u_.
         1. If _u_ is *"sort"*, then
-          1. Let _localeData_ be the value of *%Collator%*.[[sortLocaleData]].
+          1. Let _localeData_ be *%Collator%*.[[sortLocaleData]].
         1. Else,
-          1. Let _localeData_ be the value of *%Collator%*.[[searchLocaleData]].
+          1. Let _localeData_ be *%Collator%*.[[searchLocaleData]].
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
@@ -73,9 +73,9 @@
           1. If the string given in the Type column of the row is *"boolean"* and value is not *undefined*, then
             1. Let _value_ be ! ToString(_value_).
           1. Set _opt_.[[&lt;_key_&gt;]] to _value_.
-        1. Let _relevantExtensionKeys_ be the value of *%Collator%*.[[relevantExtensionKeys]].
+        1. Let _relevantExtensionKeys_ be *%Collator%*.[[relevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(*%Collator%*.[[availableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
-        1. Set _collator_.[[locale]] to the value of _r_.[[locale]].
+        1. Set _collator_.[[locale]] to _r_.[[locale]].
         1. Let _k_ be 0.
         1. Let _rExtensionKeys_ be CreateArrayFromList(_relevantExtensionKeys_).
         1. Let _len_ be ! ToLength(! Get(_rExtensionKeys_, *"length"*)).
@@ -83,11 +83,11 @@
           1. Let _key_ be ! Get(_rExtensionKeys_, ! ToString(_k_)).
           1. If _key_ is *"co"*, then
             1. Let _property_ be *"collation"*.
-            1. Let _value_ be the value of _r_.[[co]].
+            1. Let _value_ be _r_.[[co]].
             1. If _value_ is *null*, let _value_ be *"default"*.
-          1. Else use the row of <emu-xref href="#table-collator-options"></emu-xref> that contains the value of _key_ in the Key column:
+          1. Else use the row of <emu-xref href="#table-collator-options"></emu-xref> that contains _key_ in the Key column:
             1. Let _property_ be the name given in the Property column of the row.
-            1. Let _value_ be the value of _r_.[[&lt;_key_&gt;]].
+            1. Let _value_ be _r_.[[&lt;_key_&gt;]].
             1. If the name given in the Type column of the row is *"boolean"*, let _value_ be the result of comparing value with *"true"*.
           1. Set _collator_.[[&lt;_property_&gt;]] to _value_.
           1. Increase _k_ by 1.
@@ -96,7 +96,7 @@
           1. If _u_ is *"sort"*, then
             1. Let _s_ be *"variant"*.
           1. Else,
-            1. Let _dataLocale_ be the value of _r_.[[dataLocale]].
+            1. Let _dataLocale_ be _r_.[[dataLocale]].
             1. Let _dataLocaleData_ be Get(_localeData_, _dataLocale_).
             1. Let _s_ be Get(_dataLocaleData_, *"sensitivity"*).
         1. Set _collator_.[[sensitivity]] to _s_.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -71,12 +71,12 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _localeData_ be the value of *%DateTimeFormat%*.[[localeData]].
+        1. Let _localeData_ be *%DateTimeFormat%*.[[localeData]].
         1. Let _r_ be ResolveLocale( *%DateTimeFormat%*.[[availableLocales]], _requestedLocales_, _opt_, *%DateTimeFormat%*.[[relevantExtensionKeys]], _localeData_).
-        1. Set _dateTimeFormat_.[[locale]] to the value of _r_.[[locale]].
-        1. Set _dateTimeFormat_.[[calendar]] to the value of _r_.[[ca]].
-        1. Set _dateTimeFormat_.[[numberingSystem]] to the value of _r_.[[nu]].
-        1. Let _dataLocale_ be the value of _r_.[[dataLocale]].
+        1. Set _dateTimeFormat_.[[locale]] to _r_.[[locale]].
+        1. Set _dateTimeFormat_.[[calendar]] to _r_.[[ca]].
+        1. Set _dateTimeFormat_.[[numberingSystem]] to _r_.[[nu]].
+        1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _tz_ be ? Get(_options_, *"timeZone"*).
         1. If _tz_ is not *undefined*, then
           1. Let _tz_ be ? ToString(_tz_).
@@ -237,7 +237,7 @@
 
       <emu-alg>
         1. If _x_ is not a finite Number, throw a *RangeError* exception.
-        1. Let _locale_ be the value of _dateTimeFormat_.[[locale]].
+        1. Let _locale_ be _dateTimeFormat_.[[locale]].
         1. Let _nfLocale_ be CreateArrayFromList(« _locale_ »).
         1. Let _nfOptions_ be ObjectCreate(%ObjectPrototype%).
         1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, `"useGrouping"`, *false*).
@@ -247,7 +247,7 @@
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, `"useGrouping"`, *false*).
         1. Let _nf2_ be ? Construct(%NumberFormat%, « _nfLocale_, _nf2Options_ »).
         1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[calendar]], _dateTimeFormat_.[[timeZone]]).
-        1. Let _result_ be the value of the _dateTimeFormat_.[[pattern]].
+        1. Let _result_ be _dateTimeFormat_.[[pattern]].
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, do:
           1. If _dateTimeFormat_ has an internal slot with the name given in the Property column of the row, then
             1. Let _p_ be the name given in the Property column of the row.
@@ -255,10 +255,10 @@
             1. Let _v_ be _tm_.[[<_p_>]].
             1. If _p_ is *"year"* and _v_ ≤ 0, let _v_ be 1 - _v_.
             1. If _p_ is *"month"*, increase _v_ by 1.
-            1. If _p_ is *"hour"* and the value of _dateTimeFormat_.[[hour12]] is *true*, then
+            1. If _p_ is *"hour"* and _dateTimeFormat_.[[hour12]] is *true*, then
               1. Let _v_ be _v_ modulo 12.
-              1. If _v_ is equal to the value of _tm_.[[<_p_>]], let _pm_ be *false*; else let _pm_ be *true*.
-              1. If _v_ is 0 and the value of _dateTimeFormat_.[[hourNo0]] is *true*, let _v_ be 12.
+              1. If _v_ is equal to _tm_.[[<_p_>]], let _pm_ be *false*; else let _pm_ be *true*.
+              1. If _v_ is 0 and _dateTimeFormat_.[[hourNo0]] is *true*, let _v_ be 12.
             1. If _f_ is *"numeric"*, then
               1. Let _fv_ be FormatNumber(_nf_, _v_).
             1. Else if _f_ is *"2-digit"*, then
@@ -346,7 +346,7 @@
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be the value of *%DateTimeFormat%*.[[availableLocales]].
+        1. Let _availableLocales_ be *%DateTimeFormat%*.[[availableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -215,7 +215,7 @@
 
       <emu-alg>
         1. Let _dtf_ be the *this* value.
-        1. Assert: Type(_dtf_) is Object and _dtf_ has an [[initializedDateTimeFormat]] internal slot whose value is *true*.
+        1. Assert: Type(_dtf_) is Object and _dtf_.[[initializedDateTimeFormat]] is *true*.
         1. If _date_ is not provided or is *undefined*, then
           1. Let _x_ be Call(*%Date_now%*, *undefined*).
         1. Else,
@@ -251,8 +251,8 @@
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, do:
           1. If _dateTimeFormat_ has an internal slot with the name given in the Property column of the row, then
             1. Let _p_ be the name given in the Property column of the row.
-            1. Let _f_ be the value of the [[<_p_>]] internal slot of _dateTimeFormat_.
-            1. Let _v_ be the value of _tm_.[[<_p_>]].
+            1. Let _f_ be _dateTimeFormat_.[[<_p_>]].
+            1. Let _v_ be _tm_.[[<_p_>]].
             1. If _p_ is *"year"* and _v_ ≤ 0, let _v_ be 1 - _v_.
             1. If _p_ is *"month"*, increase _v_ by 1.
             1. If _p_ is *"hour"* and the value of _dateTimeFormat_.[[hour12]] is *true*, then
@@ -449,7 +449,7 @@
         1. Let _dtf_ be *this* value.
         1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
         1. If _dtf_ does not have an [[initializedDateTimeFormat]] internal slot, throw a *TypeError* exception.
-        1. If the [[boundFormat]] internal slot of _dtf_ is *undefined*, then
+        1. If _dtf_.[[boundFormat]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-format-functions"></emu-xref>).
           1. Let _bf_ be BoundFunctionCreate(_F_, _dft_, « »).
           1. Perform ! DefinePropertyOrThrow(_bf_, `"length"`, PropertyDescriptor {[[Value]]: 1, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -81,10 +81,6 @@
         The result must be derived according to the case mappings in the Unicode character database (this explicitly includes not only the UnicodeData.txt file, but also the SpecialCasings.txt file that accompanies it).
       </p>
 
-      <p>
-        The value of the *length* property of the *toLocaleLowerCase* method is 0.
-      </p>
-
       <emu-note>
         As of Unicode 5.1, the _availableLocales_ list contains the elements *"az"*, *"lt"*, and *"tr"*.
       </emu-note>
@@ -108,10 +104,6 @@
 
       <p>
         This function interprets a string value as a sequence of code points, as described in ES2017, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. This function behaves in exactly the same way as *String.prototype.toLocaleLowerCase*, except that characters are mapped to their _uppercase_ equivalents as specified in the Unicode character database.
-      </p>
-
-      <p>
-        The value of the *length* property of the *toLocaleUpperCase* method is 0.
       </p>
 
       <emu-note>
@@ -146,10 +138,6 @@
         1. Return FormatNumber(_numberFormat_, _x_).
       </emu-alg>
 
-      <p>
-        The value of the *length* property of the *toLocaleString* method is 0.
-      </p>
-
     </emu-clause>
   </emu-clause>
 
@@ -179,10 +167,6 @@
         1. Return FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
 
-      <p>
-        The value of the *length* property of the *toLocaleString* method is 0.
-      </p>
-
     </emu-clause>
 
     <emu-clause id="sup-date.prototype.tolocaledatestring">
@@ -204,10 +188,6 @@
         1. Return FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
 
-      <p>
-        The value of the *length* property of the *toLocaleDateString* method is 0.
-      </p>
-
     </emu-clause>
 
     <emu-clause id="sup-date.prototype.tolocaletimestring">
@@ -228,10 +208,6 @@
         1. Let _timeFormat_ be ? Construct(*%DateTimeFormat%*, « _locales_, _options_ »).
         1. Return FormatDateTime(_timeFormat_, _x_).
       </emu-alg>
-
-      <p>
-        The value of the *length* property of the *toLocaleTimeString* method is 0.
-      </p>
 
     </emu-clause>
   </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -183,14 +183,14 @@
       </p>
 
       <emu-alg>
-        1. Let _matcher_ be the value of _options_.[[localeMatcher]].
+        1. Let _matcher_ be _options_.[[localeMatcher]].
         1. If _matcher_ is *"lookup"*, then
           1. Let _r_ be LookupMatcher(_availableLocales_, _requestedLocales_).
         1. Else,
           1. Let _r_ be BestFitMatcher(_availableLocales_, _requestedLocales_).
-        1. Let _foundLocale_ be the value of _r_.[[locale]].
+        1. Let _foundLocale_ be _r_.[[locale]].
         1. If _r_ has an [[extension]] field, then
-          1. Let _extension_ be the value of _r_.[[extension]].
+          1. Let _extension_ be _r_.[[extension]].
           1. Let _extensionSubtags_ be CreateArrayFromList(UnicodeExtensionSubtags(_extension_)).
           1. Let _extensionSubtagsLength_ be Get(_extensionSubtags_, *"length"*).
         1. Let _result_ be a new Record.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -28,8 +28,8 @@
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be *%NumberFormat%*.[[localeData]].
         1. Let _r_ be ResolveLocale(*%NumberFormat%*.[[availableLocales]], _requestedLocales_, _opt_, *%NumberFormat%*.[[relevantExtensionKeys]], _localeData_).
-        1. Set _numberFormat_.[[locale]] to the value of _r_.[[locale]].
-        1. Set _numberFormat_.[[numberingSystem]] to the value of _r_.[[nu]].
+        1. Set _numberFormat_.[[locale]] to _r_.[[locale]].
+        1. Set _numberFormat_.[[numberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _s_ be ? GetOption(_options_, *"style"*, *"string"*, « *"decimal"*, *"percent"*, *"currency"* », *"decimal"*).
         1. Set _numberFormat_.[[style]] to _s_.
@@ -123,24 +123,24 @@
           1. If _x_ < 0, then
             1. Let _negative_ be *true*.
             1. Let _x_ be -_x_.
-          1. If the value of _numberFormat_.[[style]] is *"percent"*, let _x_ be 100 × _x_.
+          1. If _numberFormat_.[[style]] is *"percent"*, let _x_ be 100 × _x_.
           1. If the _numberFormat_.[[minimumSignificantDigits]] and _numberFormat_.[[maximumSignificantDigits]] are present, then
             1. Let _n_ be ToRawPrecision(_x_, _numberFormat_.[[minimumSignificantDigits]], _numberFormat_.[[maximumSignificantDigits]]).
           1. Else,
             1. Let _n_ be ToRawFixed(_x_, _numberFormat_.[[minimumIntegerDigits]], _numberFormat_.[[minimumFractionDigits]], _numberFormat_.[[maximumFractionDigits]]).
-          1. If the value of the _numberFormat_.[[numberingSystem]] matches one of the values in the "Numbering System" column of <emu-xref href="#table-numbering-system-digits"></emu-xref> below, then
+          1. If _numberFormat_.[[numberingSystem]] matches one of the values in the "Numbering System" column of <emu-xref href="#table-numbering-system-digits"></emu-xref> below, then
             1. Let _digits_ be an array whose 10 String valued elements are the UTF-16 string representations of the 10 _digits_ specified in the "Digits" column of the matching row in <emu-xref href="#table-numbering-system-digits"></emu-xref>.
-            1. Replace each _digit_ in _n_ with the value of _digits_[_digit_].
+            1. Replace each _digit_ in _n_ with _digits_[_digit_].
           1. Else use an implementation dependent algorithm to map _n_ to the appropriate representation of _n_ in the given numbering system.
           1. If _n_ contains the character *"."*, replace it with an ILND String representing the decimal separator.
-          1. If the value of the _numberFormat_.[[useGrouping]] is *true*, insert an ILND String representing a grouping separator into an ILND set of locations within the integer part of _n_.
+          1. If _numberFormat_.[[useGrouping]] is *true*, insert an ILND String representing a grouping separator into an ILND set of locations within the integer part of _n_.
         1. If _negative_ is *true*, then
-          1. Let _result_ be the value of _numberFormat_.[[negativePattern]].
+          1. Let _result_ be _numberFormat_.[[negativePattern]].
         1. Else,
-          1. Let _result_ be the value of _numberFormat_.[[positivePattern]].
+          1. Let _result_ be _numberFormat_.[[positivePattern]].
         1. Replace the substring *"{number}"* within _result_ with _n_.
-        1. If the value of the _numberFormat_.[[style]] is *"currency"*, then
-          1. Let _currency_ be the value of _numberFormat_.[[currency]].
+        1. If _numberFormat_.[[style]] is *"currency"*, then
+          1. Let _currency_ be _numberFormat_.[[currency]].
           1. If _numberFormat_.[[currencyDisplay]] is *"code"*, then
             1. Let _cd_ be _currency_.
           1. Else if _numberFormat_.[[currencyDisplay]] is *"symbol"*, then

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -16,7 +16,7 @@
       </p>
 
       <emu-alg>
-        1. If _numberFormat_ has an [[initializedIntlObject]] internal slot with value *true*, throw a *TypeError* exception.
+        1. If _numberFormat_.[[initializedIntlObject]] is *true*, throw a *TypeError* exception.
         1. Set _numberFormat_.[[initializedIntlObject]] to *true*.
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
@@ -93,7 +93,7 @@
 
       <emu-alg>
         1. Let _nf_ be the *this* value.
-        1. Assert: Type(_nf_) is Object and _nf_ has an [[initializedNumberFormat]] internal slot whose value is *true*.
+        1. Assert: Type(_nf_) is Object and _nf_.[[initializedNumberFormat]] is *true*.
         1. If _value_ is not provided, let _value_ be *undefined*.
         1. Let _x_ be ? ToNumber(_value_).
         1. Return FormatNumber(_nf_, _x_).


### PR DESCRIPTION
## use dot notation for accessing internal slots

This is a follow up from https://github.com/tc39/ecma262/pull/591

Specifically, change:

```
   the [[Foo]] internal slot of _O_  (132 occurrences)
```
and
```
   _O_'s [[Foo]] internal slot (265 occurrences)
```
to
```
   _O_.[[Foo]]
```

while preserving some references when using "Internal Slot" in a sentence to test for identity, and removing "the value of" wording in front.

## Length default property of functions is 0

This is a follow up from https://github.com/tc39/ecma262/pull/597

* removing unnecessary definitions