### PR TITLE
Add mnfdDefault to SetNumberFormatDigitOptions

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -5,7 +5,7 @@
     <h1>Abstract Operations For NumberFormat Objects</h1>
 
     <emu-clause id="sec-setnfdigitoptions" aoid="SetNumberFormatDigitOptions">
-      <h1>SetNumberFormatDigitOptions ( _intlObj_, _options_ )</h1>
+      <h1>SetNumberFormatDigitOptions ( _intlObj_, _options_, _mnfdDefault_ )</h1>
 
       <p>
         The abstract operation SetNumberFormatDigitOptions applies digit
@@ -14,19 +14,20 @@
       <emu-alg>
         1. Assert: Type(_intlObj_) is Object and _intlObj_.[[initializedIntlObject]] is *true*.
         1. Assert: Type(_options_) is Object.
+        1. Assert: type(_mnfdDefault_) is Number.
         1. Let _mnid_ be ? GetNumberOption(_options_, *"minimumIntegerDigits,"*, 1, 21, 1).
-        1. Let _mnfd_ be ? GetNumberOption(_options_, *"minimumFractionDigits"*, 0, 20).
+        1. Let _mnfd_ be ? GetNumberOption(_options_, *"minimumFractionDigits"*, 0, 20, _mnfdDefault_).
         1. Let _mxfd_ be ? GetNumberOption(_options_, *"maximumFractionDigits"*, _mnfd_, 20).
         1. Let _mnsd_ be ? Get(_options_, *"minimumSignificantDigits"*).
         1. Let _mxsd_ be ? Get(_options_, *"maximumSignificantDigits"*).
-        1. If _mnsd_ is not *undefined* or _mxsd_ is not *undefined*, then
-          1. Let _mnsd_ be ? GetNumberOption(_options_, *"minimumSignificantDigits"*, 1, 21, 1).
-          1. Let _mxsd_ be ? GetNumberOption(_options_, *"maximumSignificantDigits"*, _mnsd_, 21, 21).
         1. Set _intlObj_.[[minimumIntegerDigits]] to mnid.
         1. Set _intlObj_.[[minimumFractionDigits]] to mnfd.
         1. Set _intlObj_.[[maximumFractionDigits]] to mxfd.
-        1. Set _intlObj_.[[minimumSignificantDigits]] to mnsd.
-        1. Set _intlObj_.[[maximumSignificantDigits]] to mxsd.
+        1. If _mnsd_ is not *undefined* or _mxsd_ is not *undefined*, then
+          1. Let _mnsd_ be ? GetNumberOption(_options_, *"minimumSignificantDigits"*, 1, 21, 1).
+          1. Let _mxsd_ be ? GetNumberOption(_options_, *"maximumSignificantDigits"*, _mnsd_, 21, 21).
+          1. Set _intlObj_.[[minimumSignificantDigits]] to mnsd.
+          1. Set _intlObj_.[[maximumSignificantDigits]] to mxsd.
       </emu-alg>
     </emu-clause>
 
@@ -69,12 +70,11 @@
           1. Let _cDigits_ be CurrencyDigits(_c_).
         1. Let _cd_ be ? GetOption(_options_, *"currencyDisplay"*, *"string"*, &laquo; *"code"*, *"symbol"*, *"name"* &raquo;, *"symbol"*).
         1. If _s_ is *"currency"*, set _numberFormat_.[[currencyDisplay]] to _cd_.
-        1. Perform ! SetNumberFormatDigitOptions(_numberFormat_, _options_).
-        1. If _numberFormat_.[[minimumIntegerDigits]] is *undefined*, then
-          1. If _style_ is *"currency"*, then
-            1. Set _numberFormat_.[[minimumFractionDigits]] to _cDigits_.
-          1. Else,
-            1. Set _numberFormat_.[[minimumFractionDigits]] to *0*.
+        1. If _style_ is *"currency"*, then
+          1. Let _mnfdDefault_ be _cDigits_.
+        1. Else,
+          1. Let _mnfdDefault_ be *0*.
+        1. Perform ! SetNumberFormatDigitOptions(_numberFormat_, _options_, _mnfdDefault_).
         1. If _numberFormat_.[[maximumFractionDigits]] is *undefined*, then
           1. If _style_ is *"currency"*, then
             1. Set _numberFormat_.[[maximumFractionDigits]] to max(_numberFormat_.[[minimumFractionDigits]], _cDigits_).


### PR DESCRIPTION
I'm implementing the `SetNumberFormatDigitOptions` as part of the https://bugzilla.mozilla.org/show_bug.cgi?id=1270146 and noticed that this regresses `NumberFormat`.

What happens is that if the user doesn't manually pass `minimumFractionDigits` option, `minimumFractionDigits` doesn't have the default value in `SetNumberFormatDigitOptions` and `mnfd` ends up being `undefined`.

Then, `mnfd` is passed as the third argument to `GetNumberOption` for `maximumFractionDigits` and that fails the assertion that the third argument is a number.

This patch fixes the bug and also shifts the order of operations in `SetNumberFormatDigitOptions` to better replicate previous behavior with regards to `*SignificantDigits` - the two values were not set at all on the `intlObj` if they were not passed in `options`.