### PR TITLE
Normative: Avoid reading options twice

### DIFF
--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -320,6 +320,22 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-defaultnumberoption" aoid="DefaultNumberOption">
+      <h1>DefaultNumberOption ( _value_, _minimum_, _maximum_, _fallback_ )</h1>
+
+      <p>
+        The abstract operation DefaultNumberOption converts _value_ to a Number value, checks whether it is in the allowed range, and fills in a _fallback_ value if necessary.
+      </p>
+
+      <emu-alg>
+        1. If _value_ is not *undefined*, then
+          1. Let _value_ be ? ToNumber(_value_).
+          1. If _value_ is *NaN* or less than _minimum_ or greater than _maximum_, throw a *RangeError* exception.
+          1. Return floor(_value_).
+        1. Else, return _fallback_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-getnumberoption" aoid="GetNumberOption">
       <h1>GetNumberOption ( _options_, _property_, _minimum_, _maximum_, _fallback_ )</h1>
 
@@ -330,11 +346,7 @@
       <emu-alg>
         1. Let _opts_ be ? ToObject(_options_).
         1. Let _value_ be ? Get(_opts_, _property_).
-        1. If _value_ is not *undefined*, then
-          1. Let _value_ be ? ToNumber(_value_).
-          1. If _value_ is *NaN* or less than _minimum_ or greater than _maximum_, throw a *RangeError* exception.
-          1. Return floor(_value_).
-        1. Else, return _fallback_.
+        1. Return ? DefaultNumberOption(_value_, _minimum_, _maximum_, _fallback_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -26,8 +26,8 @@
         1. Set _intlObj_.[[MinimumFractionDigits]] to mnfd.
         1. Set _intlObj_.[[MaximumFractionDigits]] to mxfd.
         1. If _mnsd_ is not *undefined* or _mxsd_ is not *undefined*, then
-          1. Let _mnsd_ be ? GetNumberOption(_options_, *"minimumSignificantDigits"*, 1, 21, 1).
-          1. Let _mxsd_ be ? GetNumberOption(_options_, *"maximumSignificantDigits"*, _mnsd_, 21, 21).
+          1. Let _mnsd_ be ? DefaultNumberOption(_mnsd_, 1, 21, 1).
+          1. Let _mxsd_ be ? DefaultNumberOption(_mxsd_, _mnsd_, 21, 21).
           1. Set _intlObj_.[[MinimumSignificantDigits]] to mnsd.
           1. Set _intlObj_.[[MaximumSignificantDigits]] to mxsd.
       </emu-alg>


### PR DESCRIPTION
This patch refactors NumberFormat's option parsing code to avoid
redundant Get calls for {minimum,maximum}SignificantDigits .

Fixes #131