### PR TITLE
Correctly retrieve hourCycle/hour12 from options and Unicode extension value

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -616,7 +616,7 @@
       </p>
 
       <p>
-        For web compatibility reasons, if the property hourCycle is set, the corresponding property hour12 should be set as well.
+        For web compatibility reasons, if the property hourCycle is set, the hour12 property should be set to *true* when hourCycle is *"h11"* or *"h12"*, or to *false* when hourCycle is *"h23"* or *"h24"*.
       </p>
 
       <emu-note>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -81,6 +81,8 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
+        1. Set _opt_.[[hc]] to _hc_.
         1. Let _localeData_ be %DateTimeFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale( %DateTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %DateTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _dateTimeFormat_.[[Locale]] to _r_.[[locale]].
@@ -114,23 +116,24 @@
           1. Let _p_ be Get(_bestFormat_, _prop_).
           1. If _p_ not *undefined*, then
             1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
-        1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
         1. Let _hr12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
         1. If _dateTimeFormat_ has an internal slot [[Hour]], then
           1. Let _hcDefault_ be Get(_dataLocaleData_, *"hourCycle"*).
+          1. Let _hc_ be _dateTimeFormat_.[[HourCycle]].
+          1. If _hc_ is *null*, then
+            1. Set _hc_ to _hcDefault_
           1. If _hr12_ is not *undefined*, then
             1. If _hr12_ is *true*, then
               1. If _hcDefault_ is *"h11"* or *"h23"*, then
                 1. Set _hc_ to *"h11"*.
               1. Else,
                 1. Set _hc_ to *"h12"*.
-            1. Else, if _hr12_ is *false*, then
+            1. Else,
+              1. Assert: _hr12_ is *false*.
               1. If _hcDefault_ is *"h11"* or *"h23"*, then
                 1. Set _hc_ to *"h23"*.
               1. Else,
                 1. Set _hc_ to *"h24"*.
-          1. If _hc_ is *undefined*, then
-            1. Set _hc_ to _hcDefault_
           1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
           1. If _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then
             1. Let _pattern_ be Get(_bestFormat_, *"pattern12"*).
@@ -500,7 +503,10 @@
           The array that is the value of the "nu" property of any locale property of [[LocaleData]] must not include the values "native", "traditio", or "finance".
         </li>
         <li>
-          [[LocaleData]][locale] must have hourCycle property with String values for all locale values.
+          [[LocaleData]][locale].hc must be the array [*null*, *"h11"*, *"h12"*, *"h23"*, or *"h24"*] for all locale values.
+        </li>
+        <li>
+          [[LocaleData]][locale] must have a hourCycle property with a String value equal to *"h11"*, *"h12"*, *"h23"*, or *"h24"* for all locale values.
         </li>
         <li>
           [[LocaleData]][locale] must have a formats property for all locale values. The value of this property must be an array of objects, each of which has a subset of the properties shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each property must have one of the values specified for the property in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple objects in an array may use the same subset of the properties as long as they have different values for the properties. The following subsets must be available for each locale:

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -295,7 +295,7 @@
             1. If _p_ is *"month"*, increase _v_ by 1.
             1. If _p_ is *"hour"* and _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
               1. Let _v_ be _v_ modulo 12.
-              1. If _v_ is 0 and _dateTimeFormat_.[[HourCucle]] is *"h12"*, let _v_ be 12.
+              1. If _v_ is 0 and _dateTimeFormat_.[[HourCycle]] is *"h12"*, let _v_ be 12.
             1. If _p_ is *"hour"* and _dateTimeFormat_.[[HourCycle]] is *"h24"*, then
               1. If _v_ is 0, let _v_ be 24.
             1. If _f_ is *"numeric"*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -140,6 +140,7 @@
           1. Else,
             1. Let _pattern_ be Get(_bestFormat_, *"pattern"*).
         1. Else,
+          1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
           1. Let _pattern_ be Get(_bestFormat_, *"pattern"*).
         1. Set _dateTimeFormat_.[[Pattern]] to _pattern_.
         1. Set _dateTimeFormat_.[[BoundFormat]] to *undefined*.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -114,9 +114,9 @@
           1. Let _p_ be Get(_bestFormat_, _prop_).
           1. If _p_ not *undefined*, then
             1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
+        1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
+        1. Let _hr12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
         1. If _dateTimeFormat_ has an internal slot [[Hour]], then
-          1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
-          1. Let _hr12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
           1. Let _hcDefault_ be Get(_dataLocaleData_, *"hourCycle"*).
           1. If _hr12_ is not *undefined*, then
             1. If _hr12_ is *true*, then


### PR DESCRIPTION
c8b9f6e5714c14e4bfd253d02db5d8271d175685
- The "hourCycle" and "hour12" options should always be retrieved and validated from the options object, even when the resolved pattern doesn't contain an "hour" property.
- Otherwise invalid but unused "hourCycle" and "hour12" options aren't rejected,
- and implementations would be forced to resolve the pattern before processing "hourCycle" and "hour12".

4d771c8ef6d09320b6615a22e3a612cbc625b38c
- If an option can be set through a normal option and a Unicode extension value, the normal option should always have precedence over the Unicode extension value (cf. ResolveLocale [1]).
- That means "hourCycle" needs to be retrieved from the options object before calling ResolveLocale (right now https://tc39.github.io/ecma402/#sec-initializedatetimeformat step 12 sets dateTimeFormat.[[HourCycle]] from the Unicode extension value, and step 27.f overrides it from the options value or the locale default value).
- And to ensure we can detect when no hc Unicode extension value was present, the first entry of [[LocaleData]][locale].hc is set to *null*, this is similar to [[SortLocaleData]][locale].co and [[SearchLocaleData]][locale].co. So when we later retrieve dateTimeFormat.[[HourCycle]] again and the value is *null*, we set `hc` to `hcDefault`.

2f681f3005ffc8b7a5b1ea18c9b7be81d3e2d8ab
- To ensure [[HourCycle]] is only present in resolvedOptions() when [[Hour]] is used, we need to reset [[HourCycle]] to *undefined* when [[Hour]] is not present.

14939090f4db878d58735c01ec8e169ba214f654
- Only clarifies to which values hour12 should be set when hourCycle is present.

[1] And better ignore the bugs in ResolveLocale, I really ought to unrot the patches I have laying around for far too long to make ResolveLocale easier to understand. :stuck_out_tongue_closed_eyes: 