### PR TITLE
Use lists and records for all internal data

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -4,7 +4,7 @@
   <emu-clause id="sec-the-intl-collator-constructor">
     <h1>The Intl.Collator Constructor</h1>
     <p>
-      The Intl.Collator constructor is the <dfn>%Collator%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in 9.1.
+      The Intl.Collator constructor is the <dfn>%Collator%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-initializecollator" aoid="InitializeCollator">
@@ -171,7 +171,7 @@
       <h1>Internal Slots</h1>
 
       <p>
-        The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in 9.1. The value of the [[RelevantExtensionKeys]] internal slot is a List that must include the element *"co"*, may include any or all of the elements *"kn"* and *"kf"*, and must not include any other elements.
+        The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref>. The value of the [[RelevantExtensionKeys]] internal slot is a List that must include the element *"co"*, may include any or all of the elements *"kn"* and *"kf"*, and must not include any other elements.
       </p>
 
       <emu-note>
@@ -179,7 +179,7 @@
       </emu-note>
 
       <p>
-        The values of the [[SortLocaleData]] and [[SearchLocaleData]] internal slots are implementation defined within the constraints described in 9.1 and the following additional constraints:
+        The values of the [[SortLocaleData]] and [[SearchLocaleData]] internal slots are implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints:
       </p>
 
       <ul>
@@ -298,7 +298,7 @@
       </p>
 
       <p>
-        The CompareStrings abstract operation with any given _collator_ argument, if considered as a function of the remaining two arguments _x_ and _y_, must be a consistent comparison function (as defined in ES2017, <emu-xref href="#sec-array.prototype.sort"></emu-xref>) on the set of all Strings.
+        The CompareStrings abstract operation with any given _collator_ argument, if considered as a function of the remaining two arguments _x_ and _y_, must be a consistent comparison function (as defined in ES2018, <emu-xref href="#sec-array.prototype.sort"></emu-xref>) on the set of all Strings.
       </p>
 
       <p>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -158,8 +158,9 @@
       </p>
 
       <emu-alg>
+        1. Let _availableLocales_ be %Collator%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return ? SupportedLocales(%Collator%.[[AvailableLocales]], _requestedLocales_, _options_).
+        1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
 
       <p>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -73,7 +73,7 @@
           1. Let _type_ be the string given in the Type column of the row.
           1. Let _list_ be a List containing the Strings given in the Values column of the row, or *undefined* if no strings are given.
           1. Let _value_ be ? GetOption(_options_, _prop_, _type_, _list_, *undefined*).
-          1. If the string given in the Type column of the row is *"boolean"* and value is not *undefined*, then
+          1. If the string given in the Type column of the row is *"boolean"* and _value_ is not *undefined*, then
             1. Let _value_ be ! ToString(_value_).
           1. Set _opt_.[[&lt;_key_&gt;]] to _value_.
         1. Let _relevantExtensionKeys_ be %Collator%.[[RelevantExtensionKeys]].
@@ -86,7 +86,7 @@
             1. Set _collator_.[[Collation]] to _value_.
           1. Else use the row of <emu-xref href="#table-collator-options"></emu-xref> that contains _key_ in the Key column:
             1. Let _value_ be _r_.[[&lt;_key_&gt;]].
-            1. If the name given in the Type column of the row is *"boolean"*, let _value_ be the result of comparing value with *"true"*.
+            1. If the name given in the Type column of the row is *"boolean"*, let _value_ be SameValue(_value_, *"true"*).
             1. Set _collator_'s internal slot whose name is the Internal Slot column of the row to _value_.
         1. Let _s_ be ? GetOption(_options_, *"sensitivity"*, *"string"*, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
         1. If _s_ is *undefined*, then

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -79,11 +79,7 @@
         1. Let _relevantExtensionKeys_ be %Collator%.[[RelevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(%Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
         1. Set _collator_.[[Locale]] to _r_.[[locale]].
-        1. Let _k_ be 0.
-        1. Let _rExtensionKeys_ be CreateArrayFromList(_relevantExtensionKeys_).
-        1. Let _len_ be ! ToLength(! Get(_rExtensionKeys_, *"length"*)).
-        1. Repeat while _k_ < _len_:
-          1. Let _key_ be ! Get(_rExtensionKeys_, ! ToString(_k_)).
+        1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
           1. If _key_ is *"co"*, then
             1. Let _value_ be _r_.[[co]].
             1. If _value_ is *null*, let _value_ be *"default"*.
@@ -92,15 +88,14 @@
             1. Let _value_ be _r_.[[&lt;_key_&gt;]].
             1. If the name given in the Type column of the row is *"boolean"*, let _value_ be the result of comparing value with *"true"*.
             1. Set _collator_'s internal slot whose name is the Internal Slot column of the row to _value_.
-          1. Increase _k_ by 1.
         1. Let _s_ be ? GetOption(_options_, *"sensitivity"*, *"string"*, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
         1. If _s_ is *undefined*, then
           1. If _u_ is *"sort"*, then
             1. Let _s_ be *"variant"*.
           1. Else,
             1. Let _dataLocale_ be _r_.[[dataLocale]].
-            1. Let _dataLocaleData_ be Get(_localeData_, _dataLocale_).
-            1. Let _s_ be Get(_dataLocaleData_, *"sensitivity"*).
+            1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+            1. Let _s_ be _dataLocaleData_.[[sensitivity]].
         1. Set _collator_.[[Sensitivity]] to _s_.
         1. Let _ip_ be ? GetOption(_options_, *"ignorePunctuation"*, *"boolean"*, *undefined*, *false*).
         1. Set _collator_.[[IgnorePunctuation]] to _ip_.
@@ -185,8 +180,8 @@
 
       <ul>
         <li>The first element of [[SortLocaleData]][locale].co and [[SearchLocaleData]][locale].co must be *null* for all locale values.</li>
-        <li>The values *"standard"* and *"search"* must not be used as elements in any [[SortLocaleData]][locale].co and [[SearchLocaleData]][locale].co array.</li>
-        <li>[[SearchLocaleData]][locale] must have a sensitivity property with a String value equal to *"base"*, *"accent"*, *"case"*, or *"variant"* for all locale values.</li>
+        <li>The values *"standard"* and *"search"* must not be used as elements in any [[SortLocaleData]][locale].co and [[SearchLocaleData]][locale].co list.</li>
+        <li>[[SearchLocaleData]][locale] must have a sensitivity field with a String value equal to *"base"*, *"accent"*, *"case"*, or *"variant"* for all locale values.</li>
       </ul>
 
     </emu-clause>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -86,19 +86,14 @@
           <td>The initial value of the `prototype` data property of the intrinsic %DateTimeFormat% (<emu-xref href="#sec-intl.datetimeformat.prototype"></emu-xref>).</td>
         </tr>
         <tr>
-          <td><dfn>%StringProto_includes%</dfn></td>
-          <td>`String.prototype.includes`</td>
-          <td>The initial value of the `includes` data property of the intrinsic %StringPrototype% (ES2018, <emu-xref href="#sec-string.prototype.includes"></emu-xref>)</td>
-        </tr>
-        <tr>
           <td><dfn>%StringProto_indexOf%</dfn></td>
           <td>`String.prototype.indexOf`</td>
           <td>The initial value of the `indexOf` data property of the intrinsic %StringPrototype% (ES2018, <emu-xref href="#sec-string.prototype.indexof"></emu-xref>)</td>
         </tr>
         <tr>
-          <td><dfn>%ArrayProto_indexOf%</dfn></td>
-          <td>`Array.prototype.indexOf`</td>
-          <td>The initial value of the `indexOf` data property of the intrinsic %ArrayPrototype% (ES2018, <emu-xref href="#sec-array.prototype.indexof"></emu-xref>)</td>
+          <td><dfn>%ArrayProto_includes%</dfn></td>
+          <td>`Array.prototype.includes`</td>
+          <td>The initial value of the `includes` data property of the intrinsic %ArrayPrototype% (ES2018, <emu-xref href="#sec-array.prototype.includes"></emu-xref>)</td>
         </tr>
       </table>
     </emu-table>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -6,10 +6,10 @@
   </p>
 
   <ul>
-    <li>Object Internal Methods and Internal Slots, as described in ES2017, <emu-xref href="#sec-object-internal-methods-and-internal-slots"></emu-xref>.</li>
-    <li>Algorithm conventions, including the use of abstract operations, as described in ES2017, <emu-xref href="#sec-type-conversion"></emu-xref>, <emu-xref href="#sec-testing-and-comparison-operations"></emu-xref>, <emu-xref href="#sec-operations-on-objects"></emu-xref>.</li>
-    <li>Internal Slots, as described in ES2017, <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.</li>
-    <li>The List and Record Specification Type, as described in ES2017, <emu-xref href="#sec-list-and-record-specification-type"></emu-xref>.</li>
+    <li>Object Internal Methods and Internal Slots, as described in ES2018, <emu-xref href="#sec-object-internal-methods-and-internal-slots"></emu-xref>.</li>
+    <li>Algorithm conventions, including the use of abstract operations, as described in ES2018, <emu-xref href="#sec-type-conversion"></emu-xref>, <emu-xref href="#sec-testing-and-comparison-operations"></emu-xref>, <emu-xref href="#sec-operations-on-objects"></emu-xref>.</li>
+    <li>Internal Slots, as described in ES2018, <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.</li>
+    <li>The List and Record Specification Type, as described in ES2018, <emu-xref href="#sec-list-and-record-specification-type"></emu-xref>.</li>
   </ul>
 
   <emu-note>
@@ -17,11 +17,11 @@
   </emu-note>
 
   <p>
-    As an extension to the Record Specification Type, the notation "[[&lt;_name_&gt;]]" denotes a field whose name is given by the variable _name_, which must have a String value. For example, if a variable _s_ has the value *"a"*, then [[&lt;_s_&gt;]] denotes the field [[&lt;_a_&gt;]].
+    As an extension to the Record Specification Type, the notation "[[&lt;_name_&gt;]]" denotes a field whose name is given by the variable _name_, which must have a String value. For example, if a variable _s_ has the value *"a"*, then [[&lt;_s_&gt;]] denotes the field [[a]].
   </p>
 
   <p>
-    For ECMAScript objects, this standard may use variable-named internal slots: The notation "[[&lt;_name_&gt;]]" denotes an internal slot whose name is given by the variable name, which must have a String value. For example, if a variable _s_ has the value *"a"*, then [[&lt;_s_&gt;]] denotes the [[&lt;_a_&gt;]] internal slot.
+    For ECMAScript objects, this standard may use variable-named internal slots: The notation "[[&lt;_name_&gt;]]" denotes an internal slot whose name is given by the variable name, which must have a String value. For example, if a variable _s_ has the value *"a"*, then [[&lt;_s_&gt;]] denotes the [[a]] internal slot.
   </p>
 
   <p>
@@ -32,7 +32,7 @@
     <h1>Well-Known Intrinsic Objects</h1>
 
     <p>
-      The following table extends the Well-Known Intrinsic Objects table defined in ES2017, <emu-xref href="#sec-well-known-intrinsic-objects"></emu-xref>.
+      The following table extends the Well-Known Intrinsic Objects table defined in ES2018, <emu-xref href="#sec-well-known-intrinsic-objects"></emu-xref>.
     </p>
 
     <emu-table id="table-402-well-known-intrinsic-objects">
@@ -46,9 +46,9 @@
           </tr>
         </thead>
         <tr>
-          <td>%Date_now%</td>
+          <td><dfn>%Date_now%</dfn></td>
           <td>`Date.now`</td>
-          <td>The initial value of the `now` data property of the intrinsic %Date% (ES2017, <emu-xref href="#sec-date.now"></emu-xref>)</td>
+          <td>The initial value of the `now` data property of the intrinsic %Date% (ES2018, <emu-xref href="#sec-date.now"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%Intl%</td>
@@ -86,19 +86,19 @@
           <td>The initial value of the `prototype` data property of the intrinsic %DateTimeFormat% (<emu-xref href="#sec-intl.datetimeformat.prototype"></emu-xref>).</td>
         </tr>
         <tr>
-          <td>%StringProto_includes%</td>
+          <td><dfn>%StringProto_includes%</dfn></td>
           <td>`String.prototype.includes`</td>
-          <td>The initial value of the `includes` data property of the intrinsic %StringPrototype% (ES2017, <emu-xref href="#sec-string.prototype.includes"></emu-xref>)</td>
+          <td>The initial value of the `includes` data property of the intrinsic %StringPrototype% (ES2018, <emu-xref href="#sec-string.prototype.includes"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%StringProto_indexOf%</td>
+          <td><dfn>%StringProto_indexOf%</dfn></td>
           <td>`String.prototype.indexOf`</td>
-          <td>The initial value of the `indexOf` data property of the intrinsic %StringPrototype% (ES2017, <emu-xref href="#sec-string.prototype.indexof"></emu-xref>)</td>
+          <td>The initial value of the `indexOf` data property of the intrinsic %StringPrototype% (ES2018, <emu-xref href="#sec-string.prototype.indexof"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%ArrayProto_indexOf%</td>
+          <td><dfn>%ArrayProto_indexOf%</dfn></td>
           <td>`Array.prototype.indexOf`</td>
-          <td>The initial value of the `indexOf` data property of the intrinsic %ArrayPrototype% (ES2017, <emu-xref href="#sec-array.prototype.indexof"></emu-xref>)</td>
+          <td>The initial value of the `indexOf` data property of the intrinsic %ArrayPrototype% (ES2018, <emu-xref href="#sec-array.prototype.indexof"></emu-xref>)</td>
         </tr>
       </table>
     </emu-table>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -263,14 +263,13 @@
       <emu-alg>
         1. If _x_ is not a finite Number, throw a *RangeError* exception.
         1. Let _locale_ be _dateTimeFormat_.[[Locale]].
-        1. Let _nfLocale_ be CreateArrayFromList(&laquo; _locale_ &raquo;).
-        1. Let _nfOptions_ be ObjectCreate(%ObjectPrototype%).
+        1. Let _nfOptions_ be ObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, `"useGrouping"`, *false*).
-        1. Let _nf_ be ? Construct(%NumberFormat%, &laquo; _nfLocale_, _nfOptions_ &raquo;).
-        1. Let _nf2Options_ be ObjectCreate(%ObjectPrototype%).
+        1. Let _nf_ be ? Construct(%NumberFormat%, &laquo; _locale_, _nfOptions_ &raquo;).
+        1. Let _nf2Options_ be ObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, `"minimumIntegerDigits"`, 2).
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, `"useGrouping"`, *false*).
-        1. Let _nf2_ be ? Construct(%NumberFormat%, &laquo; _nfLocale_, _nf2Options_ &raquo;).
+        1. Let _nf2_ be ? Construct(%NumberFormat%, &laquo; _locale_, _nf2Options_ &raquo;).
         1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _pattern_ be _dateTimeFormat_.[[Pattern]].
         1. Let _result_ be a new empty List.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -195,7 +195,7 @@
         1. Let _k_ be 0.
         1. Assert: _formats_ is an Array object.
         1. Let _len_ be Get(_formats_, *"length"*).
-        1. Repeat while _k_ < _len_:
+        1. Repeat, while _k_ < _len_
           1. Let _format_ be Get(_formats_, ToString(_k_)).
           1. Let _score_ be 0.
           1. For each _property_ shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>:
@@ -376,7 +376,7 @@
       </p>
 
       <emu-alg>
-        1. Apply calendrical calculations on _date_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules. If the _calendar_ is "gregory", then the calculations must match the algorithms specified in ES2017, <emu-xref href="#sec-overview-of-date-objects-and-definitions-of-abstract-operations"></emu-xref>.
+        1. Apply calendrical calculations on _date_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules. If the _calendar_ is "gregory", then the calculations must match the algorithms specified in ES2018, <emu-xref href="#sec-overview-of-date-objects-and-definitions-of-abstract-operations"></emu-xref>.
         1. Return a Record with fields [[weekday]], [[era]], [[year]], [[month]], [[day]], [[hour]], [[minute]], [[second]], and [[inDST]], each with the corresponding calculated value.
       </emu-alg>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -114,7 +114,7 @@
           1. Let _p_ be _bestFormat_.[[<_prop_>]].
           1. If _p_ not *undefined*, then
             1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
-        1. If _dateTimeFormat_ has an internal slot [[Hour]], then
+        1. If _dateTimeFormat_.[[Hour]] is not *undefined*, then
           1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
           1. Let _hr12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
           1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
@@ -269,13 +269,13 @@
         1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _pattern_ be _dateTimeFormat_.[[Pattern]].
         1. Let _result_ be a new empty List.
-        1. Let _beginIndex_ be Call(%StringProto_indexOf%, _pattern_, "{", *0*).
+        1. Let _beginIndex_ be Call(%StringProto_indexOf%, _pattern_, &laquo; "{", *0* &raquo;).
         1. Let _endIndex_ be 0.
         1. Let _nextIndex_ be 0.
         1. Let _length_ be the number of code units in _pattern_.
         1. Repeat while _beginIndex_ is an integer index into _pattern_:
-          1. Set _endIndex_ to Call(%StringProto_indexOf%, _pattern_, "}", _beginIndex_)
-          1. If _endIndex_ = -1, throw new Error exception.
+          1. Set _endIndex_ to Call(%StringProto_indexOf%, _pattern_, &laquo; "}", _beginIndex_ &raquo;).
+          1. Assert: _endIndex_ is greater than _beginIndex_.
           1. If _beginIndex_ is greater than _nextIndex_, then:
             1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
             1. Add new part record { [[Type]]: *"literal"*, [[Value]]: _literal_ } as a new element of the list _result_.
@@ -307,7 +307,7 @@
             1. Let _literal_ be the substring of _pattern_ from position _beginIndex_, inclusive, to position _endIndex_, inclusive.
             1. Add new part record { [[Type]]: *"literal"*, [[Value]]: _literal_ } as a new element of the list _result_.
           1. Set _nextIndex_ to _endIndex_ + 1.
-          1. Set _beginIndex_ to Call(%StringProto_indexOf%, _pattern_, "}", _nextIndex_)
+          1. Set _beginIndex_ to Call(%StringProto_indexOf%, _pattern_, &laquo; "}", _nextIndex_ &raquo;).
         1. If _nextIndex_ is less than _length_, then:
           1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, exclusive, to position _length_, exclusive.
           1. Add new part record { [[Type]]: *"literal"*, [[Value]]: _literal_ } as a new element of the list _result_.
@@ -354,9 +354,9 @@
         1. Let _n_ be 0.
         1. For each _part_ in _parts_, do:
           1. Let _O_ be ObjectCreate(%ObjectPrototype%).
-          1. Perform ? CreateDataPropertyOrThrow(_O_, "type", _part_.[[Type]]).
-          1. Perform ? CreateDataPropertyOrThrow(_O_, "value", _part_.[[Value]]).
-          1. Perform ? CreateDataProperty(_result_, ? ToString(_n_), _O_).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, "type", _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, "value", _part_.[[Value]]).
+          1. Perform ! CreateDataProperty(_result_, ! ToString(_n_), _O_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -102,8 +102,8 @@
           1. Let _prop_ be the name given in the Property column of the row.
           1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
           1. Set _opt_.[[<_prop_>]] to _value_.
-        1. Let _dataLocaleData_ be Get(_localeData_, _dataLocale_).
-        1. Let _formats_ be Get(_dataLocaleData_, *"formats"*).
+        1. Let _dataLocaleData_ be _localeData_.[[<_dataLocale_>]].
+        1. Let _formats_ be _dataLocaleData_.[[formats]].
         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
         1. If _matcher_ is *"basic"*, then
           1. Let _bestFormat_ be BasicFormatMatcher(_opt_, _formats_).
@@ -111,13 +111,13 @@
           1. Let _bestFormat_ be BestFitFormatMatcher(_opt_, _formats_).
         1. For each row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, do
           1. Let _prop_ be the name given in the Property column of the row.
-          1. Let _p_ be Get(_bestFormat_, _prop_).
+          1. Let _p_ be _bestFormat_.[[<_prop_>]].
           1. If _p_ not *undefined*, then
             1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
         1. If _dateTimeFormat_ has an internal slot [[Hour]], then
           1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
           1. Let _hr12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
-          1. Let _hcDefault_ be Get(_dataLocaleData_, *"hourCycle"*).
+          1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
           1. If _hr12_ is not *undefined*, then
             1. If _hr12_ is *true*, then
               1. If _hcDefault_ is *"h11"* or *"h23"*, then
@@ -133,9 +133,9 @@
             1. Set _hc_ to _hcDefault_
           1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
           1. If _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then
-            1. Let _pattern_ be Get(_bestFormat_, *"pattern12"*).
+            1. Let _pattern_ be _bestFormat_.[[pattern12]].
           1. Else,
-            1. Let _pattern_ be Get(_bestFormat_, *"pattern"*).
+            1. Let _pattern_ be _bestFormat_.[[pattern]].
         1. Else,
           1. Let _pattern_ be Get(_bestFormat_, *"pattern"*).
         1. Set _dateTimeFormat_.[[Pattern]] to _pattern_.
@@ -192,15 +192,12 @@
         1. Let _shortMorePenalty_ be 3.
         1. Let _bestScore_ be -*Infinity*.
         1. Let _bestFormat_ be *undefined*.
-        1. Let _k_ be 0.
-        1. Assert: _formats_ is an Array object.
-        1. Let _len_ be Get(_formats_, *"length"*).
-        1. Repeat, while _k_ < _len_
-          1. Let _format_ be Get(_formats_, ToString(_k_)).
+        1. Assert: Type(_formats_) is List.
+        1. Repeat for each element _format_ of _formats_ in List order,
           1. Let _score_ be 0.
           1. For each _property_ shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>:
             1. Let _optionsProp_ be _options_.[[<_property_>]].
-            1. Let _formatProp_ be Get(_format_, _property_).
+            1. Let _formatProp_ be _format_.[[<_property_>]].
             1. If _optionsProp_ is *undefined* and _formatProp_ is not *undefined*, then decrease _score_ by _additionPenalty_.
             1. Else if _optionsProp_ is not *undefined* and _formatProp_ is *undefined*, then decrease _score_ by _removalPenalty_.
             1. Else if _optionsProp_ ≠ _formatProp_,
@@ -215,7 +212,6 @@
           1. If _score_ > _bestScore_,
             1. Let _bestScore_ be _score_.
             1. Let _bestFormat_ be _format_.
-          1. Increase _k_ by 1.
         1. Return _bestFormat_.
       </emu-alg>
     </emu-clause>
@@ -496,13 +492,13 @@
 
       <ul>
         <li>
-          The array that is the value of the "nu" property of any locale property of [[LocaleData]] must not include the values "native", "traditio", or "finance".
+          The list that is the value of the "nu" field of any locale field of [[LocaleData]] must not include the values "native", "traditio", or "finance".
         </li>
         <li>
-          [[LocaleData]][locale] must have hourCycle property with String values for all locale values.
+          [[LocaleData]][locale] must have hourCycle field with String values for all locale values.
         </li>
         <li>
-          [[LocaleData]][locale] must have a formats property for all locale values. The value of this property must be an array of objects, each of which has a subset of the properties shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each property must have one of the values specified for the property in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple objects in an array may use the same subset of the properties as long as they have different values for the properties. The following subsets must be available for each locale:
+          [[LocaleData]][locale] must have a formats field for all locale values. The value of this field must be a list of records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
           <ul>
             <li>weekday, year, month, day, hour, minute, second</li>
             <li>weekday, year, month, day</li>
@@ -512,12 +508,12 @@
             <li>hour, minute, second</li>
             <li>hour, minute</li>
           </ul>
-          Each of the objects must also have a pattern property, whose value is a String value that contains for each of the date and time format component properties of the object a substring starting with "{", followed by the name of the property, followed by "}". If the object has an hour property, it must also have a pattern12 property, whose value is a String value that, in addition to the substrings of the pattern property, contains a substring "{ampm}".
+          Each of the records must also have a pattern field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with "{", followed by the name of the field, followed by "}". If the record has an hour field, it must also have a pattern12 field, whose value is a String value that, in addition to the substrings of the pattern field, contains a substring "{ampm}".
         </li>
       </ul>
 
       <p>
-        EXAMPLE     An implementation might include the following object as part of its English locale data: {hour: "numeric", minute: "2-digit", second: "2-digit", pattern: "{hour}:{minute}:{second}", pattern12: "{hour}:{minute}:{second} {ampm}"}.
+        EXAMPLE     An implementation might include the following record as part of its English locale data: {[[hour]]: "numeric", [[minute]]: "2-digit", [[second]]: "2-digit", [[pattern]]: "{hour}:{minute}:{second}", [[pattern12]]: "{hour}:{minute}:{second} {ampm}"}.
       </p>
 
       <emu-note>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -2,7 +2,7 @@
   <h1>Locale Sensitive Functions of the ECMAScript Language Specification</h1>
 
   <p>
-    The ECMAScript Language Specification, edition 6 or successor, describes several locale sensitive functions. An ECMAScript implementation that implements this Internationalization API Specification shall implement these functions as described here.
+    The ECMAScript Language Specification, edition 9 or successor, describes several locale sensitive functions. An ECMAScript implementation that implements this Internationalization API Specification shall implement these functions as described here.
   </p>
 
   <emu-note>
@@ -16,7 +16,7 @@
       <h1>String.prototype.localeCompare ( _that_ [ , _locales_ [ , _options_ ] ] )</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2017, <emu-xref href="#sec-string.prototype.localecompare"></emu-xref>.
+        This definition supersedes the definition provided in ES2018, <emu-xref href="#sec-string.prototype.localecompare"></emu-xref>.
       </p>
 
       <p>
@@ -49,11 +49,11 @@
       <h1>String.prototype.toLocaleLowerCase ( [ _locales_ ] )</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2017, <emu-xref href="#sec-string.prototype.tolocalelowercase"></emu-xref>.
+        This definition supersedes the definition provided in ES2018, <emu-xref href="#sec-string.prototype.tolocalelowercase"></emu-xref>.
       </p>
 
       <p>
-        This function interprets a string value as a sequence of code points, as described in ES2017, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. The following steps are taken:
+        This function interprets a string value as a sequence of code points, as described in ES2018, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. The following steps are taken:
       </p>
 
       <emu-alg>
@@ -69,10 +69,10 @@
         1. Let _availableLocales_ be a List with the language tags of the languages for which the Unicode character database contains language sensitive case mappings.
         1. Let _locale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
         1. If _locale_ is *undefined*, let _locale_ be *"und"*.
-        1. Let _cpList_ be a List containing in order the code points of _S_ as defined in ES2017, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, starting at the first element of _S_.
+        1. Let _cpList_ be a List containing in order the code points of _S_ as defined in ES2018, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, starting at the first element of _S_.
         1. For each code point _c_ in _cpList_, if the Unicode Character Database provides a lower case equivalent of _c_ that is either language insensitive or for the language _locale_, replace _c_ in _cpList_ with that/those equivalent code point(s).
         1. Let _cuList_ be a new empty List.
-        1. For each code point _c_ in _cpList_, in order, append to cuList the elements of the UTF-16 Encoding (defined in ES2017, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) of _c_.
+        1. For each code point _c_ in _cpList_, in order, append to cuList the elements of the UTF-16 Encoding (defined in ES2018, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) of _c_.
         1. Let _L_ be a String whose elements are, in order, the elements of _cuList_.
         1. Return _L_.
       </emu-alg>
@@ -82,7 +82,7 @@
       </p>
 
       <emu-note>
-        As of Unicode 5.1, the _availableLocales_ list contains the elements *"az"*, *"lt"*, and *"tr"*.
+        As of Unicode 10.0, the _availableLocales_ list contains the elements *"az"*, *"lt"*, and *"tr"*.
       </emu-note>
 
       <emu-note>
@@ -99,11 +99,11 @@
       <h1>String.prototype.toLocaleUpperCase ( [ _locales_ ] )</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2017, <emu-xref href="#sec-string.prototype.tolocaleuppercase"></emu-xref>.
+        This definition supersedes the definition provided in ES2018, <emu-xref href="#sec-string.prototype.tolocaleuppercase"></emu-xref>.
       </p>
 
       <p>
-        This function interprets a string value as a sequence of code points, as described in ES2017, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. This function behaves in exactly the same way as `String.prototype.toLocaleLowerCase`, except that characters are mapped to their _uppercase_ equivalents as specified in the Unicode character database.
+        This function interprets a string value as a sequence of code points, as described in ES2018, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. This function behaves in exactly the same way as `String.prototype.toLocaleLowerCase`, except that characters are mapped to their _uppercase_ equivalents as specified in the Unicode character database.
       </p>
 
       <emu-note>
@@ -118,14 +118,14 @@
     <h1>Properties of the Number Prototype Object</h1>
 
     <p>
-      The following definition(s) refer to the abstract operation thisNumberValue as defined in ES2017, <emu-xref href="#sec-properties-of-the-number-prototype-object"></emu-xref>.
+      The following definition(s) refer to the abstract operation thisNumberValue as defined in ES2018, <emu-xref href="#sec-properties-of-the-number-prototype-object"></emu-xref>.
     </p>
 
     <emu-clause id="sup-number.prototype.tolocalestring">
       <h1>Number.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2017, <emu-xref href="#sec-number.prototype.tolocalestring"></emu-xref>.
+        This definition supersedes the definition provided in ES2018, <emu-xref href="#sec-number.prototype.tolocalestring"></emu-xref>.
       </p>
 
       <p>
@@ -145,14 +145,14 @@
     <h1>Properties of the Date Prototype Object</h1>
 
     <p>
-      The following definition(s) refer to the abstract operation thisTimeValue as defined in ES2017, <emu-xref href="#sec-properties-of-the-date-prototype-object"></emu-xref>.
+      The following definition(s) refer to the abstract operation thisTimeValue as defined in ES2018, <emu-xref href="#sec-properties-of-the-date-prototype-object"></emu-xref>.
     </p>
 
     <emu-clause id="sup-date.prototype.tolocalestring">
       <h1>Date.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2017, <emu-xref href="#sec-date.prototype.tolocalestring"></emu-xref>.
+        This definition supersedes the definition provided in ES2018, <emu-xref href="#sec-date.prototype.tolocalestring"></emu-xref>.
       </p>
 
       <p>
@@ -173,7 +173,7 @@
       <h1>Date.prototype.toLocaleDateString ( [ _locales_ [ , _options_ ] ] )</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2017, <emu-xref href="#sec-date.prototype.tolocaledatestring"></emu-xref>.
+        This definition supersedes the definition provided in ES2018, <emu-xref href="#sec-date.prototype.tolocaledatestring"></emu-xref>.
       </p>
 
       <p>
@@ -194,7 +194,7 @@
       <h1>Date.prototype.toLocaleTimeString ( [ _locales_ [ , _options_ ] ] )</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2017, <emu-xref href="#sec-date.prototype.tolocaletimestring"></emu-xref>.
+        This definition supersedes the definition provided in ES2018, <emu-xref href="#sec-date.prototype.tolocaletimestring"></emu-xref>.
       </p>
 
       <p>
@@ -219,7 +219,7 @@
       <h1>Array.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2017, <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref>.
+        This definition supersedes the definition provided in ES2018, <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref>.
       </p>
 
       <p>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -60,9 +60,8 @@
         1. Let _O_ be RequireObjectCoercible(*this* value).
         1. Let _S_ be ? ToString(_O_).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Let _len_ be the number of elements in _requestedLocales_.
-        1. If _len_ > 0, then
-          1. Let _requestedLocale_ be the first element of _requestedLocales_.
+        1. If _requestedLocales_ is not an empty List, then
+          1. Let _requestedLocale_ be _requestedLocales_[0].
         1. Else,
           1. Let _requestedLocale_ be DefaultLocale().
         1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with all Unicode locale extension sequences (<emu-xref href="#sec-unicode-locale-extension-sequences"></emu-xref>) removed.

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -97,7 +97,7 @@
 
       <emu-alg>
         1. Let _normalized_ be the result of mapping _currency_ to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
-        1. If the string length of _normalized_ is not 3, return *false*.
+        1. If the number of elements in _normalized_ is not 3, return *false*.
         1. If _normalized_ contains any character that is not in the range "A" to "Z" (U+0041 to U+005A), return *false*.
         1. Return *true*.
       </emu-alg>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -123,45 +123,38 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-unicodeextensionsubtags" aoid="UnicodeExtensionSubtags">
-      <h1>UnicodeExtensionSubtags ( _extension_ )</h1>
+    <emu-clause id="sec-unicodeextensionvalue" aoid="UnicodeExtensionValue">
+      <h1>UnicodeExtensionValue (_extension_, _key_)</h1>
 
-      <p>The abstract operation UnicodeExtensionSubtags splits _extension_, which must be a Unicode locale extension sequence, into its subtags. The following steps are taken:</p>
+      <p>The abstract operation UnicodeExtensionValue is called with _extension_, which must be a Unicode locale extension sequence, and String _key_. This operation returns the type subtags for _key_ by performing the following steps:</p>
 
       <emu-alg>
+        1. Assert: The number of elements in _key_ is 2.
         1. Let _size_ be the number of elements in _extension_.
-        1. If _size_ = 0, then
-          1. Return « ».
-        1. Let _extensionSubtags_ be « ».
-        1. Let _attribute_ be *true*.
-        1. Let _q_ be 3.
-        1. Let _p_ be _q_.
-        1. Let _t_ be _q_.
-        1. Repeat, while _q_ &lt; _size_
-          1. Let _c_ be the code unit value of the element at index _q_ in the String _extension_.
-          1. If _c_ is 0x002D (HYPHEN-MINUS), then
-            1. If _q_ - _p_ = 2, then
-              1. If _p_ - _t_ > 1, then
-                1. Let _type_ be a String value equal to the substring of _extension_ consisting of the code units at indices _t_ (inclusive) through _p_ - 1 (exclusive).
-                1. Append _type_ as the last element of _extensionSubtags_.
-              1. Let _key_ be a String value equal to the substring of _extension_ consisting of the code units at indices _p_ (inclusive) through _q_ (exclusive).
-              1. Append _key_ as the last element of _extensionSubtags_.
-              1. Let _t_ be _q_ + 1.
-              1. Let _attribute_ be *false*.
-            1. Else if _attribute_ is *true*, then
-              1. Let _attr_ be a String value equal to the substring of _extension_ consisting of the code units at indices _p_ (inclusive) through _q_ (exclusive).
-              1. Append _attr_ as the last element of _extensionSubtags_.
-              1. Let _t_ be _q_ + 1.
-            1. Let _p_ be _q_ + 1.
-          1. Let _q_ be _q_ + 1.
-        1. If _size_ - _p_ = 2, then
-          1. If _p_ - _t_ > 1, then
-            1. Let _type_ be a String value equal to the substring of _extension_ consisting of the code units at indices _t_ (inclusive) through _p_ - 1 (exclusive).
-            1. Append _type_ as the last element of _extensionSubtags_.
-          1. Let _t_ be _p_.
-        1. Let _tail_ be a String value equal to the substring of _extension_ consisting of the code units at indices _t_ (inclusive) through _size_ (exclusive).
-        1. Append _tail_ as the last element of _extensionSubtags_.
-        1. Return _extensionSubtags_.
+        1. Let _searchValue_ be the concatenation of *"-"*, _key_, and *"-"*.
+        1. Let _pos_ be Call(%StringProto_indexOf%, _extension_, « _searchValue_ »).
+        1. If _pos_ ≠ -1, then
+          1. Let _start_ be _pos_ + 4.
+          1. Let _end_ be _start_.
+          1. Let _k_ be _start_.
+          1. Let _done_ be *false*.
+          1. Repeat, while _done_ is *false*
+            1. Let _e_ be Call(%StringProto_indexOf%, _extension_, « *"-"*, _k_ »).
+            1. If _e_ = -1, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
+            1. If _len_ = 2, then
+              1. Let _done_ be *true*.
+            1. Else if _e_ = -1, then
+              1. Let _end_ be _size_.
+              1. Let _done_ be *true*.
+            1. Else,
+              1. Let _end_ be _e_.
+              1. Let _k_ be _e_ + 1.
+          1. Return the String value equal to the substring of _extension_ consisting of the code units at indices _start_ (inclusive) through _end_ (exclusive).
+        1. Let _searchValue_ be the concatenation of *"-"* and _key_.
+        1. Let _pos_ be Call(%StringProto_indexOf%, _extension_, « _searchValue_ »).
+        1. If _pos_ ≠ -1 and _pos_ + 3 = _size_, then
+          1. Return the empty String.
+        1. Return *undefined*.
       </emu-alg>
     </emu-clause>
 
@@ -169,7 +162,7 @@
       <h1>ResolveLocale ( _availableLocales_, _requestedLocales_, _options_, _relevantExtensionKeys_, _localeData_ )</h1>
 
       <p>
-        The ResolveLocale abstract operation compares a BCP 47 language priority list _requestedLocales_ against the locales in _availableLocales_ and determines the best available language to meet the request. _availableLocales_, _requestedLocales_, and _relevantExtensionKeys_ must be provided as List values, _options_ as a Record.
+        The ResolveLocale abstract operation compares a BCP 47 language priority list _requestedLocales_ against the locales in _availableLocales_ and determines the best available language to meet the request. _availableLocales_, _requestedLocales_, and _relevantExtensionKeys_ must be provided as List values, _options_ as a Record, and _localeData_ as an object.
       </p>
 
       <p>
@@ -183,32 +176,31 @@
         1. Else,
           1. Let _r_ be BestFitMatcher(_availableLocales_, _requestedLocales_).
         1. Let _foundLocale_ be _r_.[[locale]].
-        1. If _r_ has an [[extension]] field, then
-          1. Let _extension_ be _r_.[[extension]].
-          1. Let _extensionSubtags_ be CreateArrayFromList(UnicodeExtensionSubtags(_extension_)).
-          1. Let _extensionSubtagsLength_ be Get(_extensionSubtags_, *"length"*).
         1. Let _result_ be a new Record.
         1. Set _result_.[[dataLocale]] to _foundLocale_.
         1. Let _supportedExtension_ be *"-u"*.
         1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
-          1. Let _foundLocaleData_ be ? Get(_localeData_, _foundLocale_).
-          1. Let _keyLocaleData_ be ? ToObject(Get(_foundLocaleData_, _key_)).
-          1. Let _value_ be ? ToString(Get(_keyLocaleData_, *"0"*)).
+          1. Let _foundLocaleData_ be ! Get(_localeData_, _foundLocale_).
+          1. Assert: Type(_foundLocaleData_) is Object.
+          1. Let _keyLocaleData_ be ! Get(_foundLocaleData_, _key_).
+          1. Assert: _keyLocaleData_ is an Array object.
+          1. Let _value_ be ! Get(_keyLocaleData_, *"0"*).
+          1. Assert: Type(_value_) is either String or Null.
           1. Let _supportedExtensionAddition_ be *""*.
-          1. If _extensionSubtags_ is not *undefined*, then
-            1. Let _keyPos_ be Call(%ArrayProto_indexOf%, _extensionSubtags_, « _key_ ») .
-            1. If _keyPos_ ≠ -1, then
-              1. If _keyPos_ + 1 < _extensionSubtagsLength_ and the `length` property of the result of Get(_extensionSubtags_, ToString(_keyPos_ +1)) is greater than 2, then
-                1. Let _requestedValue_ be Get(_extensionSubtags_, ToString(_keyPos_ +1)).
-                1. If the result of Call(%StringProto_includes%, _keyLocaleData_, « _requestedValue_ ») is *true*, then
+          1. If _r_ has an [[extension]] field, then
+            1. Let _requestedValue_ be UnicodeExtensionValue(_r_.[[extension]], _key_).
+            1. If _requestedValue_ is not *undefined*, then
+              1. If _requestedValue_ is not the empty String, then
+                1. If the result of Call(%ArrayProto_includes%, _keyLocaleData_, « _requestedValue_ ») is *true*, then
                   1. Let _value_ be _requestedValue_.
                   1. Let _supportedExtensionAddition_ be the concatenation of *"-"*, _key_, *"-"*, and _value_.
-              1. Else if the result of Call(%StringProto_includes%, _keyLocaleData_, « *"true"* ») is *true*, then
+              1. Else if the result of Call(%ArrayProto_includes%, _keyLocaleData_, « *"true"* ») is *true*, then
                 1. Let _value_ be *"true"*.
           1. If _options_ has a field [[<_key_>]], then
-            1. Let _optionsValue_ be ? ToString(_options_.[[<_key_>]]).
-            1. If the result of Call(%StringProto_includes%, _keyLocaleData_, « _optionsValue_ ») is *true*, then
-              1. If _optionsValue_ is not equal to _value_, then
+            1. Let _optionsValue_ be _options_.[[<_key_>]].
+            1. Assert: Type(_optionsValue_) is String.
+            1. If the result of Call(%ArrayProto_includes%, _keyLocaleData_, « _optionsValue_ ») is *true*, then
+              1. If SameValue(_optionsValue_, _value_) is *false*, then
                 1. Let _value_ be _optionsValue_.
                 1. Let _supportedExtensionAddition_ be *""*.
           1. Set _result_.[[<_key_>]] to _value_.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -95,24 +95,18 @@
       </p>
 
       <emu-alg>
-        1. Let _k_ be 0.
-        1. Let _rLocales_ be CreateArrayFromList(_requestedLocales_).
-        1. Let _len_ be ! ToLength(! Get(_rLocales_, *"length"*)).
-        1. Let _availableLocale_ be *undefined*.
-        1. Repeat while _k_ < _len_ and _availableLocale_ is *undefined*:
-          1. Let _locale_ be ! Get(_rLocales_, ! ToString(_k_)) .
+        1. Let _result_ be a new Record.
+        1. Repeat for each element _locale_ of _availableLocale_ in List order,
           1. Let _noExtensionsLocale_ be the String value that is _locale_ with all Unicode locale extension sequences removed.
           1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
-          1. Increase _k_ by 1.
-        1. Let _result_ be a new Record.
-        1. If _availableLocale_ is not *undefined*, then
-          1. Set _result_.[[locale]] to _availableLocale_.
-          1. If _locale_ and _noExtensionsLocale_ are not the same String value, then
-            1. Let _extension_ be the String value consisting of the first substring of _locale_ that is a Unicode locale extension sequence.
-            1. Set _result_.[[extension]] to _extension_.
-        1. Else,
-          1. Let _defLocale_ be DefaultLocale().
-          1. Set _result_.[[locale]] to _defLocale_.
+          1. If _availableLocale_ is not *undefined*, then
+            1. Set _result_.[[locale]] to _availableLocale_.
+            1. If _locale_ and _noExtensionsLocale_ are not the same String value, then
+              1. Let _extension_ be the String value consisting of the first substring of _locale_ that is a Unicode locale extension sequence.
+              1. Set _result_.[[extension]] to _extension_.
+            1. Return _result_.
+        1. Let _defLocale_ be DefaultLocale().
+        1. Set _result_.[[locale]] to _defLocale_.
         1. Return _result_.
       </emu-alg>
 
@@ -196,11 +190,7 @@
         1. Let _result_ be a new Record.
         1. Set _result_.[[dataLocale]] to _foundLocale_.
         1. Let _supportedExtension_ be *"-u"*.
-        1. Let _k_ be 0.
-        1. Let _rExtensionKeys_ be CreateArrayFromList(_relevantExtensionKeys_).
-        1. Let _len_ be ! ToLength(! Get(_rExtensionKeys_, *"length"*)).
-        1. Repeat while _k_ < _len_
-          1. Let _key_ be ! Get(_rExtensionKeys_, ! ToString(_k_)).
+        1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
           1. Let _foundLocaleData_ be ? Get(_localeData_, _foundLocale_).
           1. Let _keyLocaleData_ be ? ToObject(Get(_foundLocaleData_, _key_)).
           1. Let _value_ be ? ToString(Get(_keyLocaleData_, *"0"*)).
@@ -223,7 +213,6 @@
                 1. Let _supportedExtensionAddition_ be *""*.
           1. Set _result_.[[<_key_>]] to _value_.
           1. Append _supportedExtensionAddition_ to _supportedExtension_.
-          1. Increase _k_ by 1.
         1. If the number of elements in _supportedExtension_ is greater than 2, then
           1. Let _privateIndex_ be Call(%StringProto_indexOf%, _foundLocale_, « `"-x-"` »).
           1. If _privateIndex_ = -1, then
@@ -251,16 +240,11 @@
       </p>
 
       <emu-alg>
-        1. Let _rLocales_ be CreateArrayFromList(_requestedLocales_).
-        1. Let _len_ be ! ToLength(! Get(_rLocales_, *"length"*)).
         1. Let _subset_ be a new empty List.
-        1. Let _k_ be 0.
-        1. Repeat while _k_ < _len_
-          1. Let _locale_ be ! Get(_rLocales_, ! ToString(_k_)).
+        1. Repeat for each element _locale_ of _requestedLocales_ in List order,
           1. Let _noExtensionsLocale_ be the String value that is _locale_ with all Unicode locale extension sequences removed.
           1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
           1. If _availableLocale_ is not *undefined*, append _locale_ to the end of _subset_.
-          1. Increment _k_ by 1.
         1. Return _subset_.
       </emu-alg>
     </emu-clause>
@@ -282,6 +266,7 @@
 
       <emu-alg>
         1. If _options_ is not *undefined*, then
+          1. Let _options_ be ? ToObject(_options_).
           1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Else, let _matcher_ be *"best fit"*.
         1. If _matcher_ is *"best fit"*,
@@ -305,8 +290,7 @@
       </p>
 
       <emu-alg>
-        1. Let _opts_ be ? ToObject(_options_).
-        1. Let _value_ be ? Get(_opts_, _property_).
+        1. Let _value_ be ? Get(_options_, _property_).
         1. If _value_ is not *undefined*, then
           1. Assert: _type_ is *"boolean"* or *"string"*.
           1. If _type_ is *"boolean"*, then
@@ -344,8 +328,7 @@
       </p>
 
       <emu-alg>
-        1. Let _opts_ be ? ToObject(_options_).
-        1. Let _value_ be ? Get(_opts_, _property_).
+        1. Let _value_ be ? Get(_options_, _property_).
         1. Return ? DefaultNumberOption(_value_, _minimum_, _maximum_, _fallback_).
       </emu-alg>
     </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -15,11 +15,11 @@
     <ul>
       <li>[[AvailableLocales]] is a List that contains structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizelanguagetag"></emu-xref>) BCP 47 language tags identifying the locales for which the implementation provides the functionality of the constructed objects. Language tags on the list must not have a Unicode locale extension sequence. The list must include the value returned by the DefaultLocale abstract operation (<emu-xref href="#sec-defaultlocale"></emu-xref>), and must not include duplicates. Implementations must include in [[AvailableLocales]] locales that can serve as fallbacks in the algorithm used to resolve locales (see <emu-xref href="#sec-resolvelocale"></emu-xref>). For example, implementations that provide a "de-DE" locale must include a "de" locale that can serve as a fallback for requests such as "de-AT" and "de-CH". For locales that in current usage would include a script subtag (such as Chinese locales), old-style language tags without script subtags must be included such that, for example, requests for "zh-TW" and "zh-HK" lead to output in traditional Chinese rather than the default simplified Chinese. The ordering of the locales within [[AvailableLocales]] is irrelevant.</li>
       <li>[[RelevantExtensionKeys]] is a List of keys of the language tag extensions defined in Unicode Technical Standard 35 that are relevant for the functionality of the constructed objects.</li>
-      <li>[[SortLocaleData]] and [[SearchLocaleData]] (for Intl.Collator) and [[LocaleData]] (for Intl.NumberFormat and Intl.DateTimeFormat) are objects that have properties for each locale contained in [[AvailableLocales]]. The value of each of these properties must be an object that has properties for each key contained in [[RelevantExtensionKeys]]. The value of each of these properties must be a non-empty array of those values defined in Unicode Technical Standard 35 for the given key that are supported by the implementation for the given locale, with the first element providing the default value.</li>
+      <li>[[SortLocaleData]] and [[SearchLocaleData]] (for Intl.Collator) and [[LocaleData]] (for Intl.NumberFormat and Intl.DateTimeFormat) are records that have fields for each locale contained in [[AvailableLocales]]. The value of each of these fields must be a record that has fields for each key contained in [[RelevantExtensionKeys]]. The value of each of these fields must be a non-empty list of those values defined in Unicode Technical Standard 35 for the given key that are supported by the implementation for the given locale, with the first element providing the default value.</li>
     </ul>
 
     <p>
-      EXAMPLE     An implementation of DateTimeFormat might include the language tag "th" in its [[AvailableLocales]] internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>) include the key "ca" in its [[RelevantExtensionKeys]] internal slot. For Thai, the "buddhist" calendar is usually the default, but an implementation might also support the calendars "gregory", "chinese", and "islamicc" for the locale "th". The [[LocaleData]] internal slot would therefore at least include {"th": {ca: ["buddhist", "gregory", "chinese", "islamicc"]}}.
+      EXAMPLE     An implementation of DateTimeFormat might include the language tag "th" in its [[AvailableLocales]] internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>) include the key "ca" in its [[RelevantExtensionKeys]] internal slot. For Thai, the "buddhist" calendar is usually the default, but an implementation might also support the calendars "gregory", "chinese", and "islamicc" for the locale "th". The [[LocaleData]] internal slot would therefore at least include {[[th]]: {[[ca]]: «"buddhist", "gregory", "chinese", "islamicc"»}}.
     </p>
   </emu-clause>
 
@@ -162,7 +162,7 @@
       <h1>ResolveLocale ( _availableLocales_, _requestedLocales_, _options_, _relevantExtensionKeys_, _localeData_ )</h1>
 
       <p>
-        The ResolveLocale abstract operation compares a BCP 47 language priority list _requestedLocales_ against the locales in _availableLocales_ and determines the best available language to meet the request. _availableLocales_, _requestedLocales_, and _relevantExtensionKeys_ must be provided as List values, _options_ as a Record, and _localeData_ as an object.
+        The ResolveLocale abstract operation compares a BCP 47 language priority list _requestedLocales_ against the locales in _availableLocales_ and determines the best available language to meet the request. _availableLocales_, _requestedLocales_, and _relevantExtensionKeys_ must be provided as List values, _options_ and _localeData_ as Records.
       </p>
 
       <p>
@@ -180,26 +180,26 @@
         1. Set _result_.[[dataLocale]] to _foundLocale_.
         1. Let _supportedExtension_ be *"-u"*.
         1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
-          1. Let _foundLocaleData_ be ! Get(_localeData_, _foundLocale_).
-          1. Assert: Type(_foundLocaleData_) is Object.
-          1. Let _keyLocaleData_ be ! Get(_foundLocaleData_, _key_).
-          1. Assert: _keyLocaleData_ is an Array object.
-          1. Let _value_ be ! Get(_keyLocaleData_, *"0"*).
+          1. Let _foundLocaleData_ be _localeData_.[[<_foundLocale_>]].
+          1. Assert: Type(_foundLocaleData_) is Record.
+          1. Let _keyLocaleData_ be _foundLocaleData_.[[<_key_>]].
+          1. Assert: Type(_keyLocaleData_) is List.
+          1. Let _value_ be _keyLocaleData_[0].
           1. Assert: Type(_value_) is either String or Null.
           1. Let _supportedExtensionAddition_ be *""*.
           1. If _r_ has an [[extension]] field, then
             1. Let _requestedValue_ be UnicodeExtensionValue(_r_.[[extension]], _key_).
             1. If _requestedValue_ is not *undefined*, then
               1. If _requestedValue_ is not the empty String, then
-                1. If the result of Call(%ArrayProto_includes%, _keyLocaleData_, « _requestedValue_ ») is *true*, then
+                1. If _keyLocaleData_ contains _requestedValue_, then
                   1. Let _value_ be _requestedValue_.
                   1. Let _supportedExtensionAddition_ be the concatenation of *"-"*, _key_, *"-"*, and _value_.
-              1. Else if the result of Call(%ArrayProto_includes%, _keyLocaleData_, « *"true"* ») is *true*, then
+              1. Else if _keyLocaleData_ contains *"true"*, then
                 1. Let _value_ be *"true"*.
           1. If _options_ has a field [[<_key_>]], then
             1. Let _optionsValue_ be _options_.[[<_key_>]].
             1. Assert: Type(_optionsValue_) is String.
-            1. If the result of Call(%ArrayProto_includes%, _keyLocaleData_, « _optionsValue_ ») is *true*, then
+            1. If _keyLocaleData_ contains _optionsValue_, then
               1. If SameValue(_optionsValue_, _value_) is *false*, then
                 1. Let _value_ be _optionsValue_.
                 1. Let _supportedExtensionAddition_ be *""*.

--- a/spec/normative-references.html
+++ b/spec/normative-references.html
@@ -10,7 +10,7 @@
   </p>
 
   <emu-note>
-    Throughout this document, the phrase "ES2017, _x_" (where x is a sequence of numbers separated by periods) may be used as shorthand for "ECMAScript 2018 Language Specification (ECMA-262 9<sup>th</sup> Edition, sub clause _x_)".
+    Throughout this document, the phrase "ES2018, _x_" (where x is a sequence of numbers separated by periods) may be used as shorthand for "ECMAScript 2018 Language Specification (ECMA-262 9<sup>th</sup> Edition, sub clause _x_)".
   </emu-note>
 
   <ul>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -158,13 +158,13 @@
         1. Else,
           1. Let _pattern_ be _numberFormat_.[[PositivePattern]].
         1. Let _result_ be a new empty List.
-        1. Let _beginIndex_ be Call(%StringProto_indexOf%, _pattern_, *"{"*, *0*).
+        1. Let _beginIndex_ be Call(%StringProto_indexOf%, _pattern_, &laquo; *"{"*, *0* &raquo;).
         1. Let _endIndex_ be 0.
         1. Let _nextIndex_ be 0.
         1. Let _length_ be the number of code units in _pattern_.
         1. Repeat while _beginIndex_ is an integer index into _pattern_:
-          1. Set _endIndex_ to Call(%StringProto_indexOf%, _pattern_, *"}"*, _beginIndex_)
-          1. Assert: _endIndex_ is greater than than _beginIndex_.
+          1. Set _endIndex_ to Call(%StringProto_indexOf%, _pattern_, &laquo; *"}"*, _beginIndex_ &raquo;).
+          1. Assert: _endIndex_ is greater than _beginIndex_.
           1. If _beginIndex_ is greater than _nextIndex_, then:
             1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
             1. Append a new Record { [[Type]]: *"literal"*, [[Value]]: _literal_ } as the last element of _result_.
@@ -183,7 +183,7 @@
                 1. Let _digits_ be a List whose 10 String valued elements are the UTF-16 string representations of the 10 _digits_ specified in the "Digits" column of the matching row in <emu-xref href="#table-numbering-system-digits"></emu-xref>.
                 1. Replace each _digit_ in _n_ with the value of _digits_[_digit_].
               1. Else use an implementation dependent algorithm to map _n_ to the appropriate representation of _n_ in the given numbering system.
-              1. Let _decimalSepIndex_ be Call(%StringProto_indexOf%, _n_, *"."*, 0).
+              1. Let _decimalSepIndex_ be Call(%StringProto_indexOf%, _n_, &laquo; *"."*, 0 &raquo;).
               1. If _decimalSepIndex_ > 0, then:
                 1. Let _integer_ be the substring of _n_ from position 0, inclusive, to position _decimalSepIndex_, exclusive.
                 1. Let _fraction_ be the substring of _n_ from position _decimalSepIndex_, exclusive, to the end of _n_.
@@ -222,13 +222,13 @@
             1. Else if _numberFormat_.[[CurrencyDisplay]] is *"symbol"*, then
               1. Let _cd_ be an ILD string representing _currency_ in short form. If the implementation does not have such a representation of _currency_, use _currency_ itself.
             1. Else if _numberFormat_.[[CurrencyDisplay]] is *"name"*, then
-              1. Let _cd_ be an ILD string representing _currency_ in long form. If the implementation does not have such a representation of _currency_, then use _currency_ itself.
+              1. Let _cd_ be an ILD string representing _currency_ in long form. If the implementation does not have such a representation of _currency_, use _currency_ itself.
             1. Append a new Record { [[Type]]: *"currency"*, [[Value]]: _cd_ } as the last element of _result_.
           1. Else,
             1. Let _literal_ be the substring of _pattern_ from position _beginIndex_, inclusive, to position _endIndex_, inclusive.
             1. Append a new Record { [[Type]]: *"literal"*, [[Value]]: _literal_ } as the last element of _result_.
           1. Set _nextIndex_ to _endIndex_ + 1.
-          1. Set _beginIndex_ to Call(%StringProto_indexOf%, _pattern_, "{", _nextIndex_)
+          1. Set _beginIndex_ to Call(%StringProto_indexOf%, _pattern_, &laquo; "{", _nextIndex_ &raquo;).
         1. If _nextIndex_ is less than _length_, then:
           1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, inclusive, to position _length_, exclusive.
           1. Append a new Record { [[Type]]: *"literal"*, [[Value]]: _literal_ } as the last element of _result_.
@@ -373,9 +373,9 @@
         1. Let _n_ be 0.
         1. For each _part_ in _parts_, do:
           1. Let _O_ be ObjectCreate(%ObjectPrototype%).
-          1. Perform ? CreateDataPropertyOrThrow(_O_, "type", _part_.[[Type]]).
-          1. Perform ? CreateDataPropertyOrThrow(_O_, "value", _part_.[[Value]]).
-          1. Perform ? CreateDataPropertyOrThrow(_result_, ? ToString(_n_), _O_).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, "type", _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, "value", _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(_n_), _O_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -406,7 +406,7 @@
           1. Let _m_ be the concatenation of the String *"0."*, –(_e_+1) occurrences of the character *"0"*, and the string _m_.
         1. If _m_ contains the character *"."*, and _maxPrecision_ > _minPrecision_, then
           1. Let _cut_ be _maxPrecision_ – _minPrecision_.
-          1. Repeat while _cut_ > 0 and the last character of _m_ is *"0"*:
+          1. Repeat, while _cut_ > 0 and the last character of _m_ is *"0"*
             1. Remove the last character from _m_.
             1. Decrease _cut_ by 1.
           1. If the last character of _m_ is *"."*, then
@@ -437,7 +437,7 @@
           1. Let _int_ be the number of characters in _a_.
         1. Else, let _int_ be the number of characters in _m_.
         1. Let _cut_ be _maxFraction_ – _minFraction_.
-        1. Repeat while _cut_ > 0 and the last character of _m_ is *"0"*:
+        1. Repeat, while _cut_ > 0 and the last character of _m_ is *"0"*
           1. Remove the last character from _m_.
           1. Decrease _cut_ by 1.
         1. If the last character of _m_ is ".", then

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -84,12 +84,12 @@
         1. Perform ? SetNumberFormatDigitOptions(_numberFormat_, _options_, _mnfdDefault_, _mxfdDefault_).
         1. Let _g_ be ? GetOption(_options_, *"useGrouping"*, *"boolean"*, *undefined*, *true*).
         1. Set _numberFormat_.[[UseGrouping]] to _g_.
-        1. Let _dataLocaleData_ be Get(_localeData_, _dataLocale_).
-        1. Let _patterns_ be Get(_dataLocaleData_, *"patterns"*).
-        1. Assert: _patterns_ is an object (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
-        1. Let _stylePatterns_ be Get(_patterns_, s).
-        1. Set _numberFormat_.[[PositivePattern]] to Get(_stylePatterns_, *"positivePattern"*).
-        1. Set _numberFormat_.[[NegativePattern]] to Get(_stylePatterns_, *"negativePattern"*).
+        1. Let _dataLocaleData_ be _localeData_.[[<_dataLocale_>]].
+        1. Let _patterns_ be _dataLocaleData_.[[patterns]].
+        1. Assert: _patterns_ is a record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
+        1. Let _stylePatterns_ be _patterns_.[[<_s_>]].
+        1. Set _numberFormat_.[[PositivePattern]] to _stylePatterns_.[[positivePattern]].
+        1. Set _numberFormat_.[[NegativePattern]] to _stylePatterns_.[[negativePattern]].
         1. Set _numberFormat_.[[BoundFormat]] to *undefined*.
         1. Set _numberFormat_.[[InitializedNumberFormat]] to *true*.
         1. Return _numberFormat_.
@@ -180,7 +180,7 @@
               1. If _numberFormat_.[[Style]] is *"percent"*, let _x_ be 100 × _x_.
               1. Let _n_ be FormatNumberToString(_numberFormat_, _x_).
               1. If the _numberFormat_.[[NumberingSystem]] matches one of the values in the "Numbering System" column of <emu-xref href="#table-numbering-system-digits"></emu-xref> below, then
-                1. Let _digits_ be an array whose 10 String valued elements are the UTF-16 string representations of the 10 _digits_ specified in the "Digits" column of the matching row in <emu-xref href="#table-numbering-system-digits"></emu-xref>.
+                1. Let _digits_ be a List whose 10 String valued elements are the UTF-16 string representations of the 10 _digits_ specified in the "Digits" column of the matching row in <emu-xref href="#table-numbering-system-digits"></emu-xref>.
                 1. Replace each _digit_ in _n_ with the value of _digits_[_digit_].
               1. Else use an implementation dependent algorithm to map _n_ to the appropriate representation of _n_ in the given numbering system.
               1. Let _decimalSepIndex_ be Call(%StringProto_indexOf%, _n_, *"."*, 0).
@@ -559,8 +559,8 @@
       </p>
 
       <ul>
-        <li>The array that is the value of the "nu" property of any locale property of [[LocaleData]] must not include the values "native", "traditio", or "finance".</li>
-        <li>[[LocaleData]][locale] must have a patterns property for all locale values. The value of this property must be an object, which must have properties with the names of the three number format styles: *"decimal"*, *"percent"*, and *"currency"*. Each of these properties in turn must be an object with the properties positivePattern and negativePattern. The value of these properties must be string values that must contain the substring *"{number}"* and may contain the substrings *"{plusSign}"*, and *"{minusSign}"*; the values within the percent property must also contain the substring *"{percentSign}"*; the values within the currency property must also contain the substring *"{currency}"*. The pattern strings must not contain any characters in the General Category “Number, decimal digit" as specified by the Unicode Standard.</li>
+        <li>The list that is the value of the "nu" field of any locale field of [[LocaleData]] must not include the values "native", "traditio", or "finance".</li>
+        <li>[[LocaleData]][locale] must have a patterns field for all locale values. The value of this field must be a record, which must have fields with the names of the three number format styles: *"decimal"*, *"percent"*, and *"currency"*. Each of these fields in turn must be a record with the fields positivePattern and negativePattern. The value of these fields must be string values that must contain the substring *"{number}"* and may contain the substrings *"{plusSign}"*, and *"{minusSign}"*; the values within the percent field must also contain the substring *"{percentSign}"*; the values within the currency field must also contain the substring *"{currency}"*. The pattern strings must not contain any characters in the General Category “Number, decimal digit" as specified by the Unicode Standard.</li>
       </ul>
 
       <emu-note>

--- a/spec/requirements.html
+++ b/spec/requirements.html
@@ -2,6 +2,6 @@
   <h1>Requirements for Standard Built-in ECMAScript Objects</h1>
 
   <p>
-    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2018 Language Specification, 9<sup>th</sup> edition, clause 17, or successor.
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2018 Language Specification, 9<sup>th</sup> edition, clause <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>, or successor.
   </p>
 </emu-clause>


### PR DESCRIPTION
Applies on top of #155 (there is a way not to include the commits from #155 here, isn't it?).

fcd6157224e759f73602e03b8112330044c22380 replaces all internal arrays with lists (and objects with records) to fix #156. The commit has a mix of &lt;fieldName&gt; and &amp;lt;fieldName&amp;gt; because I tried to stick with the form which was already used in the algorithms.

And while going through the spec, I couldn't help myself to fix some editorial nits: a9492cb800f6cc5181e51743e61bde9485deb6a7. 
