### PR TITLE
Editorial: Remove [[InitializedIntlObject]] internal slot

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -51,8 +51,6 @@
       </p>
 
       <emu-alg>
-        1. If _collator_.[[InitializedIntlObject]] is *true*, throw a *TypeError* exception.
-        1. Set _collator_.[[InitializedIntlObject]] to *true*.
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
           1. Let _options_ be ObjectCreate(%ObjectPrototype%).
@@ -115,7 +113,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _internalSlotsList_ be &laquo; [[InitializedIntlObject]], [[InitializedCollator]], [[Locale]], [[Usage]], [[Sensitivity]], [[IgnorePunctuation]], [[Collation]], [[BoundCompare]] &raquo;.
+        1. Let _internalSlotsList_ be &laquo; [[InitializedCollator]], [[Locale]], [[Usage]], [[Sensitivity]], [[IgnorePunctuation]], [[Collation]], [[BoundCompare]] &raquo;.
         1. If %Collator%.[[RelevantExtensionKeys]] contains `"kn"`, then
           1. Append [[Numeric]] as the last element of _internalSlotsList_.
         1. If %Collator%.[[RelevantExtensionKeys]] contains `"kf"`, then
@@ -331,7 +329,7 @@
     </p>
 
     <p>
-      Intl.Collator instances and other objects that have been successfully initialized as a Collator have [[InitializedIntlObject]] and [[InitializedCollator]] internal slots whose values are *true*.
+      Intl.Collator instances and other objects that have been successfully initialized as a Collator each have an [[InitializedCollator]] internal slot whose values is *true*.
     </p>
 
     <p>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -74,8 +74,6 @@
       </p>
 
       <emu-alg>
-        1. If _dateTimeFormat_.[[InitializedIntlObject]] is *true*, throw a *TypeError* exception.
-        1. Set _dateTimeFormat_.[[InitializedIntlObject]] to *true*.
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Let _options_ be ? ToDateTimeOptions(_options_, *"any"*, *"date"*).
         1. Let _opt_ be a new Record.
@@ -422,7 +420,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%DateTimeFormatPrototype%"`, &laquo; [[InitializedIntlObject]], [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]], [[HourCycle]], [[Pattern]], [[BoundFormat]] &raquo;).
+        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%DateTimeFormatPrototype%"`, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]], [[HourCycle]], [[Pattern]], [[BoundFormat]] &raquo;).
         1. Perform ? InitializeDateTimeFormat(_dateTimeFormat_, _locales_, _options_).
       </emu-alg>
       <emu-normative-optional>
@@ -628,7 +626,7 @@
     </p>
 
     <p>
-      Intl.DateTimeFormat instances and other objects that have been successfully initialized as a DateTimeFormat object have [[InitializedIntlObject]] and [[InitializedDateTimeFormat]] internal slots whose values are *true*.
+      Intl.DateTimeFormat instances and other objects that have been successfully initialized as a DateTimeFormat object each have an [[InitializedDateTimeFormat]] internal slot whose values is *true*.
     </p>
 
     <p>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -12,7 +12,7 @@
         options used for number formatting onto the intl object.
       </p>
       <emu-alg>
-        1. Assert: Type(_intlObj_) is Object and _intlObj_.[[InitializedIntlObject]] is *true*.
+        1. Assert: Type(_intlObj_) is Object.
         1. Assert: Type(_options_) is Object.
         1. Assert: type(_mnfdDefault_) is Number.
         1. Assert: type(_mxfdDefault_) is Number.
@@ -45,8 +45,6 @@
       </p>
 
       <emu-alg>
-        1. If _numberFormat_.[[InitializedIntlObject]] is *true*, throw a *TypeError* exception.
-        1. Set _numberFormat_.[[InitializedIntlObject]] to *true*.
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
           1. Let _options_ be ObjectCreate(%ObjectPrototype%).
@@ -135,7 +133,7 @@
       </p>
 
       <emu-alg>
-        1. Assert: _numberFormat_.[[InitializedIntlObject]] is true.
+        1. Assert: _numberFormat_.[[InitializedNumberFormat]] is true.
         1. If the _numberFormat_.[[MinimumSignificantDigits]] and _numberFormat_.[[MaximumSignificantDigits]] are present, then
           1. Let _result_ be ToRawPrecision(_x_, _numberFormat_.[[MinimumSignificantDigits]], _numberFormat_.[[MaximumSignificantDigits]]).
         1. Else,
@@ -486,7 +484,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%NumberFormatPrototype%"`, &laquo; [[InitializedIntlObject]], [[InitializedNumberFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[Currency]], [[CurrencyDisplay]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[UseGrouping]], [[PositivePattern]], [[NegativePattern]], [[BoundFormat]] &raquo;).
+        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%NumberFormatPrototype%"`, &laquo; [[InitializedNumberFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[Currency]], [[CurrencyDisplay]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[UseGrouping]], [[PositivePattern]], [[NegativePattern]], [[BoundFormat]] &raquo;).
         1. Perform ? InitializeNumberFormat(_numberFormat_, _locales_, _options_).
       </emu-alg>
       <emu-normative-optional>
@@ -638,7 +636,7 @@
     </p>
 
     <p>
-      Intl.NumberFormat instances and other objects that have been successfully initialized as a NumberFormat have [[InitializedIntlObject]] and [[InitializedNumberFormat]] internal slots whose values are *true*.
+      Intl.NumberFormat instances and other objects that have been successfully initialized as a NumberFormat each have an [[InitializedNumberFormat]] internal slot whose values is *true*.
     </p>
 
     <p>


### PR DESCRIPTION
This internal slot has not done anything since ECMA 402 v1.
This patch simply removes it.

Closes #115