### PR TITLE
Normative: Use a null prototype for the default options

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -55,7 +55,7 @@
         1. Set _collator_.[[InitializedIntlObject]] to *true*.
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
-          1. Let _options_ be ObjectCreate(%ObjectPrototype%).
+          1. Let _options_ be ObjectCreate(*null*).
         1. Else,
           1. Let _options_ be ? ToObject(_options_).
         1. Let _u_ be ? GetOption(_options_, *"usage"*, *"string"*, &laquo; *"sort"*, *"search"* &raquo;, *"sort"*).

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -49,7 +49,7 @@
         1. Set _numberFormat_.[[InitializedIntlObject]] to *true*.
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
-          1. Let _options_ be ObjectCreate(%ObjectPrototype%).
+          1. Let _options_ be ObjectCreate(*null*).
         1. Else,
           1. Let _options_ be ? ToObject(_options_).
         1. Let _opt_ be a new Record.


### PR DESCRIPTION
If an options object is not passed in, then use the default options
rather than querying for possible overrides in Object.prototype.
There are a couple points of motivation here:
- It is simpler to not fall back to Object.prototype, and the fallback
  there feels unexpected.
- WebIDL dictionaries default to not reading Object.prototype; it
  is nice to have consistency here.
- Real engine implementations were not consistently implementing the
  fallback for certain paths, such as Number.prototype.toLocaleString
  and String.prototype.localeCompare, where it is possible to observe
  some invalid caching which would become valid with this patch
- DateTimeFormat already does not look to Object.prototype for defaults.

Closes #123

cc @anba 