### PR TITLE
Normative: Add calendar and numberingSystem options

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -84,10 +84,13 @@
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, *"string"*, *undefined*, *undefined*).
-        1. If _calendar_ does not match `type`, throw a *RangeError* exception.
+        1. If _calendar_ is not *undefined*, then
+          1. If _calendar_ does not match the `(3*8alphanum) *("-" (3*8alphanum))` sequence, throw a *RangeError* exception.
         1. Set _opt_.[[ca]] to _calendar_.
         1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
         1. If _numberingSystem_ does not match `type`, throw a *RangeError* exception.
+        1. If _numberingSystem_ is not *undefined*, then
+          1. If _numberingSystem_ does not match the `(3*8alphanum) *("-" (3*8alphanum))` sequence, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
         1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -73,12 +73,22 @@
         The abstract operation InitializeDateTimeFormat accepts the arguments _dateTimeFormat_ (which must be an object), _locales_, and _options_. It initializes _dateTimeFormat_ as a DateTimeFormat object. This abstract operation functions as follows:
       </p>
 
+      <p>
+        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
+      </p>
+
       <emu-alg>
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Let _options_ be ? ToDateTimeOptions(_options_, *"any"*, *"date"*).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, *"string"*, *undefined*, *undefined*).
+        1. If _calendar_ does not match `type`, throw a *RangeError* exception.
+        1. Set _opt_.[[ca]] to _calendar_.
+        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
+        1. If _numberingSystem_ does not match `type`, throw a *RangeError* exception.
+        1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
         1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
         1. If _hour12_ is not *undefined*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -74,7 +74,7 @@
       </p>
 
       <p>
-        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
+        The following algorithm refers to the `type` nonterminal from <a href="http://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
       </p>
 
       <emu-alg>
@@ -85,12 +85,13 @@
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, *"string"*, *undefined*, *undefined*).
         1. If _calendar_ is not *undefined*, then
-          1. If _calendar_ does not match the `(3*8alphanum) *("-" (3*8alphanum))` sequence, throw a *RangeError* exception.
+          1. If _calendar_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
+          1. Set _calendar_ to the result of mapping _calendar_ to lower case as as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
         1. Set _opt_.[[ca]] to _calendar_.
         1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
-        1. If _numberingSystem_ does not match `type`, throw a *RangeError* exception.
         1. If _numberingSystem_ is not *undefined*, then
-          1. If _numberingSystem_ does not match the `(3*8alphanum) *("-" (3*8alphanum))` sequence, throw a *RangeError* exception.
+          1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
+          1. Set _numberingSystem_ to the result of mapping _numberingSystem_ to lower case as as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
         1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -9,7 +9,7 @@
     <h1>Case Sensitivity and Case Mapping</h1>
 
     <p>
-      The String values used to identify locales, currencies, and time zones are interpreted in a case-insensitive manner, treating the Unicode Basic Latin characters *"A"* to *"Z"* (U+0041 to U+005A) as equivalent to the corresponding Basic Latin characters *"a"* to *"z"* (U+0061 to U+007A). No other case folding equivalences are applied. When mapping to upper case, a mapping shall be used that maps characters in the range *"a"* to *"z"* (U+0061 to U+007A) to the corresponding characters in the range *"A"* to *"Z"* (U+0041 to U+005A) and maps no other characters to the latter range.
+      The String values used to identify locales, currencies, and time zones are interpreted in a case-insensitive manner, treating the Unicode Basic Latin characters *"A"* to *"Z"* (U+0041 to U+005A) as equivalent to the corresponding Basic Latin characters *"a"* to *"z"* (U+0061 to U+007A). No other case folding equivalences are applied. When mapping to upper case, a mapping shall be used that maps characters in the range *"a"* to *"z"* (U+0061 to U+007A) to the corresponding characters in the range *"A"* to *"Z"* (U+0041 to U+005A) and maps no other characters to the latter range. When mapping to lower case, a mapping shall be used that maps characters in the range *"A"* to *"Z"* (U+0041 to U+005A) to the corresponding characters in the range *"a"* to *"z"* (U+0061 to U+007A) and maps no other characters to the latter range.
     </p>
 
     <p>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -41,7 +41,7 @@
       </p>
 
       <p>
-        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
+        The following algorithm refers to the `type` nonterminal from <a href="http://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
       </p>
 
       <emu-alg>
@@ -55,7 +55,8 @@
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _numberingSystem_ be ? GetOption(_options_, `"numberingSystem"`, `"string"`, *undefined*, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
-          1. If _numberingSystem_ does not match the `(3*8alphanum) *("-" (3*8alphanum))` sequence, throw a *RangeError* exception.
+          1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
+          1. Set _numberingSystem_ to the result of mapping _numberingSystem_ to lower case as as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %NumberFormat%.[[RelevantExtensionKeys]], _localeData_).

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -40,6 +40,10 @@
         The abstract operation InitializeNumberFormat accepts the arguments _numberFormat_ (which must be an object), _locales_, and _options_. It initializes _numberFormat_ as a NumberFormat object. The following steps are taken:
       </p>
 
+      <p>
+        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
+      </p>
+
       <emu-alg>
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
@@ -49,6 +53,9 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Let _numberingSystem_ be ? GetOption(_options_, `"numberingSystem"`, `"string"`, *undefined*, *undefined*).
+        1. If _numberingSystem_ does not match `type`, throw a *RangeError* exception.
+        1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %NumberFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _numberFormat_.[[Locale]] to _r_.[[locale]].

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -54,7 +54,8 @@
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _numberingSystem_ be ? GetOption(_options_, `"numberingSystem"`, `"string"`, *undefined*, *undefined*).
-        1. If _numberingSystem_ does not match `type`, throw a *RangeError* exception.
+        1. If _numberingSystem_ is not *undefined*, then
+          1. If _numberingSystem_ does not match the `(3*8alphanum) *("-" (3*8alphanum))` sequence, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %NumberFormat%.[[RelevantExtensionKeys]], _localeData_).


### PR DESCRIPTION
This patch allows calendar and numberingSystem to be specified in
the options bag of the DateTimeFormat and NumberFormat constructors.
One use case for these options would be, when working with locales
which have two numbering systems and calendars in use--the UA default
may be the non-Western one, but in some contexts, it may be appropriate
to use the Western one. Currently, without the patch, it would be
necessary to parse the BCP 47 language tag in the application, but Intl
provides no library to do so. For example, this all occurs in this bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=1370086

Related bug: #105 . This patch leaves out "collation" because of a lack
of clear use cases.