### PR TITLE
Editorial: Update Array.prototype.toLocaleString to mirror the algorithm in ECMA-262. (Fixes #173)

### DIFF
--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -226,27 +226,25 @@
       </p>
 
       <emu-alg>
-        1. Let _A_ be ? ToObject(*this* value).
-        1. Let _len_ be ? ToLength(? Get(_A_, *"length"*)).
-        1. Let _separator_ be the String value for the list-separator String appropriate for the host environment’s current locale (this is derived in an implementation-defined way).
-        1. If _len_ is zero, return the empty String.
-        1. Let _firstElement_ be ? Get(_A_, *"0"*).
-        1. If _firstElement_ is *undefined* or *null*, then
-          1. Let _R_ be the empty String.
-        1. Else,
-          1. Let _R_ be ? ToString(? Invoke(_firstElement_, *"toLocaleString"*, &laquo; _locales_, _options_ &raquo;)).
-        1. Let _k_ be 1.
-        1. Repeat, while _k_ < _len_
-          1. Let _S_ be a String value produced by concatenating _R_ and _separator_.
-          1. Let _nextElement_ be ? Get(_A_, ToString(_k_)).
-          1. If _nextElement_ is *undefined* or *null*, then
-            1. Let _R_ be the empty String.
-          1. Else,
-            1. Let _R_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*, &laquo; _locales_, _options_ &raquo;)).
-          1. Let _R_ be a String value produced by concatenating _S_ and _R_.
+        1. Let _array_ be ? ToObject(*this* value).
+        1. Let _len_ be ? ToLength(? Get(_array_, `"length"`)).
+        1. Let _separator_ be the String value for the list-separator String appropriate for the host environment's current locale (this is derived in an implementation-defined way).
+        1. Let _R_ be the empty String.
+        1. Let _k_ be 0.
+        1. Repeat, while _k_ &lt; _len_
+          1. If _k_ &gt; 0, then
+            1. Set _R_ to the string-concatenation of _R_ and _separator_.
+          1. Let _nextElement_ be ? Get(_array_, ! ToString(_k_)).
+          1. If _nextElement_ is not *undefined* or *null*, then
+            1. Let _S_ be ? ToString(? Invoke(_nextElement_, `"toLocaleString"`, &laquo; _locales_, _options_ &raquo;)).
+            1. Set _R_ to the string-concatenation of _R_ and _S_.
           1. Increase _k_ by 1.
         1. Return _R_.
       </emu-alg>
+
+      <emu-note>
+        This algorithm's steps mirror the steps taken in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref>, with the exception that Invoke(_nextElement_, `"toLocaleString"`) now takes _locales_ and _options_ as arguments.
+      </emu-note>
 
       <emu-note>
         The elements of the array are converted to Strings using their *toLocaleString* methods, and these Strings are then concatenated, separated by occurrences of a separator String that has been derived in an implementationdefined locale-specific way. The result of calling this function is intended to be analogous to the result of *toString*, except that the result of this function is intended to be locale-specific.


### PR DESCRIPTION
Also added note about the effective difference between this algorithm and the version from ECMA-262.

See https://github.com/tc39/ecma262/pull/662 for the update to ECMA-262's version.

Fixes #173