### PR TITLE
Change link addresses to https where possible

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -300,7 +300,7 @@
       </p>
 
       <emu-note>
-        It is recommended that the CompareStrings abstract operation be implemented following Unicode Technical Standard 10, Unicode Collation Algorithm (available at <a href="http://unicode.org/reports/tr10/">http://unicode.org/reports/tr10/</a>), using tailorings for the effective locale and collation options of _collator_. It is recommended that implementations use the tailorings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
+        It is recommended that the CompareStrings abstract operation be implemented following Unicode Technical Standard 10, Unicode Collation Algorithm (available at <a href="https://unicode.org/reports/tr10/">https://unicode.org/reports/tr10/</a>), using tailorings for the effective locale and collation options of _collator_. It is recommended that implementations use the tailorings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
       </emu-note>
 
       <emu-note>

--- a/spec/normative-references.html
+++ b/spec/normative-references.html
@@ -6,7 +6,7 @@
 
   <p>
     ECMAScript 2018 Language Specification (ECMA-262 9<sup>th</sup> Edition, or successor).<br>
-    <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">http://www.ecma-international.org/publications/standards/Ecma-262.htm</a>
+    <a href="https://www.ecma-international.org/publications/standards/Ecma-262.htm">https://www.ecma-international.org/publications/standards/Ecma-262.htm</a>
   </p>
 
   <emu-note>
@@ -17,36 +17,36 @@
     <li>
       ISO/IEC 10646:2014: Information Technology – Universal Multiple-Octet Coded Character Set (UCS) plus Amendment 1:2015 and Amendment 2, plus additional amendments and corrigenda, or successor
       <ul>
-        <li><a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=63182">http://www.iso.org/iso/catalogue_detail.htm?csnumber=63182</a></li>
-        <li><a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=65047">http://www.iso.org/iso/catalogue_detail.htm?csnumber=65047</a></li>
-        <li><a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=66791">http://www.iso.org/iso/catalogue_detail.htm?csnumber=66791</a></li>
+        <li><a href="https://www.iso.org/iso/catalogue_detail.htm?csnumber=63182">https://www.iso.org/iso/catalogue_detail.htm?csnumber=63182</a></li>
+        <li><a href="https://www.iso.org/iso/catalogue_detail.htm?csnumber=65047">https://www.iso.org/iso/catalogue_detail.htm?csnumber=65047</a></li>
+        <li><a href="https://www.iso.org/iso/catalogue_detail.htm?csnumber=66791">https://www.iso.org/iso/catalogue_detail.htm?csnumber=66791</a></li>
       </ul>
     </li>
     <li>
-      <a href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=64758">ISO 4217:2015, Codes for the representation of currencies and funds, or successor</a>
+      <a href="https://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=64758">ISO 4217:2015, Codes for the representation of currencies and funds, or successor</a>
     </li>
     <li>
       IETF BCP 47:
       <ul>
         <li>
-          <a href="http://tools.ietf.org/html/rfc5646">RFC 5646, Tags for Identifying Languages, or successor</a>
+          <a href="https://tools.ietf.org/html/rfc5646">RFC 5646, Tags for Identifying Languages, or successor</a>
         </li>
         <li>
-          <a href="http://tools.ietf.org/html/rfc4647">RFC 4647, Matching of Language Tags, or successor</a>
+          <a href="https://tools.ietf.org/html/rfc4647">RFC 4647, Matching of Language Tags, or successor</a>
         </li>
       </ul>
     </li>
     <li>
-      <a href="http://tools.ietf.org/html/rfc6067">IETF RFC 6067, BCP 47 Extension U, or successor</a>
+      <a href="https://tools.ietf.org/html/rfc6067">IETF RFC 6067, BCP 47 Extension U, or successor</a>
     </li>
     <li>
-      <a href="http://www.iana.org/time-zones/">IANA Time Zone Database</a>
+      <a href="https://www.iana.org/time-zones/">IANA Time Zone Database</a>
     </li>
     <li>
-      <a href="http://www.unicode.org/versions/latest">The Unicode Standard</a>
+      <a href="https://www.unicode.org/versions/latest">The Unicode Standard</a>
     </li>
     <li>
-      <a href="http://www.unicode.org/reports/tr35/">Unicode Technical Standard 35, Unicode Locale Data Markup Language</a>
+      <a href="https://www.unicode.org/reports/tr35/">Unicode Technical Standard 35, Unicode Locale Data Markup Language</a>
     </li>
   </ul>
 


### PR DESCRIPTION
- `cldr.unicode.org` doesn't accept https.
- `https://www.unicode.org/versions/Unicode10.0.0/` is reachable per https, but the redirect from `https://www.unicode.org/versions/latest` goes to the http version