### PR TITLE
Remove notion of "objects initialized as Collator/NumberFormat/DateTimeFormat"

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -97,8 +97,6 @@
         1. Set _collator_.[[Sensitivity]] to _s_.
         1. Let _ip_ be ? GetOption(_options_, *"ignorePunctuation"*, *"boolean"*, *undefined*, *false*).
         1. Set _collator_.[[IgnorePunctuation]] to _ip_.
-        1. Set _collator_.[[BoundCompare]] to *undefined*.
-        1. Set _collator_.[[InitializedCollator]] to *true*.
         1. Return _collator_.
       </emu-alg>
 
@@ -193,7 +191,7 @@
     </p>
 
     <p>
-      In the following descriptions of functions that are properties or [[Get]] attributes of properties of %CollatorPrototype%, the phrase "this Collator object" refers to the object that is the *this* value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedCollator]] internal slot with value *true*.
+      In the following descriptions of functions that are properties or [[Get]] attributes of properties of %CollatorPrototype%, the phrase "this Collator object" refers to the object that is the *this* value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedCollator]] internal slot.
     </p>
 
     <emu-clause id="sec-intl.collator.prototype.constructor">
@@ -256,7 +254,7 @@
 
       <emu-alg>
         1. Let _collator_ be the *this* value.
-        1. Assert: Type(_collator_) is Object and _collator_ .[[InitializedCollator]] is *true*.
+        1. Assert: Type(_collator_) is Object and _collator_ has an [[InitializedCollator]] internal slot.
         1. If _x_ is not provided, let _x_ be *undefined*.
         1. If _y_ is not provided, let _y_ be *undefined*.
         1. Let _X_ be ? ToString(_x_).
@@ -329,11 +327,11 @@
     </p>
 
     <p>
-      Intl.Collator instances and other objects that have been successfully initialized as a Collator each have an [[InitializedCollator]] internal slot whose values is *true*.
+      Intl.Collator instances have an [[InitializedCollator]] internal slot.
     </p>
 
     <p>
-      Objects that have been successfully initialized as a Collator also have several internal slots that are computed by the constructor:
+      Intl.Collator instances also have several internal slots that are computed by the constructor:
     </p>
 
     <ul>
@@ -345,7 +343,7 @@
     </ul>
 
     <p>
-      Objects that have been successfully initialized as a Collator also have the following internal slots if the key corresponding to the name of the internal slot in <emu-xref href="#table-collator-options"></emu-xref> is included in the [[RelevantExtensionKeys]] internal slot of Intl.Collator:
+      Intl.Collator instances also have the following internal slots if the key corresponding to the name of the internal slot in <emu-xref href="#table-collator-options"></emu-xref> is included in the [[RelevantExtensionKeys]] internal slot of Intl.Collator:
     </p>
 
     <ul>
@@ -354,7 +352,7 @@
     </ul>
 
     <p>
-      Finally, objects that have been successfully initialized as a Collator have a [[BoundCompare]] internal slot that caches the function returned by the compare accessor (<emu-xref href="#sec-intl.collator.prototype.compare"></emu-xref>).
+      Finally, Intl.Collator instances have a [[BoundCompare]] internal slot that caches the function returned by the compare accessor (<emu-xref href="#sec-intl.collator.prototype.compare"></emu-xref>).
     </p>
 
   </emu-clause>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -141,8 +141,6 @@
           1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
           1. Let _pattern_ be Get(_bestFormat_, *"pattern"*).
         1. Set _dateTimeFormat_.[[Pattern]] to _pattern_.
-        1. Set _dateTimeFormat_.[[BoundFormat]] to *undefined*.
-        1. Set _dateTimeFormat_.[[InitializedDateTimeFormat]] to *true*.
         1. Return _dateTimeFormat_.
       </emu-alg>
     </emu-clause>
@@ -234,7 +232,7 @@
 
       <emu-alg>
         1. Let _dtf_ be the *this* value.
-        1. Assert: Type(_dtf_) is Object and _dtf_.[[InitializedDateTimeFormat]] is *true*.
+        1. Assert: Type(_dtf_) is Object and _dtf_ has an [[InitializedDateTimeFormat]] internal slot.
         1. If _date_ is not provided or is *undefined*, then
           1. Let _x_ be Call(%Date_now%, *undefined*).
         1. Else,
@@ -391,13 +389,12 @@
       </p>
       <emu-normative-optional>
       <emu-alg>
-        1. If Type(_dtf_) is Object and _dtf_ does not have an [[initializedDateTimeFormat]] internal slot and ? InstanceofOperator(dtf, %DateTimeFormat%) is true, then
-        1. If _dtf_ does not have an [[InitializedDateTimeFormat]] internal slot and ? InstanceofOperator(_dtf_, %DateTimeFormat%) is equal *true*, then
-          1. Let _dtf_ be Get(_dtf_, Intl.[[FallbackSymbol]]).
+        1. If Type(_dtf_) is Object and _dtf_ does not have an [[InitializedDateTimeFormat]] internal slot and ? InstanceofOperator(_dtf_, %DateTimeFormat%) is *true*, then
+          1. Let _dtf_ be ? Get(_dtf_, Intl.[[FallbackSymbol]]).
       </emu-alg>
       </emu-normative-optional>
       <emu-alg>
-        3. If Type(_dtf_) is not Object or _dtf_ does not have an [[initializedDateTimeFormat]] internal slot, then
+        2. If Type(_dtf_) is not Object or _dtf_ does not have an [[InitializedDateTimeFormat]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Return _dtf_.
       </emu-alg>
@@ -427,7 +424,7 @@
       <emu-normative-optional>
       <emu-alg>
         4. Let _this_ be the *this* value.
-        1. If NewTarget is *undefined* and ? InstanceofOperator(_this_, %DateTimeFormat%), then
+        1. If NewTarget is *undefined* and ? InstanceofOperator(_this_, %DateTimeFormat%) is *true*, then
           1. Perform ? DefineOwnPropertyOrThrow(_this_, Intl.[[FallbackSymbol]], { [[Value]]: _dateTimeFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _this_.
       </emu-alg>
@@ -537,7 +534,7 @@
     </p>
 
     <p>
-      In the following descriptions of functions that are properties or [[Get]] attributes of properties of the Intl.DateTimeFormat prototype object, the phrase "this DateTimeFormat object" refers to the object that is the this value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedDateTimeFormat]] internal slot with value *true*.
+      In the following descriptions of functions that are properties or [[Get]] attributes of properties of the Intl.DateTimeFormat prototype object, the phrase "this DateTimeFormat object" refers to the object that is the this value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedDateTimeFormat]] internal slot.
     </p>
 
     <emu-clause id="sec-intl.datetimeformat.prototype.constructor">
@@ -628,11 +625,11 @@
     </p>
 
     <p>
-      Intl.DateTimeFormat instances and other objects that have been successfully initialized as a DateTimeFormat object each have an [[InitializedDateTimeFormat]] internal slot whose values is *true*.
+      Intl.DateTimeFormat instances have an [[InitializedDateTimeFormat]] internal slot.
     </p>
 
     <p>
-      Objects that have been successfully initialized as a DateTimeFormat also have several internal slots that are computed by the constructor:
+      Intl.DateTimeFormat instances also have several internal slots that are computed by the constructor:
     </p>
 
     <ul>
@@ -646,7 +643,7 @@
     </ul>
 
     <p>
-      Finally, objects that have been successfully initialized as a DateTimeFormat have a [[BoundFormat]] internal slot that caches the function returned by the format accessor (<emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref>).
+      Finally, Intl.DateTimeFormat instances have a [[BoundFormat]] internal slot that caches the function returned by the format accessor (<emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref>).
     </p>
   </emu-clause>
 </emu-clause>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -71,7 +71,7 @@
         1. Let _cpList_ be a List containing in order the code points of _S_ as defined in ES2018, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, starting at the first element of _S_.
         1. For each code point _c_ in _cpList_, if the Unicode Character Database provides a lower case equivalent of _c_ that is either language insensitive or for the language _locale_, replace _c_ in _cpList_ with that/those equivalent code point(s).
         1. Let _cuList_ be a new empty List.
-        1. For each code point _c_ in _cpList_, in order, append to cuList the elements of the UTF-16 Encoding (defined in ES2018, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) of _c_.
+        1. For each code point _c_ in _cpList_, in order, append to _cuList_ the elements of the UTF-16 Encoding (defined in ES2018, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) of _c_.
         1. Let _L_ be a String whose elements are, in order, the elements of _cuList_.
         1. Return _L_.
       </emu-alg>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -88,8 +88,6 @@
         1. Let _stylePatterns_ be _patterns_.[[&lt;_s_&gt;]].
         1. Set _numberFormat_.[[PositivePattern]] to _stylePatterns_.[[positivePattern]].
         1. Set _numberFormat_.[[NegativePattern]] to _stylePatterns_.[[negativePattern]].
-        1. Set _numberFormat_.[[BoundFormat]] to *undefined*.
-        1. Set _numberFormat_.[[InitializedNumberFormat]] to *true*.
         1. Return _numberFormat_.
       </emu-alg>
     </emu-clause>
@@ -114,7 +112,7 @@
 
       <emu-alg>
         1. Let _nf_ be the *this* value.
-        1. Assert: Type(_nf_) is Object and _nf_.[[InitializedNumberFormat]] is *true*.
+        1. Assert: Type(_nf_) is Object and _nf_ has an [[InitializedNumberFormat]] internal slot.
         1. If _value_ is not provided, let _value_ be *undefined*.
         1. Let _x_ be ? ToNumber(_value_).
         1. Return FormatNumber(_nf_, _x_).
@@ -133,7 +131,7 @@
       </p>
 
       <emu-alg>
-        1. Assert: _numberFormat_.[[InitializedNumberFormat]] is true.
+        1. Assert: _numberFormat_ has an [[InitializedNumberFormat]] internal slot.
         1. If the _numberFormat_.[[MinimumSignificantDigits]] and _numberFormat_.[[MaximumSignificantDigits]] are present, then
           1. Let _result_ be ToRawPrecision(_x_, _numberFormat_.[[MinimumSignificantDigits]], _numberFormat_.[[MaximumSignificantDigits]]).
         1. Else,
@@ -456,8 +454,8 @@
       </p>
       <emu-normative-optional>
       <emu-alg>
-        1. If Type(_nf_) is Object and _nf_ does not have an [[InitializedNumberFormat]] internal slot and ? InstanceofOperator(_nf_, %NumberFormat%) is equal *true*, then
-          1. Let _nf_ be Get(_nf_, Intl.[[FallbackSymbol]]).
+        1. If Type(_nf_) is Object and _nf_ does not have an [[InitializedNumberFormat]] internal slot and ? InstanceofOperator(_nf_, %NumberFormat%) is *true*, then
+          1. Let _nf_ be ? Get(_nf_, Intl.[[FallbackSymbol]]).
       </emu-alg>
       </emu-normative-optional>
       <emu-alg>
@@ -491,7 +489,7 @@
       <emu-normative-optional>
       <emu-alg>
         4. Let _this_ be the *this* value.
-        1. If NewTarget is *undefined* and ? InstanceofOperator(_this_, %NumberFormat%), then
+        1. If NewTarget is *undefined* and ? InstanceofOperator(_this_, %NumberFormat%) is *true*, then
           1. Perform ? DefineOwnPropertyOrThrow(_this_, Intl.[[FallbackSymbol]], { [[Value]]: _numberFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _this_.
       </emu-alg>
@@ -576,7 +574,7 @@
       The Intl.NumberFormat prototype object is itself an ordinary object. <dfn>%NumberFormatPrototype%</dfn> is not an Intl.NumberFormat instance and does not have an [[InitializedNumberFormat]] internal slot or any of the other internal slots of Intl.NumberFormat instance objects.
     </p>
     <p>
-      In the following descriptions of functions that are properties or [[Get]] attributes of properties of %NumberFormatPrototype%, the phrase "this NumberFormat object" refers to the object that is the this  value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedNumberFormat]] internal slot with value *true*.
+      In the following descriptions of functions that are properties or [[Get]] attributes of properties of %NumberFormatPrototype%, the phrase "this NumberFormat object" refers to the object that is the this value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedNumberFormat]] internal slot.
     </p>
 
     <emu-clause id="sec-intl.numberformat.prototype.constructor">
@@ -608,7 +606,7 @@
       <emu-alg>
         1. Let _nf_ be *this* value.
         1. If Type(_nf_) is not Object, throw a *TypeError* exception.
-        1. Let _nf_ be ? UnwrapNumberFormat(_nf_);
+        1. Let _nf_ be ? UnwrapNumberFormat(_nf_).
         1. If _nf_.[[BoundFormat]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions"></emu-xref>).
           1. Let _bf_ be BoundFunctionCreate(_F_, _nf_, &laquo; &raquo;).
@@ -654,11 +652,11 @@
     </p>
 
     <p>
-      Intl.NumberFormat instances and other objects that have been successfully initialized as a NumberFormat each have an [[InitializedNumberFormat]] internal slot whose values is *true*.
+      Intl.NumberFormat instances have an [[InitializedNumberFormat]] internal slot.
     </p>
 
     <p>
-      Objects that have been successfully initialized as a NumberFormat object also have several internal slots that are computed by the constructor:
+      Intl.NumberFormat instances also have several internal slots that are computed by the constructor:
     </p>
 
     <ul>
@@ -675,7 +673,7 @@
     </ul>
 
     <p>
-      Finally, objects that have been successfully initialized as a NumberFormat have a [[BoundFormat]] internal slot that caches the function returned by the format accessor (<emu-xref href="#sec-intl.numberformat.prototype.format"></emu-xref>).
+      Finally, Intl.NumberFormat instances have a [[BoundFormat]] internal slot that caches the function returned by the format accessor (<emu-xref href="#sec-intl.numberformat.prototype.format"></emu-xref>).
     </p>
   </emu-clause>
 </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -124,18 +124,17 @@
     </emu-clause>
 
     <emu-clause id="sec-formatnumberstring" aoid="FormatNumberToString">
-      <h1>FormatNumberToString ( _numberFormat_, _x_ )</h1>
+      <h1>FormatNumberToString ( _intlObject_, _x_ )</h1>
 
       <p>
-        The FormatNumberToString abstract operation is called with arguments _numberFormat_ (which must be an object with fields minimumSignificantDigits, maximumSignificantDigits, minimumIntegerDigits, minimumFractionDigits and maximumFractionDigits), and _x_ (which must be a Number value), and returns _x_ as a string value with digits formatted according to the 5 formatting parameters.
+        The FormatNumberToString abstract operation is called with arguments _intlObject_ (which must be an object with [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], and [[MaximumFractionDigits]] internal slots), and _x_ (which must be a Number value), and returns _x_ as a string value with digits formatted according to the five formatting parameters.
       </p>
 
       <emu-alg>
-        1. Assert: _numberFormat_ has an [[InitializedNumberFormat]] internal slot.
-        1. If the _numberFormat_.[[MinimumSignificantDigits]] and _numberFormat_.[[MaximumSignificantDigits]] are present, then
-          1. Let _result_ be ToRawPrecision(_x_, _numberFormat_.[[MinimumSignificantDigits]], _numberFormat_.[[MaximumSignificantDigits]]).
+        1. If _intlObject_.[[MinimumSignificantDigits]] and _intlObject_.[[MaximumSignificantDigits]] are both not *undefined*, then
+          1. Let _result_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]]).
         1. Else,
-          1. Let _result_ be ToRawFixed(_x_, _numberFormat_.[[MinimumIntegerDigits]], _numberFormat_.[[MinimumFractionDigits]], _numberFormat_.[[MaximumFractionDigits]]).
+          1. Let _result_ be ToRawFixed(_x_, _intlObject_.[[MinimumIntegerDigits]], _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]]).
         1. Return _result_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
66b872f79f2ccff5259896a5728af47fa351cc41:
- Arbitrary objects can no longer be initialized as Intl object instances, so we can remove the phrases "xyz has been successfully initialized as a Collator/NumberFormat/DateTimeFormat". 
- I've also aligned the type tests for Intl objects to only test for the presence of the `[[Initialized<...>]]` internal slots. Newer code only tested for the presence of these slots, whereas older code still tested that the value of the internal slot is `true`.
- The initial value of `[[Bound<...>]]` internal slots is already `undefined`, so we can also remove the additional assignment. 
- And some drive-by fixes.

22d11efe64383659a63e94a50be059fa1c112d11:
- FormatNumberToString will also be called with Intl.PluralRules objects, so we shouldn't assert that the argument is a NumberFormat object.
- We also need to test for the value of `[[MinimumSignificantDigits]]` and `[[MaximumSignificantDigits]]` internal slots, not if they're present.