### PR TITLE
Add algorithms for resolvedOptions()

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -192,10 +192,6 @@
       The Intl.Collator prototype object is itself an ordinary object. <dfn>%CollatorPrototype%</dfn> is not an Intl.Collator instance and does not have an [[InitializedCollator]] internal slot or any of the other internal slots of Intl.Collator instance objects.
     </p>
 
-    <p>
-      In the following descriptions of functions that are properties or [[Get]] attributes of properties of %CollatorPrototype%, the phrase "this Collator object" refers to the object that is the *this* value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedCollator]] internal slot with value *true*.
-    </p>
-
     <emu-clause id="sec-intl.collator.prototype.constructor">
       <h1>Intl.Collator.prototype.constructor</h1>
 

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -315,9 +315,66 @@
       <p>
         This function provides access to the locale and collation options computed during initialization of the object.
       </p>
-      <p>
-        The function returns a new object whose properties and attributes are set as if constructed by an object literal assigning to each of the following properties the value of the corresponding internal slot of this Collator object (see <emu-xref href="#sec-properties-of-intl-collator-instances"></emu-xref>): locale, usage, sensitivity, ignorePunctuation, collation, as well as those properties shown in <emu-xref href="#table-collator-options"></emu-xref> whose keys are included in the %Collator%.[[RelevantExtensionKeys]] internal slot of the standard built-in object that is the initial value of Intl.Collator.
-      </p>
+
+      <emu-alg>
+        1. Let _collator_ be *this* value.
+        1. If Type(_collator_) is not Object, throw a *TypeError* exception.
+        1. If _collator_ does not have an [[InitializedCollator]] internal slot, throw a *TypeError* exception.
+        1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).
+        1. For each row of <emu-xref href="#table-collator-resolvedoptions-properties"></emu-xref>, except the header row, in any order, do
+          1. Let _p_ be the Property value of the current row.
+          1. If <emu-xref href="#table-collator-options"></emu-xref> has a row that contains _p_ in the Property column, then
+            1. Let _extensionKey_ be the Key value of the row in <emu-xref href="#table-collator-options"></emu-xref>.
+            1. If %Collator%.[[RelevantExtensionKeys]] contains _extensionKey_, then
+              1. Let _v_ be the value of _collator_'s internal slot whose name is the Internal Slot value of the current row.
+            1. Else,
+              1. Let _v_ be *undefined*.
+          1. Else,
+            1. Let _v_ be the value of _collator_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If _v_ is not *undefined*, then
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+        1. Return _options_.
+      </emu-alg>
+
+      <emu-table id="table-collator-resolvedoptions-properties">
+        <emu-caption>Resolved Options of Collator Instances</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Internal Slot</th>
+              <th>Property</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[Locale]]</td>
+            <td>"locale"</td>
+          </tr>
+          <tr>
+            <td>[[Usage]]</td>
+            <td>"usage"</td>
+          </tr>
+          <tr>
+            <td>[[Sensitivity]]</td>
+            <td>"sensitivity"</td>
+          </tr>
+          <tr>
+            <td>[[IgnorePunctuation]]</td>
+            <td>"ignorePunctuation"</td>
+          </tr>
+          <tr>
+            <td>[[Collation]]</td>
+            <td>"collation"</td>
+          </tr>
+          <tr>
+            <td>[[Numeric]]</td>
+            <td>"numeric"</td>
+          </tr>
+          <tr>
+            <td>[[CaseFirst]]</td>
+            <td>"caseFirst"</td>
+          </tr>
+        </table>
+      </emu-table>
     </emu-clause>
   </emu-clause>
 

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -219,7 +219,7 @@
         This named accessor property returns a function that compares two strings according to the sort order of this Collator object.
       </p>
       <p>
-        The value of the [[Get]] attribute is a function that takes the following steps:
+        Intl.Collator.prototype.compare is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:
       </p>
 
       <emu-alg>
@@ -235,13 +235,8 @@
       </emu-alg>
 
       <emu-note>
-        The function returned by [[Get]] is bound to this Collator object so that it can be passed directly to `Array.prototype.sort` or other functions.
+        The returned function is bound to _collator_ so that it can be passed directly to `Array.prototype.sort` or other functions.
       </emu-note>
-
-      <p>
-        The value of the [[Set]] attribute is *undefined*.
-      </p>
-
     </emu-clause>
 
     <emu-clause id="sec-collator-compare-functions">

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -603,16 +603,99 @@
       <h1>Intl.DateTimeFormat.prototype.resolvedOptions ()</h1>
 
       <p>
-        This function provides access to the locale and formatting options computed during initialization of the object. This function initially invokes the internal algorithm UnwrapDateTimeFormat to get the %DateTimeFormat% object on which to operate.
+        This function provides access to the locale and formatting options computed during initialization of the object.
       </p>
 
-      <p>
-        The function returns a new object whose properties and attributes are set as if constructed by an object literal assigning to each of the following properties the value of the corresponding internal slot of this DateTimeFormat object (see <emu-xref href="#sec-properties-of-intl-datetimeformat-instances"></emu-xref>): locale, calendar, numberingSystem, timeZone, hourCycle, weekday, era, year, month, day, hour, minute, second, and timeZoneName. Properties whose corresponding internal slots have the value *undefined* are not assigned.
-      </p>
+      <emu-alg>
+        1. Let _dtf_ be *this* value.
+        1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
+        1. Let _dtf_ be ? UnwrapDateTimeFormat(_dtf_).
+        1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).
+        1. For each row of <emu-xref href="#table-datetimeformat-resolvedoptions-properties"></emu-xref>, except the header row, in any order, do
+          1. Let _p_ be the Property value of the current row.
+          1. If _p_ is `"hour12"`, then
+            1. Let _hc_ be _dtf_.[[HourCycle]].
+            1. If _hc_ is `"h11"` or `"h12"`, let _v_ be *true*.
+            1. Else if, _hc_ is `"h23"` or `"h24"`, let _v_ be *false*.
+            1. Else, let _v_ be *undefined*.
+          1. Else,
+            1. Let _v_ be the value of _dtf_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If _v_ is not *undefined*, then
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+        1. Return _options_.
+      </emu-alg>
 
-      <p>
-        For web compatibility reasons, if the property hourCycle is set, the hour12 property should be set to *true* when hourCycle is *"h11"* or *"h12"*, or to *false* when hourCycle is *"h23"* or *"h24"*.
-      </p>
+      <emu-table id="table-datetimeformat-resolvedoptions-properties">
+        <emu-caption>Resolved Options of DateTimeFormat Instances</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Internal Slot</th>
+              <th>Property</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[Locale]]</td>
+            <td>"locale"</td>
+          </tr>
+          <tr>
+            <td>[[Calendar]]</td>
+            <td>"calendar"</td>
+          </tr>
+          <tr>
+            <td>[[NumberingSystem]]</td>
+            <td>"numberingSystem"</td>
+          </tr>
+          <tr>
+            <td>[[TimeZone]]</td>
+            <td>"timeZone"</td>
+          </tr>
+          <tr>
+            <td>[[HourCycle]]</td>
+            <td>"hourCycle"</td>
+          </tr>
+          <tr>
+            <td></td>
+            <td>"hour12"</td>
+          </tr>
+          <tr>
+            <td>[[Weekday]]</td>
+            <td>"weekday"</td>
+          </tr>
+          <tr>
+            <td>[[Era]]</td>
+            <td>"era"</td>
+          </tr>
+          <tr>
+            <td>[[Year]]</td>
+            <td>"year"</td>
+          </tr>
+          <tr>
+            <td>[[Month]]</td>
+            <td>"month"</td>
+          </tr>
+          <tr>
+            <td>[[Day]]</td>
+            <td>"day"</td>
+          </tr>
+          <tr>
+            <td>[[Hour]]</td>
+            <td>"hour"</td>
+          </tr>
+          <tr>
+            <td>[[Minute]]</td>
+            <td>"minute"</td>
+          </tr>
+          <tr>
+            <td>[[Second]]</td>
+            <td>"second"</td>
+          </tr>
+          <tr>
+            <td>[[TimeZoneName]]</td>
+            <td>"timeZoneName"</td>
+          </tr>
+        </table>
+      </emu-table>
 
       <emu-note>
         In this version of the ECMAScript 2018 Internationalization API, the timeZone property will be the name of the default time zone if no timeZone property was provided in the options object provided to the Intl.DateTimeFormat constructor. The first edition left the timeZone property *undefined* in this case.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -536,10 +536,6 @@
       The Intl.DateTimeFormat prototype object is itself an ordinary object. <dfn>%DateTimeFormatPrototype%</dfn> is not an Intl.DateTimeFormat instance and does not have an [[InitializedDateTimeFormat]] internal slot or any of the other internal slots of Intl.DateTimeFormat instance objects.
     </p>
 
-    <p>
-      In the following descriptions of functions that are properties or [[Get]] attributes of properties of the Intl.DateTimeFormat prototype object, the phrase "this DateTimeFormat object" refers to the object that is the this value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedDateTimeFormat]] internal slot with value *true*.
-    </p>
-
     <emu-clause id="sec-intl.datetimeformat.prototype.constructor">
       <h1>Intl.DateTimeFormat.prototype.constructor</h1>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -242,10 +242,6 @@
         1. Return FormatDateTime(_dtf_, _x_).
       </emu-alg>
 
-      <emu-note>
-        The function returned by [[Get]] is bound to this DateTimeFormat object so that it can be passed directly to Array.prototype.map or other functions.
-      </emu-note>
-
       <p>
         The `length` property of a DateTime format function is 1.
       </p>
@@ -574,6 +570,10 @@
           1. Set _dtf_.[[BoundFormat]] to _bf_.
         1. Return _dtf_.[[BoundFormat]].
       </emu-alg>
+
+      <emu-note>
+        The returned function is bound to _dtf_ so that it can be passed directly to `Array.prototype.map` or other functions.
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DateTimeFormat.prototype.formatToParts">

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -696,6 +696,10 @@
       <emu-note>
         In this version of the ECMAScript 2018 Internationalization API, the timeZone property will be the name of the default time zone if no timeZone property was provided in the options object provided to the Intl.DateTimeFormat constructor. The first edition left the timeZone property *undefined* in this case.
       </emu-note>
+
+      <emu-note>
+        For compatibility with versions prior to the fifth edition, the `"hour12"` property is set in addition to the `"hourCycle"` property.
+      </emu-note>
     </emu-clause>
   </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -638,11 +638,77 @@
       <h1>Intl.NumberFormat.prototype.resolvedOptions ()</h1>
 
       <p>
-        This function provides access to the locale and formatting options computed during initialization of the object. This function initially invokes the internal algorithm UnwrapNumberFormat to get the %NumberFormat% object on which to operate.
+        This function provides access to the locale and formatting options computed during initialization of the object.
       </p>
-      <p>
-        The function returns a new object whose properties and attributes are set as if constructed by an object literal assigning to each of the following properties the value of the corresponding internal slot of this NumberFormat object (see <emu-xref href="#sec-properties-of-intl-numberformat-instances"></emu-xref>): locale, numberingSystem, style, currency, currencyDisplay, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, and useGrouping. Properties whose corresponding internal slots have the value *undefined* are not assigned.
-      </p>
+
+      <emu-alg>
+        1. Let _nf_ be *this* value.
+        1. If Type(_nf_) is not Object, throw a *TypeError* exception.
+        1. Let _nf_ be ? UnwrapNumberFormat(_nf_).
+        1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).
+        1. For each row of <emu-xref href="#table-numberformat-resolvedoptions-properties"></emu-xref>, except the header row, in any order, do
+          1. Let _p_ be the Property value of the current row.
+          1. Let _v_ be the value of _nf_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If _v_ is not *undefined*, then
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+        1. Return _options_.
+      </emu-alg>
+
+      <emu-table id="table-numberformat-resolvedoptions-properties">
+        <emu-caption>Resolved Options of NumberFormat Instances</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Internal Slot</th>
+              <th>Property</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[Locale]]</td>
+            <td>"locale"</td>
+          </tr>
+          <tr>
+            <td>[[NumberingSystem]]</td>
+            <td>"numberingSystem"</td>
+          </tr>
+          <tr>
+            <td>[[Style]]</td>
+            <td>"style"</td>
+          </tr>
+          <tr>
+            <td>[[Currency]]</td>
+            <td>"currency"</td>
+          </tr>
+          <tr>
+            <td>[[CurrencyDisplay]]</td>
+            <td>"currencyDisplay"</td>
+          </tr>
+          <tr>
+            <td>[[MinimumIntegerDigits]]</td>
+            <td>"minimumIntegerDigits"</td>
+          </tr>
+          <tr>
+            <td>[[MinimumFractionDigits]]</td>
+            <td>"minimumFractionDigits"</td>
+          </tr>
+          <tr>
+            <td>[[MaximumFractionDigits]]</td>
+            <td>"maximumFractionDigits"</td>
+          </tr>
+          <tr>
+            <td>[[MinimumSignificantDigits]]</td>
+            <td>"minimumSignificantDigits"</td>
+          </tr>
+          <tr>
+            <td>[[MaximumSignificantDigits]]</td>
+            <td>"maximumSignificantDigits"</td>
+          </tr>
+          <tr>
+            <td>[[UseGrouping]]</td>
+            <td>"useGrouping"</td>
+          </tr>
+        </table>
+      </emu-table>
     </emu-clause>
   </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -575,9 +575,6 @@
     <p>
       The Intl.NumberFormat prototype object is itself an ordinary object. <dfn>%NumberFormatPrototype%</dfn> is not an Intl.NumberFormat instance and does not have an [[InitializedNumberFormat]] internal slot or any of the other internal slots of Intl.NumberFormat instance objects.
     </p>
-    <p>
-      In the following descriptions of functions that are properties or [[Get]] attributes of properties of %NumberFormatPrototype%, the phrase "this NumberFormat object" refers to the object that is the this  value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedNumberFormat]] internal slot with value *true*.
-    </p>
 
     <emu-clause id="sec-intl.numberformat.prototype.constructor">
       <h1>Intl.NumberFormat.prototype.constructor</h1>


### PR DESCRIPTION
037a18ed4e4d62fc6249691e5aaedea3744b2008
Because the current algorithms don't explicitly specify in which order the properties are added, the new algorithms are a bit ugly, especially for `Intl.Collator` with its optional internal slots. :disappointed: 
We should probably fix this and add the properties in a specific order.

568e7bdbfd951853ff5f527ba5616b8ccb91e9ca 
No longer needed with the previous commit. Other, non-normative uses of these terms are removed in the next commit.

cf2b87144b953e4b3e31d7e238b6f35c1b99bb2e
So the preamble matches the current style. Also rephrases and moves a note for the DateTimeFormat bound function to the correct position.

a528cd9d4bc6d1608d6895ee2137701388d15994
IMO the `hour12` property note shouldn't be exclusively about web-compatibility, so I rephrased it a bit.


Fixes #124 