### PR TITLE
Normative: Apply TimeClip in PartitionDateTimePattern.

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -257,7 +257,8 @@
       </p>
 
       <emu-alg>
-        1. If _x_ is not a finite Number, throw a *RangeError* exception.
+        1. Let _x_ be TimeClip(_x_).
+        1. If _x_ is *NaN*, throw a *RangeError* exception.
         1. Let _locale_ be _dateTimeFormat_.[[Locale]].
         1. Let _nfOptions_ be ObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, `"useGrouping"`, *false*).


### PR DESCRIPTION
Fixes #192 

This change will limit the maximum allowed date-time value and aligns the limit with `Date`.

```js
var dtf = Intl.DateTimeFormat("en-US");
print(dtf.format(8640000000000000 - 1)); // 9/13/275760
print(dtf.format(8640000000000000)); // 9/13/275760
print(dtf.format(8640000000000000 + 1)); // <-- Throws a RangeError with the proposed patch!
```

```js
print(new Date(8640000000000000 - 1).getTime()); // 8639999999999999
print(new Date(8640000000000000).getTime()); // 8640000000000000
print(new Date(8640000000000000 + 1).getTime()); // NaN
```