### PR TITLE
Editorial fixes and clean-ups

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -194,67 +194,67 @@
       <emu-note>
         The returned function is bound to _collator_ so that it can be passed directly to `Array.prototype.sort` or other functions.
       </emu-note>
-    </emu-clause>
 
-    <emu-clause id="sec-collator-compare-functions">
-      <h1>Collator Compare Functions</h1>
+      <emu-clause id="sec-collator-compare-functions">
+        <h1>Collator Compare Functions</h1>
 
-      <p>A Collator compare function is an anonymous built-in function.</p>
-      <p>When a Collator compare function is called with arguments _x_ and _y_, the following steps are taken:</p>
+        <p>A Collator compare function is an anonymous built-in function.</p>
+        <p>When a Collator compare function is called with arguments _x_ and _y_, the following steps are taken:</p>
 
-      <emu-alg>
-        1. Let _collator_ be the *this* value.
-        1. Assert: Type(_collator_) is Object and _collator_ has an [[InitializedCollator]] internal slot.
-        1. If _x_ is not provided, let _x_ be *undefined*.
-        1. If _y_ is not provided, let _y_ be *undefined*.
-        1. Let _X_ be ? ToString(_x_).
-        1. Let _Y_ be ? ToString(_y_).
-        1. Return CompareStrings(_collator_, _X_, _Y_).
-      </emu-alg>
+        <emu-alg>
+          1. Let _collator_ be the *this* value.
+          1. Assert: Type(_collator_) is Object and _collator_ has an [[InitializedCollator]] internal slot.
+          1. If _x_ is not provided, let _x_ be *undefined*.
+          1. If _y_ is not provided, let _y_ be *undefined*.
+          1. Let _X_ be ? ToString(_x_).
+          1. Let _Y_ be ? ToString(_y_).
+          1. Return CompareStrings(_collator_, _X_, _Y_).
+        </emu-alg>
 
-      <p>
-        When the <dfn id="sec-collator-comparestrings" aoid="CompareStrings">CompareStrings</dfn> abstract operation is called with arguments _collator_ (which must be an object initialized as a Collator), _x_ and _y_ (which must be String values), it returns a Number other than *NaN* that represents the result of a locale-sensitive String comparison of _x_ with _y_. The two Strings are compared in an implementation-defined fashion. The result is intended to order String values in the sort order specified by the effective locale and collation options computed during construction of _collator_, and will be negative, zero, or positive, depending on whether _x_ comes before _y_ in the sort order, the Strings are equal under the sort order, or _x_ comes after _y_ in the sort order, respectively. String values must be interpreted as UTF-16 code unit sequences, and a surrogate pair (a code unit in the range 0xD800 to 0xDBFF followed by a code unit in the range 0xDC00 to 0xDFFF) within a string must be interpreted as the corresponding code point.
-      </p>
+        <p>
+          When the <dfn id="sec-collator-comparestrings" aoid="CompareStrings">CompareStrings</dfn> abstract operation is called with arguments _collator_ (which must be an object initialized as a Collator), _x_ and _y_ (which must be String values), it returns a Number other than *NaN* that represents the result of a locale-sensitive String comparison of _x_ with _y_. The two Strings are compared in an implementation-defined fashion. The result is intended to order String values in the sort order specified by the effective locale and collation options computed during construction of _collator_, and will be negative, zero, or positive, depending on whether _x_ comes before _y_ in the sort order, the Strings are equal under the sort order, or _x_ comes after _y_ in the sort order, respectively. String values must be interpreted as UTF-16 code unit sequences, and a surrogate pair (a code unit in the range 0xD800 to 0xDBFF followed by a code unit in the range 0xDC00 to 0xDFFF) within a string must be interpreted as the corresponding code point.
+        </p>
 
-      <p>
-        The sensitivity of _collator_ is interpreted as follows:
-      </p>
+        <p>
+          The sensitivity of _collator_ is interpreted as follows:
+        </p>
 
-      <ul>
-        <li>base: Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A.</li>
-        <li>accent: Only strings that differ in base letters or accents and other diacritic marks compare as unequal. Examples: a ≠ b, a ≠ á, a = A.</li>
-        <li>case: Only strings that differ in base letters or case compare as unequal. Examples: a ≠ b, a = á, a ≠ A.</li>
-        <li>variant: Strings that differ in base letters, accents and other diacritic marks, or case compare as unequal. Other differences may also be taken into consideration. Examples: a ≠ b, a ≠ á, a ≠ A.</li>
-      </ul>
+        <ul>
+          <li>base: Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A.</li>
+          <li>accent: Only strings that differ in base letters or accents and other diacritic marks compare as unequal. Examples: a ≠ b, a ≠ á, a = A.</li>
+          <li>case: Only strings that differ in base letters or case compare as unequal. Examples: a ≠ b, a = á, a ≠ A.</li>
+          <li>variant: Strings that differ in base letters, accents and other diacritic marks, or case compare as unequal. Other differences may also be taken into consideration. Examples: a ≠ b, a ≠ á, a ≠ A.</li>
+        </ul>
 
-      <emu-note>
-      In some languages, certain letters with diacritic marks are considered base letters. For example, in Swedish, “ö” is a base letter that’s different from “o”.
-      </emu-note>
+        <emu-note>
+        In some languages, certain letters with diacritic marks are considered base letters. For example, in Swedish, “ö” is a base letter that’s different from “o”.
+        </emu-note>
 
-      <p>
-        If the collator is set to ignore punctuation, then strings that differ only in punctuation compare as equal.
-      </p>
+        <p>
+          If the collator is set to ignore punctuation, then strings that differ only in punctuation compare as equal.
+        </p>
 
-      <p>
-        For the interpretation of options settable through extension keys, see Unicode Technical Standard 35.
-      </p>
+        <p>
+          For the interpretation of options settable through extension keys, see Unicode Technical Standard 35.
+        </p>
 
-      <p>
-        The CompareStrings abstract operation with any given _collator_ argument, if considered as a function of the remaining two arguments _x_ and _y_, must be a consistent comparison function (as defined in ES2018, <emu-xref href="#sec-array.prototype.sort"></emu-xref>) on the set of all Strings.
-      </p>
+        <p>
+          The CompareStrings abstract operation with any given _collator_ argument, if considered as a function of the remaining two arguments _x_ and _y_, must be a consistent comparison function (as defined in ES2018, <emu-xref href="#sec-array.prototype.sort"></emu-xref>) on the set of all Strings.
+        </p>
 
-      <p>
-        The actual return values are implementation-defined to permit implementers to encode additional information in the value. The method is required to return *+0* when comparing Strings that are considered canonically equivalent by the Unicode standard.
-      </p>
+        <p>
+          The actual return values are implementation-defined to permit implementers to encode additional information in the value. The method is required to return *+0* when comparing Strings that are considered canonically equivalent by the Unicode standard.
+        </p>
 
-      <emu-note>
-        It is recommended that the CompareStrings abstract operation be implemented following Unicode Technical Standard 10, Unicode Collation Algorithm (available at <a href="https://unicode.org/reports/tr10/">https://unicode.org/reports/tr10/</a>), using tailorings for the effective locale and collation options of _collator_. It is recommended that implementations use the tailorings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
-      </emu-note>
+        <emu-note>
+          It is recommended that the CompareStrings abstract operation be implemented following Unicode Technical Standard 10, Unicode Collation Algorithm (available at <a href="https://unicode.org/reports/tr10/">https://unicode.org/reports/tr10/</a>), using tailorings for the effective locale and collation options of _collator_. It is recommended that implementations use the tailorings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
+        </emu-note>
 
-      <emu-note>
-        Applications should not assume that the behaviour of the CompareStrings abstract operation for Collator instances with the same resolved options will remain the same for different versions of the same implementation.
-      </emu-note>
+        <emu-note>
+          Applications should not assume that the behaviour of the CompareStrings abstract operation for Collator instances with the same resolved options will remain the same for different versions of the same implementation.
+        </emu-note>
 
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-intl.collator.prototype.resolvedoptions">

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -11,43 +11,7 @@
       <h1>InitializeCollator ( _collator_, _locales_, _options_ )</h1>
 
       <p>
-        The abstract operation InitializeCollator accepts the arguments _collator_ (which must be an object), _locales_, and _options_. It initializes _collator_ as a *Collator* object.
-      </p>
-
-      <p>
-        Several steps in the algorithm use values from the following table, which associates Unicode locale extension keys, internal slots, property names, types, and allowable values:
-      </p>
-
-      <emu-table id="table-collator-options">
-        <emu-caption>Collator options settable through extension keys, internal slots and options properties</emu-caption>
-        <table class="real-table">
-          <thead>
-            <tr>
-              <th>Key</th>
-              <th>Internal Slot</th>
-              <th>Property</th>
-              <th>Type</th>
-              <th>Values</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>kn</td>
-            <td>[[Numeric]]</td>
-            <td>`"numeric"`</td>
-            <td>`"boolean"`</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>kf</td>
-            <td>[[CaseFirst]]</td>
-            <td>`"caseFirst"`</td>
-            <td>`"string"`</td>
-            <td>`"upper"`, `"lower"`, `"false"`</td>
-          </tr>
-        </table>
-      </emu-table>
-      <p>
-        The following steps are taken:
+        The abstract operation InitializeCollator accepts the arguments _collator_ (which must be an object), _locales_, and _options_. It initializes _collator_ as a *Collator* object. The following steps are taken:
       </p>
 
       <emu-alg>
@@ -65,27 +29,22 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. For each row in <emu-xref href="#table-collator-options"></emu-xref>, except the header row, do
-          1. Let _key_ be the name given in the Key column of the row.
-          1. Let _prop_ be the name given in the Property column of the row.
-          1. Let _type_ be the string given in the Type column of the row.
-          1. Let _list_ be a List containing the Strings given in the Values column of the row, or *undefined* if no strings are given.
-          1. Let _value_ be ? GetOption(_options_, _prop_, _type_, _list_, *undefined*).
-          1. If the string given in the Type column of the row is `"boolean"` and _value_ is not *undefined*, then
-            1. Let _value_ be ! ToString(_value_).
-          1. Set _opt_.[[&lt;_key_&gt;]] to _value_.
+        1. Let _numeric_ be ? GetOption(_options_, `"numeric"`, `"boolean"`, *undefined*, *undefined*).
+        1. If _numeric_ is not *undefined*, then
+          1. Let _numeric_ be ! ToString(_numeric_).
+        1. Set _opt_.[[kn]] to _numeric_.
+        1. Let _caseFirst_ be ? GetOption(_options_, `"caseFirst"`, `"string"`, &laquo; `"upper"`, `"lower"`, `"false"` &raquo;, *undefined*).
+        1. Set _opt_.[[kf]] to _caseFirst_.
         1. Let _relevantExtensionKeys_ be %Collator%.[[RelevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(%Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
         1. Set _collator_.[[Locale]] to _r_.[[locale]].
-        1. For each element _key_ of _relevantExtensionKeys_ in List order, do
-          1. If _key_ is `"co"`, then
-            1. Let _value_ be _r_.[[co]].
-            1. If _value_ is *null*, let _value_ be `"default"`.
-            1. Set _collator_.[[Collation]] to _value_.
-          1. Else use the row of <emu-xref href="#table-collator-options"></emu-xref> that contains _key_ in the Key column
-            1. Let _value_ be _r_.[[&lt;_key_&gt;]].
-            1. If the name given in the Type column of the row is `"boolean"`, let _value_ be SameValue(_value_, `"true"`).
-            1. Set _collator_'s internal slot whose name is the Internal Slot column of the row to _value_.
+        1. Let _collation_ be _r_.[[co]].
+        1. If _collation_ is *null*, let _collation_ be `"default"`.
+        1. Set _collator_.[[Collation]] to _collation_.
+        1. If _relevantExtensionKeys_ contains `"kn"`, then
+          1. Set _collator_.[[Numeric]] to ! SameValue(_r_.[[kn]], `"true"`).
+        1. If _relevantExtensionKeys_ contains `"kf"`, then
+          1. Set _collator_.[[CaseFirst]] to _r_.[[kf]].
         1. Let _sensitivity_ be ? GetOption(_options_, `"sensitivity"`, `"string"`, &laquo; `"base"`, `"accent"`, `"case"`, `"variant"` &raquo;, *undefined*).
         1. If _sensitivity_ is *undefined*, then
           1. If _usage_ is `"sort"`, then
@@ -312,14 +271,11 @@
         1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).
         1. For each row of <emu-xref href="#table-collator-resolvedoptions-properties"></emu-xref>, except the header row, in any order, do
           1. Let _p_ be the Property value of the current row.
-          1. If <emu-xref href="#table-collator-options"></emu-xref> has a row that contains _p_ in the Property column, then
-            1. Let _extensionKey_ be the Key value of the row in <emu-xref href="#table-collator-options"></emu-xref>.
-            1. If %Collator%.[[RelevantExtensionKeys]] contains _extensionKey_, then
-              1. Let _v_ be the value of _collator_'s internal slot whose name is the Internal Slot value of the current row.
-            1. Else,
+          1. Let _v_ be the value of _collator_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If the current row has an Extension Key value, then
+            1. Let _extensionKey_ be the Extension Key value of the current row.
+            1. If %Collator%.[[RelevantExtensionKeys]] does not contain _extensionKey_, then
               1. Let _v_ be *undefined*.
-          1. Else,
-            1. Let _v_ be the value of _collator_'s internal slot whose name is the Internal Slot value of the current row.
           1. If _v_ is not *undefined*, then
             1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
         1. Return _options_.
@@ -332,35 +288,43 @@
             <tr>
               <th>Internal Slot</th>
               <th>Property</th>
+              <th>Extension Key</th>
             </tr>
           </thead>
           <tr>
             <td>[[Locale]]</td>
             <td>`"locale"`</td>
+            <td></td>
           </tr>
           <tr>
             <td>[[Usage]]</td>
             <td>`"usage"`</td>
+            <td></td>
           </tr>
           <tr>
             <td>[[Sensitivity]]</td>
             <td>`"sensitivity"`</td>
+            <td></td>
           </tr>
           <tr>
             <td>[[IgnorePunctuation]]</td>
             <td>`"ignorePunctuation"`</td>
+            <td></td>
           </tr>
           <tr>
             <td>[[Collation]]</td>
             <td>`"collation"`</td>
+            <td></td>
           </tr>
           <tr>
             <td>[[Numeric]]</td>
             <td>`"numeric"`</td>
+            <td>kn</td>
           </tr>
           <tr>
             <td>[[CaseFirst]]</td>
             <td>`"caseFirst"`</td>
+            <td>kf</td>
           </tr>
         </table>
       </emu-table>
@@ -391,12 +355,12 @@
     </ul>
 
     <p>
-      Intl.Collator instances also have the following internal slots if the key corresponding to the name of the internal slot in <emu-xref href="#table-collator-options"></emu-xref> is included in the [[RelevantExtensionKeys]] internal slot of Intl.Collator:
+      Intl.Collator instances also have the following internal slots if the key corresponding to the name of the internal slot in <emu-xref href="#table-collator-resolvedoptions-properties"></emu-xref> is included in the [[RelevantExtensionKeys]] internal slot of Intl.Collator:
     </p>
 
     <ul>
       <li>[[Numeric]] is a Boolean value, specifying whether numeric sorting is used.</li>
-      <li>[[CaseFirst]] is a String value; allowed values are specified in <emu-xref href="#table-collator-options"></emu-xref>.</li>
+      <li>[[CaseFirst]] is one of the String values `"upper"`, `"lower"`, or `"false"`.</li>
     </ul>
 
     <p>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -56,9 +56,9 @@
           1. Let _options_ be ObjectCreate(*null*).
         1. Else,
           1. Let _options_ be ? ToObject(_options_).
-        1. Let _u_ be ? GetOption(_options_, `"usage"`, `"string"`, &laquo; `"sort"`, `"search"` &raquo;, `"sort"`).
-        1. Set _collator_.[[Usage]] to _u_.
-        1. If _u_ is `"sort"`, then
+        1. Let _usage_ be ? GetOption(_options_, `"usage"`, `"string"`, &laquo; `"sort"`, `"search"` &raquo;, `"sort"`).
+        1. Set _collator_.[[Usage]] to _usage_.
+        1. If _usage_ is `"sort"`, then
           1. Let _localeData_ be %Collator%.[[SortLocaleData]].
         1. Else,
           1. Let _localeData_ be %Collator%.[[SearchLocaleData]].
@@ -86,17 +86,17 @@
             1. Let _value_ be _r_.[[&lt;_key_&gt;]].
             1. If the name given in the Type column of the row is `"boolean"`, let _value_ be SameValue(_value_, `"true"`).
             1. Set _collator_'s internal slot whose name is the Internal Slot column of the row to _value_.
-        1. Let _s_ be ? GetOption(_options_, `"sensitivity"`, `"string"`, &laquo; `"base"`, `"accent"`, `"case"`, `"variant"` &raquo;, *undefined*).
-        1. If _s_ is *undefined*, then
-          1. If _u_ is `"sort"`, then
-            1. Let _s_ be `"variant"`.
+        1. Let _sensitivity_ be ? GetOption(_options_, `"sensitivity"`, `"string"`, &laquo; `"base"`, `"accent"`, `"case"`, `"variant"` &raquo;, *undefined*).
+        1. If _sensitivity_ is *undefined*, then
+          1. If _usage_ is `"sort"`, then
+            1. Let _sensitivity_ be `"variant"`.
           1. Else,
             1. Let _dataLocale_ be _r_.[[dataLocale]].
             1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-            1. Let _s_ be _dataLocaleData_.[[sensitivity]].
-        1. Set _collator_.[[Sensitivity]] to _s_.
-        1. Let _ip_ be ? GetOption(_options_, `"ignorePunctuation"`, `"boolean"`, *undefined*, *false*).
-        1. Set _collator_.[[IgnorePunctuation]] to _ip_.
+            1. Let _sensitivity_ be _dataLocaleData_.[[sensitivity]].
+        1. Set _collator_.[[Sensitivity]] to _sensitivity_.
+        1. Let _ignorePunctuation_ be ? GetOption(_options_, `"ignorePunctuation"`, `"boolean"`, *undefined*, *false*).
+        1. Set _collator_.[[IgnorePunctuation]] to _ignorePunctuation_.
         1. Return _collator_.
       </emu-alg>
 

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -336,31 +336,31 @@
           </thead>
           <tr>
             <td>[[Locale]]</td>
-            <td>"locale"</td>
+            <td>`"locale"`</td>
           </tr>
           <tr>
             <td>[[Usage]]</td>
-            <td>"usage"</td>
+            <td>`"usage"`</td>
           </tr>
           <tr>
             <td>[[Sensitivity]]</td>
-            <td>"sensitivity"</td>
+            <td>`"sensitivity"`</td>
           </tr>
           <tr>
             <td>[[IgnorePunctuation]]</td>
-            <td>"ignorePunctuation"</td>
+            <td>`"ignorePunctuation"`</td>
           </tr>
           <tr>
             <td>[[Collation]]</td>
-            <td>"collation"</td>
+            <td>`"collation"`</td>
           </tr>
           <tr>
             <td>[[Numeric]]</td>
-            <td>"numeric"</td>
+            <td>`"numeric"`</td>
           </tr>
           <tr>
             <td>[[CaseFirst]]</td>
-            <td>"caseFirst"</td>
+            <td>`"caseFirst"`</td>
           </tr>
         </table>
       </emu-table>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -185,9 +185,8 @@
         1. If _collator_ does not have an [[InitializedCollator]] internal slot, throw a *TypeError* exception.
         1. If _collator_.[[BoundCompare]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-collator-compare-functions"></emu-xref>.
-          1. Let _bc_ be BoundFunctionCreate(_F_, _collator_, &laquo; &raquo;).
-          1. Perform ! DefinePropertyOrThrow(_bc_, `"length"`, PropertyDescriptor {[[Value]]: 2, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
-          1. Set _collator_.[[BoundCompare]] to _bc_.
+          1. Set _F_.[[Collator]] to _collator_.
+          1. Set _collator_.[[BoundCompare]] to _F_.
         1. Return _collator_.[[BoundCompare]].
       </emu-alg>
 
@@ -198,11 +197,11 @@
       <emu-clause id="sec-collator-compare-functions">
         <h1>Collator Compare Functions</h1>
 
-        <p>A Collator compare function is an anonymous built-in function.</p>
-        <p>When a Collator compare function is called with arguments _x_ and _y_, the following steps are taken:</p>
+        <p>A Collator compare function is an anonymous built-in function that has a [[Collator]] internal slot.</p>
+        <p>When a Collator compare function _F_ is called with arguments _x_ and _y_, the following steps are taken:</p>
 
         <emu-alg>
-          1. Let _collator_ be the *this* value.
+          1. Let _collator_ be _F_.[[Collator]].
           1. Assert: Type(_collator_) is Object and _collator_ has an [[InitializedCollator]] internal slot.
           1. If _x_ is not provided, let _x_ be *undefined*.
           1. If _y_ is not provided, let _y_ be *undefined*.
@@ -210,6 +209,8 @@
           1. Let _Y_ be ? ToString(_y_).
           1. Return CompareStrings(_collator_, _X_, _Y_).
         </emu-alg>
+
+        <p>The `length` property of a Collator compare function is 2.</p>
       </emu-clause>
 
       <emu-clause id="sec-collator-comparestrings" aoid="CompareStrings">

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -210,9 +210,13 @@
           1. Let _Y_ be ? ToString(_y_).
           1. Return CompareStrings(_collator_, _X_, _Y_).
         </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-collator-comparestrings" aoid="CompareStrings">
+        <h1>CompareStrings ( _collator_, _x_, _y_ )</h1>
 
         <p>
-          When the <dfn id="sec-collator-comparestrings" aoid="CompareStrings">CompareStrings</dfn> abstract operation is called with arguments _collator_ (which must be an object initialized as a Collator), _x_ and _y_ (which must be String values), it returns a Number other than *NaN* that represents the result of a locale-sensitive String comparison of _x_ with _y_. The two Strings are compared in an implementation-defined fashion. The result is intended to order String values in the sort order specified by the effective locale and collation options computed during construction of _collator_, and will be negative, zero, or positive, depending on whether _x_ comes before _y_ in the sort order, the Strings are equal under the sort order, or _x_ comes after _y_ in the sort order, respectively. String values must be interpreted as UTF-16 code unit sequences, and a surrogate pair (a code unit in the range 0xD800 to 0xDBFF followed by a code unit in the range 0xDC00 to 0xDFFF) within a string must be interpreted as the corresponding code point.
+          When the CompareStrings abstract operation is called with arguments _collator_ (which must be an object initialized as a Collator), _x_ and _y_ (which must be String values), it returns a Number other than *NaN* that represents the result of a locale-sensitive String comparison of _x_ with _y_. The two Strings are compared in an implementation-defined fashion. The result is intended to order String values in the sort order specified by the effective locale and collation options computed during construction of _collator_, and will be negative, zero, or positive, depending on whether _x_ comes before _y_ in the sort order, the Strings are equal under the sort order, or _x_ comes after _y_ in the sort order, respectively. String values must be interpreted as UTF-16 code unit sequences, and a surrogate pair (a code unit in the range 0xD800 to 0xDBFF followed by a code unit in the range 0xDC00 to 0xDFFF) within a string must be interpreted as the corresponding code point.
         </p>
 
         <p>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -21,10 +21,6 @@
   </p>
 
   <p>
-    For ECMAScript objects, this standard may use variable-named internal slots: The notation "[[&lt;_name_&gt;]]" denotes an internal slot whose name is given by the variable name, which must have a String value. For example, if a variable _s_ has the value `"a"`, then [[&lt;_s_&gt;]] denotes the [[a]] internal slot.
-  </p>
-
-  <p>
     This specification uses blocks demarcated as <span class="normative-optional">Normative Optional</span> to denote the sense of <a href="https://tc39.github.io/ecma262/#sec-additional-ecmascript-features-for-web-browsers">Annex B</a> in ECMA 262. That is, normative optional sections are required when the ECMAScript host is a web browser. The content of the section is normative but optional if the ECMAScript host is not a web browser.
   </p>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -139,7 +139,7 @@
             1. Let _pattern_ be _bestFormat_.[[pattern]].
         1. Else,
           1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
-          1. Let _pattern_ be Get(_bestFormat_, `"pattern"`).
+          1. Let _pattern_ be _bestFormat_.[[pattern]].
         1. Set _dateTimeFormat_.[[Pattern]] to _pattern_.
         1. Return _dateTimeFormat_.
       </emu-alg>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -629,63 +629,63 @@
           </thead>
           <tr>
             <td>[[Locale]]</td>
-            <td>"locale"</td>
+            <td>`"locale"`</td>
           </tr>
           <tr>
             <td>[[Calendar]]</td>
-            <td>"calendar"</td>
+            <td>`"calendar"`</td>
           </tr>
           <tr>
             <td>[[NumberingSystem]]</td>
-            <td>"numberingSystem"</td>
+            <td>`"numberingSystem"`</td>
           </tr>
           <tr>
             <td>[[TimeZone]]</td>
-            <td>"timeZone"</td>
+            <td>`"timeZone"`</td>
           </tr>
           <tr>
             <td>[[HourCycle]]</td>
-            <td>"hourCycle"</td>
+            <td>`"hourCycle"`</td>
           </tr>
           <tr>
             <td></td>
-            <td>"hour12"</td>
+            <td>`"hour12"`</td>
           </tr>
           <tr>
             <td>[[Weekday]]</td>
-            <td>"weekday"</td>
+            <td>`"weekday"`</td>
           </tr>
           <tr>
             <td>[[Era]]</td>
-            <td>"era"</td>
+            <td>`"era"`</td>
           </tr>
           <tr>
             <td>[[Year]]</td>
-            <td>"year"</td>
+            <td>`"year"`</td>
           </tr>
           <tr>
             <td>[[Month]]</td>
-            <td>"month"</td>
+            <td>`"month"`</td>
           </tr>
           <tr>
             <td>[[Day]]</td>
-            <td>"day"</td>
+            <td>`"day"`</td>
           </tr>
           <tr>
             <td>[[Hour]]</td>
-            <td>"hour"</td>
+            <td>`"hour"`</td>
           </tr>
           <tr>
             <td>[[Minute]]</td>
-            <td>"minute"</td>
+            <td>`"minute"`</td>
           </tr>
           <tr>
             <td>[[Second]]</td>
-            <td>"second"</td>
+            <td>`"second"`</td>
           </tr>
           <tr>
             <td>[[TimeZoneName]]</td>
-            <td>"timeZoneName"</td>
+            <td>`"timeZoneName"`</td>
           </tr>
         </table>
       </emu-table>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -383,10 +383,13 @@
         for various methods which implement ECMA-402 v1 semantics for supporting initializing
         existing Intl objects.
       </p>
+      <emu-alg>
+        1. Assert: Type(_dtf_) is Object.
+      </emu-alg>
       <emu-normative-optional>
       <emu-alg>
-        1. If Type(_dtf_) is Object and _dtf_ does not have an [[InitializedDateTimeFormat]] internal slot and ? InstanceofOperator(_dtf_, %DateTimeFormat%) is *true*, then
-          1. Let _dtf_ be ? Get(_dtf_, Intl.[[FallbackSymbol]]).
+        2. If _dtf_ does not have an [[InitializedDateTimeFormat]] internal slot and ? InstanceofOperator(_dtf_, %DateTimeFormat%) is *true*, then
+          1. Let _dtf_ be ? Get(_dtf_, %Intl%.[[FallbackSymbol]]).
       </emu-alg>
       </emu-normative-optional>
       <emu-alg>
@@ -421,7 +424,7 @@
       <emu-alg>
         4. Let _this_ be the *this* value.
         1. If NewTarget is *undefined* and ? InstanceofOperator(_this_, %DateTimeFormat%) is *true*, then
-          1. Perform ? DefinePropertyOrThrow(_this_, Intl.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: _dateTimeFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Perform ? DefinePropertyOrThrow(_this_, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: _dateTimeFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _this_.
       </emu-alg>
       </emu-normative-optional>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -227,11 +227,11 @@
     <emu-clause id="sec-datetime-format-functions">
       <h1>DateTime Format Functions</h1>
 
-      <p>A DateTime format function is an anonymous built-in function.</p>
-      <p>When a DateTime format function is called with optional argument _date_, the following steps are taken:</p>
+      <p>A DateTime format function is an anonymous built-in function that has a [[DateTimeFormat]] internal slot.</p>
+      <p>When a DateTime format function _F_ is called with optional argument _date_, the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _dtf_ be the *this* value.
+        1. Let _dtf_ be _F_.[[DateTimeFormat]].
         1. Assert: Type(_dtf_) is Object and _dtf_ has an [[InitializedDateTimeFormat]] internal slot.
         1. If _date_ is not provided or is *undefined*, then
           1. Let _x_ be Call(%Date_now%, *undefined*).
@@ -562,9 +562,8 @@
         1. Let _dtf_ be ? UnwrapDateTimeFormat(_dtf_).
         1. If _dtf_.[[BoundFormat]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-format-functions"></emu-xref>).
-          1. Let _bf_ be BoundFunctionCreate(_F_, _dft_, &laquo; &raquo;).
-          1. Perform ! DefinePropertyOrThrow(_bf_, `"length"`, PropertyDescriptor {[[Value]]: 1, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
-          1. Set _dtf_.[[BoundFormat]] to _bf_.
+          1. Set _F_.[[DateTimeFormat]] to _dtf_.
+          1. Set _dtf_.[[BoundFormat]] to _F_.
         1. Return _dtf_.[[BoundFormat]].
       </emu-alg>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -79,8 +79,8 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _hc_ be ? GetOption(_options_, `"hourCycle"`, `"string"`, &laquo; `"h11"`, `"h12"`, `"h23"`, `"h24"` &raquo;, *undefined*).
-        1. Set _opt_.[[hc]] to _hc_.
+        1. Let _hourCycle_ be ? GetOption(_options_, `"hourCycle"`, `"string"`, &laquo; `"h11"`, `"h12"`, `"h23"`, `"h24"` &raquo;, *undefined*).
+        1. Set _opt_.[[hc]] to _hourCycle_.
         1. Let _localeData_ be %DateTimeFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale( %DateTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %DateTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _dateTimeFormat_.[[Locale]] to _r_.[[locale]].
@@ -88,15 +88,15 @@
         1. Set _dateTimeFormat_.[[HourCycle]] to _r_.[[hc]].
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _tz_ be ? Get(_options_, `"timeZone"`).
-        1. If _tz_ is not *undefined*, then
-          1. Let _tz_ be ? ToString(_tz_).
-          1. If the result of IsValidTimeZoneName(_tz_) is *false*, then
+        1. Let _timeZone_ be ? Get(_options_, `"timeZone"`).
+        1. If _timeZone_ is not *undefined*, then
+          1. Let _timeZone_ be ? ToString(_timeZone_).
+          1. If the result of IsValidTimeZoneName(_timeZone_) is *false*, then
             1. Throw a *RangeError* exception.
-          1. Let _tz_ be CanonicalizeTimeZoneName(_tz_).
+          1. Let _timeZone_ be CanonicalizeTimeZoneName(_timeZone_).
         1. Else,
-          1. Let _tz_ be DefaultTimeZone().
-        1. Set _dateTimeFormat_.[[TimeZone]] to _tz_.
+          1. Let _timeZone_ be DefaultTimeZone().
+        1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
         1. Let _opt_ be a new Record.
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, do
           1. Let _prop_ be the name given in the Property column of the row.
@@ -114,20 +114,20 @@
           1. Let _p_ be _bestFormat_.[[&lt;_prop_&gt;]].
           1. If _p_ not *undefined*, then
             1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
-        1. Let _hr12_ be ? GetOption(_options_, `"hour12"`, `"boolean"`, *undefined*, *undefined*).
+        1. Let _hour12_ be ? GetOption(_options_, `"hour12"`, `"boolean"`, *undefined*, *undefined*).
         1. If _dateTimeFormat_.[[Hour]] is not *undefined*, then
           1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
           1. Let _hc_ be _dateTimeFormat_.[[HourCycle]].
           1. If _hc_ is *null*, then
             1. Set _hc_ to _hcDefault_.
-          1. If _hr12_ is not *undefined*, then
-            1. If _hr12_ is *true*, then
+          1. If _hour12_ is not *undefined*, then
+            1. If _hour12_ is *true*, then
               1. If _hcDefault_ is `"h11"` or `"h23"`, then
                 1. Set _hc_ to `"h11"`.
               1. Else,
                 1. Set _hc_ to `"h12"`.
             1. Else,
-              1. Assert: _hr12_ is *false*.
+              1. Assert: _hour12_ is *false*.
               1. If _hcDefault_ is `"h11"` or `"h23"`, then
                 1. Set _hc_ to `"h23"`.
               1. Else,

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -103,11 +103,11 @@
     <emu-clause id="sec-number-format-functions">
       <h1>Number Format Functions</h1>
 
-      <p>A Number format function is an anonymous built-in function.</p>
-      <p>When a Number format function is called with optional argument _value_, the following steps are taken:</p>
+      <p>A Number format function is an anonymous built-in function that has a [[NumberFormat]] internal slot.</p>
+      <p>When a Number format function _F_ is called with optional argument _value_, the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _nf_ be the *this* value.
+        1. Let _nf_ be _F_.[[NumberFormat]].
         1. Assert: Type(_nf_) is Object and _nf_ has an [[InitializedNumberFormat]] internal slot.
         1. If _value_ is not provided, let _value_ be *undefined*.
         1. Let _x_ be ? ToNumber(_value_).
@@ -601,9 +601,8 @@
         1. Let _nf_ be ? UnwrapNumberFormat(_nf_).
         1. If _nf_.[[BoundFormat]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions"></emu-xref>).
-          1. Let _bf_ be BoundFunctionCreate(_F_, _nf_, &laquo; &raquo;).
-          1. Perform ! DefinePropertyOrThrow(_bf_, `"length"`, PropertyDescriptor {[[Value]]: 1, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
-          1. Set _nf_.[[BoundFormat]] to _bf_.
+          1. Set _F_.[[NumberFormat]] to _nf_.
+          1. Set _nf_.[[BoundFormat]] to _F_.
         1. Return _nf_.[[BoundFormat]].
       </emu-alg>
     </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -81,7 +81,7 @@
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _patterns_ be _dataLocaleData_.[[patterns]].
         1. Assert: _patterns_ is a record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
-        1. Let _stylePatterns_ be _patterns_.[[&lt;_s_&gt;]].
+        1. Let _stylePatterns_ be _patterns_.[[&lt;_style_&gt;]].
         1. Set _numberFormat_.[[PositivePattern]] to _stylePatterns_.[[positivePattern]].
         1. Set _numberFormat_.[[NegativePattern]] to _stylePatterns_.[[negativePattern]].
         1. Return _numberFormat_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -447,14 +447,17 @@
         for various methods which implement ECMA-402 v1 semantics for supporting initializing
         existing Intl objects.
       </p>
+      <emu-alg>
+        1. Assert: Type(_nf_) is Object.
+      </emu-alg>
       <emu-normative-optional>
       <emu-alg>
-        1. If Type(_nf_) is Object and _nf_ does not have an [[InitializedNumberFormat]] internal slot and ? InstanceofOperator(_nf_, %NumberFormat%) is *true*, then
-          1. Let _nf_ be ? Get(_nf_, Intl.[[FallbackSymbol]]).
+        2. If _nf_ does not have an [[InitializedNumberFormat]] internal slot and ? InstanceofOperator(_nf_, %NumberFormat%) is *true*, then
+          1. Let _nf_ be ? Get(_nf_, %Intl%.[[FallbackSymbol]]).
       </emu-alg>
       </emu-normative-optional>
       <emu-alg>
-        2. If Type(_nf_) is not Object or _nf_ does not have an [[InitializedNumberFormat]] internal slot, then
+        3. If Type(_nf_) is not Object or _nf_ does not have an [[InitializedNumberFormat]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Return _nf_.
       </emu-alg>
@@ -485,7 +488,7 @@
       <emu-alg>
         4. Let _this_ be the *this* value.
         1. If NewTarget is *undefined* and ? InstanceofOperator(_this_, %NumberFormat%) is *true*, then
-          1. Perform ? DefinePropertyOrThrow(_this_, Intl.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: _numberFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Perform ? DefinePropertyOrThrow(_this_, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: _numberFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _this_.
       </emu-alg>
       </emu-normative-optional>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -655,47 +655,47 @@
           </thead>
           <tr>
             <td>[[Locale]]</td>
-            <td>"locale"</td>
+            <td>`"locale"`</td>
           </tr>
           <tr>
             <td>[[NumberingSystem]]</td>
-            <td>"numberingSystem"</td>
+            <td>`"numberingSystem"`</td>
           </tr>
           <tr>
             <td>[[Style]]</td>
-            <td>"style"</td>
+            <td>`"style"`</td>
           </tr>
           <tr>
             <td>[[Currency]]</td>
-            <td>"currency"</td>
+            <td>`"currency"`</td>
           </tr>
           <tr>
             <td>[[CurrencyDisplay]]</td>
-            <td>"currencyDisplay"</td>
+            <td>`"currencyDisplay"`</td>
           </tr>
           <tr>
             <td>[[MinimumIntegerDigits]]</td>
-            <td>"minimumIntegerDigits"</td>
+            <td>`"minimumIntegerDigits"`</td>
           </tr>
           <tr>
             <td>[[MinimumFractionDigits]]</td>
-            <td>"minimumFractionDigits"</td>
+            <td>`"minimumFractionDigits"`</td>
           </tr>
           <tr>
             <td>[[MaximumFractionDigits]]</td>
-            <td>"maximumFractionDigits"</td>
+            <td>`"maximumFractionDigits"`</td>
           </tr>
           <tr>
             <td>[[MinimumSignificantDigits]]</td>
-            <td>"minimumSignificantDigits"</td>
+            <td>`"minimumSignificantDigits"`</td>
           </tr>
           <tr>
             <td>[[MaximumSignificantDigits]]</td>
-            <td>"maximumSignificantDigits"</td>
+            <td>`"maximumSignificantDigits"`</td>
           </tr>
           <tr>
             <td>[[UseGrouping]]</td>
-            <td>"useGrouping"</td>
+            <td>`"useGrouping"`</td>
           </tr>
         </table>
       </emu-table>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -56,16 +56,16 @@
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _style_ be ? GetOption(_options_, `"style"`, `"string"`, &laquo; `"decimal"`, `"percent"`, `"currency"` &raquo;, `"decimal"`).
         1. Set _numberFormat_.[[Style]] to _style_.
-        1. Let _c_ be ? GetOption(_options_, `"currency"`, `"string"`, *undefined*, *undefined*).
-        1. If _c_ is not *undefined*, then
-          1. If the result of IsWellFormedCurrencyCode(_c_) is *false*, throw a *RangeError* exception.
-        1. If _style_ is `"currency"` and _c_ is *undefined*, throw a *TypeError* exception.
+        1. Let _currency_ be ? GetOption(_options_, `"currency"`, `"string"`, *undefined*, *undefined*).
+        1. If _currency_ is not *undefined*, then
+          1. If the result of IsWellFormedCurrencyCode(_currency_) is *false*, throw a *RangeError* exception.
+        1. If _style_ is `"currency"` and _currency_ is *undefined*, throw a *TypeError* exception.
         1. If _style_ is `"currency"`, then
-          1. Let _c_ be the result of converting _c_ to upper case as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
-          1. Set _numberFormat_.[[Currency]] to _c_.
-          1. Let _cDigits_ be CurrencyDigits(_c_).
-        1. Let _cd_ be ? GetOption(_options_, `"currencyDisplay"`, `"string"`, &laquo; `"code"`, `"symbol"`, `"name"` &raquo;, `"symbol"`).
-        1. If _style_ is `"currency"`, set _numberFormat_.[[CurrencyDisplay]] to _cd_.
+          1. Let _currency_ be the result of converting _currency_ to upper case as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
+          1. Set _numberFormat_.[[Currency]] to _currency_.
+          1. Let _cDigits_ be CurrencyDigits(_currency_).
+        1. Let _currencyDisplay_ be ? GetOption(_options_, `"currencyDisplay"`, `"string"`, &laquo; `"code"`, `"symbol"`, `"name"` &raquo;, `"symbol"`).
+        1. If _style_ is `"currency"`, set _numberFormat_.[[CurrencyDisplay]] to _currencyDisplay_.
         1. If _style_ is `"currency"`, then
           1. Let _mnfdDefault_ be _cDigits_.
           1. Let _mxfdDefault_ be _cDigits_.
@@ -76,8 +76,8 @@
           1. Else,
             1. Let _mxfdDefault_ be 3.
         1. Perform ? SetNumberFormatDigitOptions(_numberFormat_, _options_, _mnfdDefault_, _mxfdDefault_).
-        1. Let _g_ be ? GetOption(_options_, `"useGrouping"`, `"boolean"`, *undefined*, *true*).
-        1. Set _numberFormat_.[[UseGrouping]] to _g_.
+        1. Let _useGrouping_ be ? GetOption(_options_, `"useGrouping"`, `"boolean"`, *undefined*, *true*).
+        1. Set _numberFormat_.[[UseGrouping]] to _useGrouping_.
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _patterns_ be _dataLocaleData_.[[patterns]].
         1. Assert: _patterns_ is a record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).


### PR DESCRIPTION
5cb0883def35f5b5a307531fff92fb25d75791ac
- Some variables were already updated in the past to use the more descriptive long names. Update the remaining option variables to use long names, too.

e91e340db485e9e844f4f670adae63558ccdf18a
- Replaces the iteration over Table 2 with explicit steps. This removes more uses of the dynamic record field access syntax and should also make the spec more similar to actual implementations.

8a962e51d0afecd1ad55af3285fcf9fac6653e71
- The dynamic internal slot access syntax isn't used anymore! 

a3e71a4dca57acbc46736ae5916918adc54b412d
- Makes "sec-collator-compare-functions" a proper sub-clause of "sec-intl.collator.prototype.compare".

 688fd6ca8282b2de535961553ace78b7f814dd5c
- Adds a separate emu-clause for `CompareStrings`.

a42253620f8045cc92e6d81d233b7f2d4cb02ac5
- Switch to internal slots to store the Intl instances instead of bound functions. This matches how the main spec stores per-function this-values. Implementations are still free to use actual bound functions for the bound `compare` and `format' functions.

d3a6dc92c9ab0247e5d865d42ba9244fdab48b45
- Use `%Intl%` to be more explicit that these steps refer to the `Intl` object of the current realm.
- Replace a type check which is always true with an assertion.

