### PR TITLE
Check in past notes

### DIFF
--- a/meetings/notes-2017-12-15.md
+++ b/meetings/notes-2017-12-15.md
@@ -1,0 +1,154 @@
+Agenda: [https://github.com/tc39/ecma402/blob/master/meetings/agenda-2017-12-15.md](https://github.com/tc39/ecma402/blob/master/meetings/agenda-2017-12-15.md)
+
+# Attendees
+
+* DE: Daniel Ehrenberg (Igalia)
+* AK: Adam Klein (Google)
+* Eemeli
+* SRL: Steven R. Loomis (IBM) @srl295
+* NC: Nebojša Ćirić
+* ZB: Zibi Braniecki (Mozilla)
+* RX: Rafael Xaviers (Paypal)
+* MS: Michael Saboff (Apple)
+* SM: Stas Małolepszy (Mozilla)
+* CC: Craig Cornelius (Google) 
+* FB: Felipe Balbontín (Google)
+* CP: Caridy Patiño (Salesforce)
+* JS: Jungshik Shin (Google)
+* JH: Jack Horton (MSFT) github/jackhorton
+* DIV: Doug Ilijev (MSFT) github/dilijev
+* BT: Brian Terlson (MSFT) github/bterlson
+
+# Agenda
+
+1. Introduction and intention of this meeting: (~5m)
+    1. Move forward the ECMA 402 (Intl) standard by discussing among experts in the field, developing and refining proposals, and making recommendations to TC39
+    2. Quick overview of current TC39 process and recent status of ECMA 402
+2. Everyone: Who is here and what is your interest in ECMA 402? What direction would you like to see it go in? (~15m)
+    1. [Google's i18n interests and mid-term goals](https://goo.gl/wKcA6w)
+3. Overview of new features in ECMA 402 after v2:
+    1. [formatToParts](https://github.com/tc39/ecma402/issues/47)
+    2. [PluralRules](https://github.com/tc39/proposal-intl-plural-rules)
+    3. [hourCycle](https://github.com/tc39/ecma402/pull/135)
+    4. Intl.getCanonicalLocales
+4. Overview of advanced pending proposals and their status--what do you think of these? (~10m)
+    1. [Intl.Segmenter](https://github.com/tc39/proposal-intl-segmenter) (Stage 3)
+    2. [Intl.ListFormat](https://github.com/tc39/proposal-intl-list-format) (Stage 2)
+    3. [Intl.RelativeTimeFormat](https://github.com/tc39/proposal-intl-relative-time) (Stage 2)
+5. Less advanced proposals (~10m)
+    1. [Intl.UnitFormat](https://github.com/tc39/ecma402/issues/32) (Stage 1)
+    2. [dateStyle/timeStyle options](https://github.com/tc39/proposal-ecma402-datetime-style) (Stage 1)
+    3. Adding various options to existing formatters ([overview](https://github.com/tc39/ecma402/issues/186#issuecomment-338788856), [label for bugs](https://github.com/tc39/ecma402/labels/option))
+    4. [Intl.IntervalFormat](https://github.com/tc39/ecma402/issues/188)
+    5. [Intl.DurationFormat](https://github.com/tc39/ecma402/issues/47)
+    6. Data access: [display names](https://github.com/tc39/ecma402/issues/31), likely subtags, [Unicode character database](https://github.com/tc39/ecma402/issues/90), BiDi information etc
+    7. [navigator.locales](https://github.com/whatwg/html/pull/3046), [window.ontimezonechange](https://github.com/whatwg/html/pull/3047)
+    8. What else would you like to pursue beyond this? Hyphenation? MessageFormat?
+6. If there is time, go over some questions to answer from bugs/PRs: (~5m)
+    1. [Intl.RelativeTimeFormat type: numeric/text naming](https://github.com/tc39/proposal-intl-relative-time/issues/54)
+    2. [Should locales support _?](https://github.com/tc39/proposal-intl-locale/issues/7)
+    3. [ISO 4217 vs CLDR default currency digits](https://github.com/tc39/ecma402/issues/134)
+    4. There are several more bugs [in the bug tracker](https://github.com/tc39/ecma402/issues)
+7. Work to do in ICU to support proposals (~5m)
+    1. RelativeTimeFormat [formatToParts](https://ssl.icu-project.org/trac/ticket/13256)
+    2. (possibly) [API for PluralRules supported locales](https://ssl.icu-project.org/trac/ticket/12756)
+    3. Anything more?
+    4. *[srl] ICU-TC Liason? [this was in a mistargetted agenda PR]*
+8. Future (~10m)
+    1. How should we structure these group's work and these meetings in the future?
+    2. Do we want to schedule a follow-on meeting?
+    3. How should we divide up action items among us?
+    4. Minor: Should we propose to become an official task group of TC39, or continue as an ad-hoc group?
+
+# Notes
+
+DE: a quick overview of 402. In the bug tracker there are a lot of new APIs proposed. The goal of this meeting is to figure out the process of moving forward on these proposals and of building agreement between implementations to add new features.
+
+DE: what direction tc39 should go in?
+
+NC: We created a spreadsheet which outlines APIs built into Google Closure some of which we’d like to propose to 402.
+
+DE: The proposals currently before tc39: Segmenter (refinement over Intl.v8BreakIterator)
+
+NC: might be much easier to refer to the Unicode standard.
+
+SRL: standards specifically mention [customization of breaking](https://www.unicode.org/reports/tr14/#Customization). There’s breaking that’s not specific to any language. And then there’s custom breaking which can provide [tailoring](https://unicode.org/reports/tr29/#Tailoring) to breaking. Having these customization does not mean an implementation is non-standard.
+
+DE: why don’t we go through the implementor’s intent for #3 on the agend (formatToParts, PluralRules, hourCycle)
+
+JH (?): (of Chakra impl) formatToParts is pretty straightforward. hourCycle seems more complex. If you specify hourTwelve to be false, how does it interact with -u-hc-h12? (I’m not sure I captured that right)
+
+ZB: Mozilla has a concern about the size increase related to implementing Segmenter. Segmenter adds ~3 MB to the bundle size, which is a 100% increase over the rest of Intl.
+
+JS: It’s 800K without zh/ja dictionaries but with Khmer/Burmese/Lao/Thai dictionaries.
+
+SRL, NC: can we drop Mozilla’s current impl to save some space?
+
+ZB: we have an incomplete impl, with some tables, but it wouldn’t save us a lot. Android doesn’t expose its tables, so we can’t use it. We might be able to save around 300 KB by dropping the old impl.
+
+JS: Chrome on Android doesn’t ship with Chinese and Japanese dictionaries to save space. Khmer dictionary can be further optimized to save ~ 100kB more.
+
+SRL: extended grapheme clusters [are locale-dependent](https://unicode.org/cldr/trac/ticket/2992).
+
+CP: let’s take this offline
+
+DE: ListFormat. Join items with commas and prepositions. Stage 2 in TC39. I’m proposing it for Stage 3 at the next meeting. We try to get most of the design question out of the way by Stage 3. Stage 3 is pretty stable and means that we’ve figured out most of the details by now.
+
+CP: from the editorial POV, this one seems very strong. No objection to move forward.
+
+ZB: I implemented a polyfill using data from CLDR. It’s ~5 patterns per language. A very lightweight API. It shows up a lot in combination with UnitFormat. I also proposed an extension of NumberFormat which is aware of units, rather than UnitFormat.
+
+DE: we were going to propose RelativeTimeFormat for Stage 3. It includes formatToParts but there’s no ICU support for that right now.
+
+ZB: RTF is a very lightweight API, ~8 patterns per language. I implemented it for SpiderMonkey.
+
+JS: it should be more than 8 because of plurals
+
+ZB: you’re right, it’s 8 * plural categories per language
+
+Doug: we need the ICU support to implement this
+
+DE: it should be possible to do via an ICU extension. Should we recommend RTF for Stage 3?
+
+CP: hopefully we can get it in
+
+DE: let’s move on to less advanced proposal. UnitFormat. One option is to do something similar to the ICU API. But it’s not compositional with units. It just takes just a few types of units.
+
+SRL: Shane  has a different proposal. A new API which follows the fluent API style (easy chaining of methods).
+
+DE: Zibi also proposed additional DateTime options
+
+ZB: options bag passed to the constructor make sense but might not make sense for higher-level API. In most cases users want simple "short", “long”, “normal”. Operating Systems also allow users to customize the pattern (skeleton?). dateStyle: short, timeStyle: short would be shortcut options for expressing the user’s general intent. We could also look into the OS settings and check for any customizations and apply them to the pattern when these options are present.
+
+J: it was part of the original proposal but we dropped in favor of the options bag.
+
+SRL: from the user’s perspective, there might be more valid settings than the standard four.
+
+ZB: these prefs could be made locale-sensitive, as in, dateStyle: short might mean month: short in language A, and month: 2-digit in language B.
+
+DE: navigator.locales could expose OS’s calendar prefs (something navigator.languages doesn’t expose)
+
+DE: Intl.Locale API makes an update that corresponds to lang tag and options You can parse out the script or change the calendar and pass it to other Intl ctors. 
+
+NC: it feels like it combines two separate things: locales and user preferences.
+
+DE: that’s the role of navigator.locales.
+
+SRL: user preferences are expressed as locales (-u extensions). We need to answer two questions: What is the locale the user is expecting? What are the customizations to that locale?
+
+DE: I’d like to talk about scheduling future meetings. Does the current format work?
+
+NC: face to face would be more useful. But this works as well and is probably the best we can do for now.
+
+DE: maybe we can have a few calls like this and then see about scheduling a face to face meeting
+
+NC: once a month.
+
+Microsoft and Mozilla agree.
+
+NC: schedule a 402 meeting a week (or a few days) before the next TC39 meeting (which happen every 3 months)
+
+CP: there’s only one more TC39 meeting before the next release is cut. Let’s try to focus on proposals which can be moved to Stage 4 (and maybe stage 3).
+
+Doug: the agenda is pretty dense. Maybe try to have fewer items. Maybe collect feedback on it prior to the meeting.
+

--- a/meetings/notes-2018-01-19.md
+++ b/meetings/notes-2018-01-19.md
@@ -1,0 +1,237 @@
+Agenda: [https://github.com/tc39/ecma402/blob/master/meetings/agenda-2018-01-19.md](https://github.com/tc39/ecma402/blob/master/meetings/agenda-2018-01-19.md)
+
+Attendees:
+
+* Caridy Patino (CP) - 
+* Zbignew Braniecki (ZB) - Mozilla - 
+* Daniel Ehrenberg (DE)  - Igalia - github.com/littledan 
+* Stas Malolepszy (SM)
+* Jungshik Shin (JS) - Google - github.com/jungshik
+* Steven R. Loomis (SL) - IBM - github.com/srl295
+* Eemeli Aro (EA) - github.com/eemeli
+* Nebojsa Ciric (NC) - Google 
+* Shane Carr (Shane) - Google 
+* JH: Jack Horton (MSFT) github.com/jackhorton
+* DIV: Doug Ilijev (MSFT) github.com/dilijev
+* BT: Brian Terlson (MSFT) github.com/bterlson
+* AA: Axel Andrejs (MSFT)
+* JG: Jeff Genovy (MSFT)
+
+1. Introduce meeting
+    1. Agenda priority: Discuss proposals which are furthest along in standardization first
+    2. The greatest need for feedback for committee process is the proposals for advancement to Stage 3 (4. below); however, first review the new "finished" standards.
+2. ECMA 402, 2018 edition
+    1. [formatToParts](https://github.com/tc39/ecma402/issues/47)
+        * For DateTimeFormat and NumberFormat
+        * Template for future proposals
+        * Stage 4
+        * Implemented and shipped in Chrome and Firefox
+        * Standardized in 2017 edition (DateTimeFormat) and standardizing 2018 edition (NumberFormat)
+        * Any concerns?
+            * DIV: NumberFormat formatToParts is exposed as "draft" in ICU 60, so it’s not exposed in the Windows ICU API, which only exposes stable things. Plan is to expose it as Stable in ICU 61.
+            * SL: You could also just pull [the implementation](http://bugs.icu-project.org/trac/ticket/12684). Maybe we should discuss this offline further with MS ICU people to make it available earlier.
+            * ZB: Are you concerned about putting it in the 2018 edition before you’re able to ship it?
+            * JH: I think it’s reasonable to say that we can ship it later, though I can’t make promises for what we will ship.
+            * DIV: The [MSFT] ICU team in general is hesitant about specifying an unstable API for use here.
+            * ZB: The specification doesn’t specifically mention the API
+            * SL: The ICU API is following the request here and marking this stable. The ICU API came as a response to this request from the ECMA specification.
+            * ZB: OK, ICU 61 is coming out in March, seems like this is good to go.
+    2. [PluralRules](https://github.com/tc39/proposal-intl-plural-rules)
+        * Stage 4
+        * Implemented and shipped in Chrome and Firefox
+        * Standardizing in 2018 edition
+        * Should ICU support [an API for getting the supported locales](https://ssl.icu-project.org/trac/ticket/12756) or should ICU users assume all locales are supported?
+        * Any concerns?
+            * CP: This is a new API merged into the specification.
+            * ZB: Six years since we added a new constructor in ECMA 402!
+            * EA: How is the polyfill?
+            * ZB: Seems like this would be useful in Intl.js
+            * NC: Does PluralRules enable us to do message formatting any way we want until we get actual message formatting
+            * JS: Any plural-related things, lets you select the message. Doesn’t include the message.
+            * ZB: Everything on top of PluralRules is just an algorithm, so hopefully this reduces the load of any 
+            * EA: The data is small here
+            * NC: Seems like this 
+            * DE: Is there a way to get the list of availableLocales for plural rules? 
+            * EA: Seen a locale with Cardinal rules but without Ordinal Rules
+            * SL: can assume that  if ‘locale’ data (e.g. for formatting) is available for a given locale, PR is also available for the locale.
+            * SM: Firefox ships or is preparing to ship in 19 locales which don't have plural rules defined in the CLDR. These are: ach, an, cak, csb, gn, hto, ia (Interlingua), kok, lij, ltg, mai, oc, pbb, qvi, rw, sat, son, trs, tsz.
+            * SL: Can you make sure these issues are raised to CLDR?
+            * ZB: Mozilla will upstream the plural rules for those 19
+            * SM: I’ll check if we’ve already submitted tickets.
+    3. [hourCycle](https://github.com/tc39/ecma402/pull/135)
+        * Landed as a pull request (no stages)
+        * Standardizing in 2018 edition
+        * [PR out for review](https://github.com/tc39/ecma402/pull/204) -- minor tweak for resolved locale
+        * Any concerns?
+            * Implemented and shipped in Firefox
+            * JH: Implemented in ChakraCore but not released yet
+            * OK, no more concerns
+    4. Small changes
+        * [Normative: Add calendar and numberingSystem options](https://github.com/tc39/ecma402/pull/175)
+            * Add two things to the option bag that are present in locale tags
+            * TC39 agreed to the change
+            * Any concerns?
+                1. NC: There was an ICU problem previously
+                2. JS: The ICU problem should be resolved
+                3. ZB: We discussed this in the bug tracker with several people; it seemed uncontroversial
+                4. SL: Gotcha in ICU: You can’t change these settings on the fly, but it has to be in the constructor. This is a long-standing feature now
+                5. JS: Maybe we should add a feature to ICU to change the calendar on the fly
+                6. SL: This feature request doesn’t seem appropriate to me.
+        * [Normative: Apply TimeClip in PartitionDateTimePattern](https://github.com/tc39/ecma402/pull/194)
+            * Throw RangeError for dates which are invalid by being too large or small
+            * Aligns with Date without adding complexity
+            * Test262 tests; implemented in Firefox 59
+            * Any concerns?
+                7. Seems good
+        * [Make LocalTZA take 't' and 'isUTC' and drop DSTA(t)](https://github.com/tc39/ecma262/pull/778)
+            * Date semantics tweaks for timezones
+            * Timezone offset is dependent on the current time, matching reality
+            * Define particular semantics for repeated times due to DST
+            * Implementation out for review in V8
+            * Merged into ECMA 262, slated for ES2018
+                8. JS: Previous specification assumes that the local timezone offset doesn’t change over time. But, this is not accurate; several time zones have had their base change over time. The current specification makes it impossible to properly handle historical dates. There’s a V8 implementation out for review, using the ICU API. I think other implementations can do the same.
+                9. NC: Do we carry the historical timezone data?
+                10. JS: Yes. Actually we had some historical Mozilla test that we had to disable since it expected the spec semantics.
+                11. DE: I’m not sure if OS semantics support this, as opposed to using ICU. Many JS implementations currently use OS APIs.
+                12. JS: I think the Windows API supports this, but we would’ve had to modify the sandbox to support it. For Linux, it probably is possible, but it would probably require a lot of hooks and duplicating a lot of what ICU does. For that reason, I didn’t other to do it.
+                13. SL: POSIX APIs assume that 
+                14. JS: I have an ICU change request open to change ICU to make this easier to implement.
+                15. ZB: Do implementers have any concerns?
+                16. JH: If this will require an ICU API, we definitely need it to not be internal.
+                17. JS: For Edge, you have two options: If you want to use the Windows API, there is a Windows API that makes it easier to use this.
+                18. SL: This is a long-standing stable ICU API
+                19. JS: But one API that I need to use is marked internal.
+                20. SL: Let’s follow up offline.
+    5. [Data-Driven APIs for formatting](https://github.com/tc39/ecma402/issues/210)
+        * SC: Many libraries are working to extract data from Intl. If we could have a data-driven API, it would be easier to customize
+        * NC: This is a good idea, and this data would always be more useful, but the data format is an open question. We shouldn’t depend on ICU.
+        * SC: We could use UTS 35, or make a new data standard.
+        * CP: None of the formats that are there make forward-compatibility guarantees.
+        * ZB: UTS 35 doesn’t help us too much; none of ECMA 402 depends on this. We’d have to make a lot of changes to the specification, and not make things data-dependent.
+        * SC: If we introduce this, then other specifications could be rephrased in terms of this new data source.
+        * CP: The problem is the stability of UTS 35--we have to make sure that 
+        * DE: Seems like there is still a lot more design work.
+3. Stage 3 proposals
+    1. [Intl.Segmenter](https://github.com/tc39/proposal-intl-segmenter/)
+        * Stage 3
+        * No implementations or test262 tests
+        * Current specification deliberately doesn't specify segmentation algorithm.
+        * Should we switch to requiring UAX 14/29 + unspecified tailoring?
+        * Should we require that HTML line breaking matches Intl.Segmenter breaks?
+        * Discussion
+            * NC: The segmenter is being reworked significantly internally
+            * JS: That’s not relevant here; isn’t the concern the dictionary size? What do we say about CJK?
+            * NC: There’s improvements for reverse iteration, etc.
+            * DE: The specification lets you jump to a random code unit and iterate forwards or backwards; is this too general?
+            * JS: The specification deliberately doesn’t specify the segmentation algorithm. We discussed dictionary size. Chrome on Android dropped the CJK dictionary due to the size concern. V8 on Android is different from V8 on desktop as far as CJK segmentation is concerned. What about Node?
+            * SL: There’s a stripped-down data set by default, and then you can install all the data which includes dictionaries.
+            * DE: So, is unspecified breaking right? And, should we continue to leave the connection to CSS unspecified?
+            * JS: ICU has ‘strict’, ‘loose’ and ‘normal’ from CSS3. Does Ecma want to have those options?
+            * DE: Possible to add them as an option. Currently, there’s no option. 
+            * DE: how about ‘word-break: break-all’?  
+            * JS: This is for latin text in CJK text
+            * SL: There’s a lot of room for improvement here
+            * NC: Internally in Google, there’s a lot of machine learning work going on for segmenters
+            * JS: As far as CJK is concerned, dictionaries are only used for word breaking, not line breaking. Dictionary is required for line and word breaking in Thai,Khmer,Lao,Burmese, but the dictionary is smaller.
+            * NC: Do we handle grapheme breaking in Segmenter or in String?
+            * DE: Grapheme breaking is part of the Segmenter. We have word, grapheme, sentence and line breaking.
+            * NC: Seems like we won’t have perfect support in all locales, but it is reasonable to add this.
+            * JS: For me, line breaking is the most important piece. Word breaking requires dictionary for CJK and SEA; line breaking requires dictionary for just SEA.
+            * NC: So, let’s settle on the API.
+            * DE: No need to advance stages, already at Stage 3. So, should we continue to not specify an algorithm?
+            * NC: It won’t be possible to specify an algorithm.
+            * SL: We could expose the lb tag to specify strictness.
+            * DE: Currently strictness is only supported via the options bag
+            * JS: Seems like we should add this to the locale tag.
+            * SL: There are many other things in locales that could be added
+            * SL: Unicode locale extensions have ‘lb’ (line breaking), ‘wb’ (? word breaking), ss (suppress …), 
+            * SL: If we have those three in the BCP, we should mention them in the specification here. [https://www.unicode.org/repos/cldr/trunk/specs/ldml/tr35.html#UnicodeLineBreakStyleIdentifier](https://www.unicode.org/repos/cldr/trunk/specs/ldml/tr35.html#UnicodeLineBreakStyleIdentifier) [https://www.unicode.org/repos/cldr/trunk/specs/ldml/tr35.html#UnicodeSentenceBreakSuppressionsIdentifier](https://www.unicode.org/repos/cldr/trunk/specs/ldml/tr35.html#UnicodeSentenceBreakSuppressionsIdentifier)
+            * NC: Currently we support lb. Should we support wb and ss? Are they important enough? Some of these seem a little artificial, like ss, which is based on the technology underneath.
+            * SL: I don’t quite follow. Ss specifies an improvement to line breaks using commonly known exceptions.
+            * DE: I’ll open an issue so we can continue to discuss these options in GitHub.
+4. Proposals for advancement to Stage 3
+    1. [Intl.RelativeTimeFormat](https://github.com/tc39/proposal-intl-relative-time)
+        * Stage 2
+        * [Intl.RelativeTimeFormat type: numeric/text naming](https://github.com/tc39/proposal-intl-relative-time/issues/54)
+        * [ICU support](https://ssl.icu-project.org/trac/ticket/13256) for RelativeTimeFormat.prototype.formatToParts?
+        * API: Similar to ICU, create a formatter, then use it with a particular unit. No built-in algorithm for choice of unit. [PR](https://github.com/tc39/proposal-intl-relative-time/pull/18)
+        * Aesthetics: Unit is passed as a string, accepted in either singular or plural [Bug](https://github.com/tc39/proposal-intl-relative-time/issues/40)
+        * Omitted features: Capitalization context, days of the week, compound uni
+        * Ready for Stage 3?
+            * NC: Does this make "32 days ago" into “one month and two days ago”
+            * DE: compound unit is not supported. Earlier draft supported it, but it was removed due to design issues.
+            * JS: future plan for compound unit?
+            * DE: We could do this in a future version, but there are many policy choices, so it is complicated. List format over RelativeTF is an option.
+            * NC: Does this work 
+            * DE: What should we do about type: numeric/text, which has numeric as the default?
+            * JS: What’s the motivation?
+            * DE: You don’t know which is the right cutoff unless you know what time of day it is, etc. You don’t have the timeline that this is relative to.
+            * CP: Depending how you do the computation, you may decide tomorrow or in one day, but the default needs to be numeric.
+            * NC: Even with numeric, you have the problem of what to do in timezone changes.
+            * DIV: When I saw this option, when I saw "type: numeric" I thought I’d be getting a number back.
+            * CP: This is one concern of mine; we’ve been bikeshedding.
+            * SL: I’ve thought of numeric as based on an interval, rather than an numeric.
+            * NC: Is it right for numeric to be the default?
+            * DIV: I think numeric should be the default.
+            * CP: I think so too. You have to be aware of this issue if you want to get yesterday/tomorrow.
+            * DIV: Speaking of days, can we have "1 day, 1 hour, and 30 seconds ago"?
+            * (reply): can do with [ListFormat](?) + RelativeTimeFormat 
+            * This is a low-level API (similar to PluralRules) on top of which a library writer can implement a smarter (higher-level) API. 
+            * Will present next week (name TBD?)
+    2. [Intl.Locale](https://github.com/tc39/proposal-intl-locale/)
+        * Stage 2
+        * [Should locales support _?](https://github.com/tc39/proposal-intl-locale/issues/7)
+            * DIV: No, underscore is deprecated / part of the old (replaced) RFC!
+            * SC: Why not support the underscore?
+            * SL: In ICU, you have an API to convert ICU-locale id  to BCP 47 language tag (toLanguageTag) , but conversion is more than replacing ‘_’ with ‘-’ (they’re different locale id systems). There are also Windows locale APIs.
+            * JS: Yes, it should be explicit.
+            * Conclusion: Not supported.
+        * [Will not throw an exception on unsupported locales](https://github.com/tc39/proposal-intl-locale/issues/6)
+            * NC: We were talking about possible additional data packs. This allows working with the locale ID. We don’t have any data, but we have a working BCP 47 ID. If it goes into date formatter, date formatter will 
+        * [Should additional tags be passed through?](https://github.com/tc39/proposal-intl-locale/issues/4)
+            * SL: Should be able to round-trip, though it’s OK to sort the tags and normalize the locale.
+        * OK to ship this as a minimal base, with other important complements (likely subtags, display names, more options) in follow-on proposals?
+            * We may also want to add more things to read data from the locale
+            * NC: We could add a get value for key operation. I’ll try to propose something early enough; otherwise, propose it for Stage 3 without that.
+            * JS: Should we restrict this to the u subtag, or allow more?
+            * SL: This is a little complicated, with all the namespaces. ‘-u’ extension has ‘key-value’ semantics, but other extensions do not necessarily. Need to read BCP 47 spec more carefully.
+        * Ready for Stage 3?
+        * DE: Interface to BCP 47. Identify script, region, language, etc from a given locale id. Has toString() to build a locale id in a string
+        * DE: future extension for likelySubtag, etc
+        * When Locale is passed to Intl.* API,  should Locale be treated specially instead of invoking toString() ? 
+        * DE: Yes
+    3. [Intl.ListFormat](https://github.com/tc39/proposal-intl-list-format)
+        * Stage 2
+        * [List elements are not formatted; non-strings throw](https://github.com/tc39/proposal-intl-list-format/issues/4). Seem reasonable?
+            * Sure
+        * Ready for Stage 3?
+            * Styles?
+                21. Currently support unit, and regular ("and")
+                22. NS: Should we rename regular to "and" and add negative lists as “or”?
+                23. DIV: How about we call regular lists "conjunction" and add “disjunction” (linguistic terms rather than english-specific words “and”/”or”)
+                24. ZB: I like this suggestion, since "and" and “or” seems too specific to English
+                25. DIV: There are issues in languages about handling adjectives, etc. 
+                26. ZB: I’m not sure if we’ll support adjectives here.
+                27. NC: Do we need gender information? ListFormat supports this...
+                    1. SL: personList with gender
+                28. ZB: For version 2, we could add gender maybe?
+                29. NC: So, should we add "negative" for the first version?
+                30. ZB: I’d prefer not to, unless you think it makes the API useless.
+                31. SL: What’s the reason for not adding the "or"? Complexity?
+                32. ZB: Actually I was more concerned about genders; this would be OK. But, I’d like help for V2 with figuring out the solution for relative time formats and lists--if anyone interested in this could think about potential solutions.
+                33. NC: I think what we talked about RelativeTimeFormat should handle the data and a future proposal will be more automatic
+                34. ZB: Date ranges handled separately by DateTimeFormat
+                35. JS: This could be somewhat diminishing utility without compound times
+                36. ZB: The most common requirement is single times.
+                37. NC: We might want to change the name to something less friendly
+        * [https://www.unicode.org/repos/cldr/trunk/specs/ldml/tr35-general.html#ListPatterns](https://www.unicode.org/repos/cldr/trunk/specs/ldml/tr35-general.html#ListPatterns)
+5. Future meetings
+    1. Does the two-hour, once a month format work well?
+    2. Feedback about prioritization, running meeting, etc
+    3. Is Feb 16th a good next meeting time?
+        * JS: Put up the actual proposal ahead of time for the next meeting.
+        * NC: At least a week before the meeting
+        * Move the meeting 45 minutes earlier for friendliness for European time
+
+Conclusion: All three proposals good for Stage 3 in TC39
+

--- a/meetings/notes-2018-02-16.md
+++ b/meetings/notes-2018-02-16.md
@@ -1,0 +1,261 @@
+Agenda: [https://github.com/tc39/ecma402/blob/master/meetings/agenda-2018-02-16.md](https://github.com/tc39/ecma402/blob/master/meetings/agenda-2018-02-16.md)
+
+Attendees: Zibi Braniecki, Mozilla (ZB), Caridy Patiño (CP), Brian Terlson (BT), Doug Ilijev (DIV), Jack Horton (JH) Steven R. Loomis (SR), Shane Carr (SC), Jeff Genovy (JG) Felipe (F)
+
+Agenda:
+
+1. TC39 summary
+    1. ECMA 402 2018 edition feature set finalized
+        * [formatToParts](https://github.com/tc39/ecma402/issues/47)
+        * [PluralRules](https://github.com/tc39/proposal-intl-plural-rules)
+        * [hourCycle](https://github.com/tc39/ecma402/pull/135)
+    2. Features reached Stage 3
+        * [ListFormat](https://github.com/tc39/proposal-intl-list-format)
+        * [RelativeTimeFormat](https://github.com/tc39/proposal-intl-relative-time)
+        * [Locale](https://github.com/tc39/proposal-intl-locale)
+    3. [lb option added to Segmenter](https://github.com/tc39/proposal-intl-segmenter/pull/24);[ renamed to lineBreakStyle](https://github.com/tc39/proposal-intl-segmenter/pull/25)
+    4. [Settled on numeric: always/auto](https://github.com/tc39/proposal-intl-relative-time/pull/60)
+    5. [Explained the existence of this call; well-received](https://github.com/tc39/tc39-notes/blob/master/es8/2018-01/jan-23.md#4-ecma402-status-updates)
+    6. Non-members who contribute to ECMA 402 (either PRs or in this call): Sign[ this form](https://tc39.github.io/agreements/contributor/) to license contributions to Ecma
+2. Questions/issues with existing advanced proposals and APIs
+    1. [Normative: Add calendar and numberingSystem options](https://github.com/tc39/ecma402/pull/175)
+        * Should we do validation which throws for these? Is there an ICU API?
+    2. [Segmenter: Should we add all the options (lw, ss), or just lb?](https://github.com/tc39/proposal-intl-segmenter/issues/23)
+        * At the last meeting, it seemed like Steven favorited this change but Jungshik was hesitant
+        * tiebreaker: stay minimal?
+    3. Locale:
+        * [Consider performing complete Unicode extension canonicalization per RFC6067](https://github.com/tc39/proposal-intl-locale/issues/14)
+            * Namely, should we sort and deduplicate all of the extensions (not just the recognized ones)?
+        * [Return DefaultLocale() when calling Intl.Locale() with an absent/undefined tag argument?](https://github.com/tc39/proposal-intl-locale/issues/15)
+        * [Spec questions/errors](https://github.com/tc39/proposal-intl-locale/issues/12)
+            * Do we want to carry forward the optionality of kf and kn?
+            * How are we handling regular and irregular grandfathered tags? (also for the[ main specification](https://github.com/tc39/ecma402/issues/177)) anba's questions
+3. ICU tickets to support existing advanced proposals and APIs
+    1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://ssl.icu-project.org/trac/ticket/13256)
+        * Dan sent an icu-design email; does anyone want to review?
+        * ICU patch wanted
+    2. [RelativeDateTimeFormatter doesn't handle -0 well](http://bugs.icu-project.org/trac/ticket/12936)
+        * ICU patch wanted
+    3. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](http://bugs.icu-project.org/trac/ticket/13268)
+        * Jungshik wrote a patch, anyone want to review?
+        * Was a proposal sent to icu-design? (Dan can't find it)
+    4. [Get locales with PluralRules support](https://ssl.icu-project.org/trac/ticket/12756)
+        * Should we close as will-not-fix because all locales will always be x1considered supported?
+    5. Any other support needed from ICU for Intl proposals?
+4. New proposals
+    1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
+        * Overall thoughts?
+        * What to do with the style option: "deprecate" it (Option 1) or keep it as a first-class citizen (Option 2)?
+        * Where to put the modifiers for units, like the width and compound units: as a top-level setting (Option A) or as a nested object literal on the unit key (Option B)?
+    2. [UnitFormat](https://github.com/tc39/proposal-intl-unit-format) ([bug](https://github.com/tc39/ecma402/issues/32)) (Stage 1)
+        * Still relevant with Shane's proposal?
+        * API suggestions for[ compound units](https://github.com/tc39/proposal-intl-unit-format/issues/2)?
+    3. [Closure i18n features](https://docs.google.com/spreadsheets/d/1WSvi865QADMs6vi6Z91hNauxxx_4cjyzdYPCNyJ_Xgc/edit#gid=0)
+        * Number parsing (Discuss)
+        * Compact decimal format (covered by Shane's proposal)
+        * Scientific format (covered by Shane's proposal)
+        * [IntervalFormat](https://github.com/tc39/ecma402/issues/188)
+            * Should we add .formatRange(date1, date2) to Intl.DateTimeFormat or propose adding a new formatter (Intl.DateIntervalFormat)?
+        * Date time parsing (Discuss)
+        * Unicode BIDI algorithm (Discuss; not in Closure)
+5. Future meetings
+    1. Does the two-hour, once a month format still work well?
+    2. Feedback about prioritization, running meeting, etc
+    3. Is March 16th at 17:15 UTC a good next meeting time? (Note: TC39 is in London March 20-22)
+        * Are we missing out on participation from Asia with these meeting times?
+        * Standing request: Find a time which is not Friday evening in some time zones
+
+Notes:
+
+**Item 1.i:**
+
+ZB: One open issue for me. This table [https://kangax.github.io/compat-table/esintl/](https://kangax.github.io/compat-table/esintl/) is very outdated.
+
+BT: It takes a couple of hours to update the chakra status report.
+
+**Item 1.ii**
+
+ZB: Any comments about those 3 proposals? None
+
+Item 1.iii:
+
+**Item 1.iv:**
+
+ZB: We have merged the update to the numeric option based. Spidermonkey folks don’t like this name, but there is not a counterproposal. I’m fine with this name.
+
+**Item 1.v:**
+
+ZB: We have presented in the tc39 meeting!
+
+**Item 1.vi:**
+
+...
+
+**Item 2.i:**
+
+ZB: Any thoughts on this? Questions is whether or not we should throw with values out of range?
+
+SR: It is very problematic to say what supported actually mean.
+
+ZB: What happen if we try to pass the wrong argument? Any thoughts?
+
+SR: That’s the other design decision.
+
+SC: I’m trying to understand this proposal?
+
+ZB: Calendar and number system are supported as locale extension keys right now. But they are not supported via option bag. I’m ok with not throwing when invalid options are provided.
+
+ZB: we have consensus to match existing behavior of extension keys and options. I will document the consensus.
+
+**Item 2.ii:**
+
+JH: It is definitely a concern if engines start having different data.
+
+SR: Not all scripts are supported in one environment. I know chrome modifies the data heavily.
+
+SR: Maybe we can use an extension pack. It depends on the application.
+
+SR: How does the browser breaks today?
+
+NC: I think we do character break only.
+
+SR: I’m just trying to make a point about the data size.
+
+ZB: ??
+
+SR: This is a newer feature.
+
+ZB: Let’s take this offline. ???
+
+ZB: We are leaning toward SR suggestion.
+
+**Item 2.iii:**
+
+ZB: ...explaining the proposal...
+
+ZB: Any concerns about this?
+
+NC: No.
+
+**Item 2.iii.b:**
+
+ZB: I don’t have strong opinions about this. Different systems allow differnet locale for different intl feature. Using the same locale for all, number, date, plurals, is not always true.
+
+ZB: I think it should throw or an empty option bag.
+
+NC: Is und-c-ca-gregorian useful for anyone? Where do you use that?
+
+SR: Is just default behavior.
+
+NC: No, I’m is this even useful in any case?
+
+SR: It is not great to show it to the glass, but it is going to be consistent when carry on certain operations.
+
+SR: und is root.
+
+JS: better for users to explicitly specify a locale, rather than mysterious default locale showing up automatically
+
+??: 
+
+Conclusion: Throw when a locale isn’t provided.
+
+**Item 2.iii.c**
+
+ZB: 
+
+SR: 
+
+**Item 3 (ICU tickets)**
+
+3.i
+
+SR: we just closed feature freeze for 61.
+
+3.ii:
+
+ZB: This should be a quick fix. Maybe someone from this group wants to take this one.
+
+SR: Shane, is this something that will be changed by your new code?
+
+SR: Lets take it offline, it is just a bug.
+
+3.iii:
+
+JS: There is a more simpler solution here. I will follow up on that. We missed the train for the next ICU release.
+
+SR: Any implementation should not be blocked by ICU.
+
+JS: Even with the current ICU, it is possible to do the right thing.
+
+3.iv:
+
+ZB: any locale that we support have plural rules. Basically, the list of supported languages in plural rules is the same everywhere.
+
+ZB: ICU [does not have a separate ](http://bugs.icu-project.org/trac/ticket/12756)[list](http://bugs.icu-project.org/trac/ticket/12756)[ for locales that support plural rules](http://bugs.icu-project.org/trac/ticket/12756). The assumption is that you can have different data for date, number, etc., but it is not well defined for plural rules.
+
+DI: This sounds like a bug in ICU, and should not affect the spec in any way.
+
+DI: Basically, we have a gentleman's agreement on this!
+
+JH: one other question: I missed section ????
+
+4. (New Proposals)
+
+4.i:
+
+SC: … quick overview… 2min.
+
+ZB: My understanding is that this is a counterproposal for the unit format proposal
+
+SC: yes, this includes unit format on it.
+
+JH: I want to point two things. This relies heavily on ICU design, which MS usually push back. Point two is the the C implementation of these ICU apis is very far away it seems. This might put a serious burden on us.
+
+SC: Yes, there are ICU Apis that maps directly to this new APIs. But this is a 402 spec, we don’t have to model the spec after ICU. 
+
+DIV: We (Chakra) must have non-experimental ICU C (not C++) APIs to implement any of these features. Until experimental tag is removed from those C APIs, we should not allow these proposals to get to stage 4.
+
+ZB: spidermonkey also prefers the C, instead of the C++.
+
+SR: I think this should be a different discussion.
+
+ZB: Concerns about new ICU apis are accurate, but we have a long road ahead.
+
+NC: Another problem: Making one of the options obsolete, vs keeping it around.
+
+CP: We did something very similar in 262 for the class orthogonality analysis and proposal. This proposal, even if it is not adopted, we can use it as a framework for smaller related proposals to have consistency across options, and axis.
+
+Conclusion: few more days of discussions, then a new repo for the stage 0 proposal. We will discuss it in details in next meeting ahead of the tc39 meeting for stage 1.
+
+4.iii:
+
+F: … quick overview … 2min
+
+F: The biggest question I have is whether we should add a new method formatRange to the datetimeformat, or a different constructor.
+
+F: Another questions here is about format to parts for ranges. This will require new ICU APIs.
+
+ZB: general agreement is that any formatting method should have the format to parts counterpart as well.
+
+F: Does this means I should add that one here?
+
+ZB: Yes.
+
+Conclusion: Felipe will prepare the material to present it on the next tc39 meeting.
+
+5.i
+
+NC: the last one worked better.
+
+• looking at overflow: [https://github.com/tc39/ecma402/blob/master/meetings/agenda-2018-02-16.md#overflow](https://github.com/tc39/ecma402/blob/master/meetings/agenda-2018-02-16.md#overflow)
+
+ZB: ovf 1.iv.b - likelySubtags
+
+NC: maximize?  Yes.  (and minimize)
+
+ZB: ovf 1.vi.a: datetime style? 
+
+CP: Organizational…  Will be out 2H2018, need help on editorial role.
+
+SR: FYI,  node Intl WG decommissioned,  new node **[i18**n](https://github.com/nodejs/i18n/) WG with similar charter (and more participation, including l10n) [couldn't talk for some reason]
+

--- a/meetings/notes-2018-03-16.md
+++ b/meetings/notes-2018-03-16.md
@@ -1,0 +1,201 @@
+Agenda link: [https://github.com/tc39/ecma402/blob/master/meetings/agenda-2018-03-16.md](https://github.com/tc39/ecma402/blob/master/meetings/agenda-2018-03-16.md)
+
+Attendees:
+
+	Daniel Ehrenberg
+
+	Steven Loomis (SL)
+
+	Jeff Genovy
+
+	Zibi Braniecki (ZB)
+
+	Craig Cornelius
+
+	Eemeli Aro
+
+	Jack Horton
+
+Nebojsa Ciric (NC)
+
+Jungshik Shin (JS)
+
+Felipe Balbontin (FB)
+
+Agenda and minutes (take notes inline)
+
+1. TC39 summary
+    1. Non-members who contribute to ECMA 402 (either PRs or in this call): Sign [this form](https://tc39.github.io/agreements/contributor/) to license contributions to Ecma
+2. Questions/issues with existing advanced proposals and APIs
+    1. [Normative: Add calendar and numberingSystem options](https://github.com/tc39/ecma402/pull/175)
+        * Resolution from the last meeting: We should validate the shape, but not the actual contents.
+        * Dan working on a test262, V8, spec patches for this.
+        * Notes: Yes, continue with this
+    2. [Segmenter: Should we add all the options (lw, ss), or just lb?](https://github.com/tc39/proposal-intl-segmenter/issues/23)
+        * Data size?
+        * Notes:
+            * Jungshik: Supporting lw supports a lot of things, and ICU doesn’t actually support it. It doesn’t make sense. You need the part of speech marker, etc, not so it’s not so useful for Chinese and Japanese.
+            * Dan: And ss?
+            * Jungshik: Maybe, not sure, but I’m against lw. There are only some exceptions there. There are only 30 entries per language. So it should be pretty small. 
+            * Steven Loomis: This would be useful
+            * Steven: For counting sentences for translation or split up for other purposes, we make use of sentence suppressions to make sure the sentences aren’t split incorrectly.
+            * Jungshik:  Examples are ‘Dr.’, ‘Mr.’, ‘Mrs.’, ‘i.e.’, and so forth.
+            * Ciric: It’s not the greatest system, it’s driven by exceptions, and it’s mostly English.
+            * Steven: Actually it’s statistical
+            * Jungshik: Maybe just turn it on all the time?
+            * Steven: If you turn it off, you don’t have heuristic, so it may be faster, be guaranteed by Unicode rules.
+            * Dan: But we don’t even specify the break algorithm when it’s off
+            * Ciric: How would you know whether to turn it on?
+            * Steven: See the docs. For our own processing, we use it by default. For general use in ICU segmenter, there’s a concern that the performance could be improved. And it does take time, since it has to look at the exceptions, so you can’t just go through the existing finite tree. We’re thinking about JS, but there are discussions here at several levels. So, it can be important to make sure we’re having the discussion at the right levels. What’s the purpose of the ECMA 402 spec? It’s not to describe it.
+            * Jungshik: My concern is that this is too implementation-specific.
+            * Steven: This is a question of whether we want to pass down all the keys.
+            * Dan: We’ve never passed down all the keys in Intl
+            * Zibi: What’s the problem with adding it later?
+            * Steven: OK, sounds like that’s the path forward
+    3. Locale:
+        * [Consider performing complete Unicode extension canonicalization per RFC6067](https://github.com/tc39/proposal-intl-locale/issues/14)
+            * Conclusion was to do the full canonicalization?
+            * Notes: Yes
+            * Jungshik: Are we going to drop an unrecognized value if it is well-formed? No
+        * [Return DefaultLocale() when calling Intl.Locale() with an absent/undefined tag argument?](https://github.com/tc39/proposal-intl-locale/issues/15)
+            * Conclusion was to not make this change and require an argument?
+            * Ciric: The discussion is between making undefined lead to the root locale, or throw an exception. We agreed that we don’t want to expose the default locale here.
+            * Zibi: Intl.Locale is a way of processing locales, not 
+            * Steven: It’d be a convenience, but it might not add much value and blur the distinction between a class responsible for processing data. The Locale should be an identifier, not a service
+            * Dan: Does anyone have a problem with throwing an exception here?
+            * (everyone is OK with it)
+            * Ciric: What happens when you pass something not well-formed, like "1", 2? - throws, not well formatted
+
+            * Conclusion - keep spec as is (throw, don’t return defaults)
+        * [Spec questions/errors](https://github.com/tc39/proposal-intl-locale/issues/12)
+            * Do we want to carry forward the optionality of kf and kn?
+                1. Jack: caseFirst isn’t supported in Windows globalization, as an example of why we may want to leave this as optional. (Also relative time format).
+            * ZB: Raises a larger question of what is mandatory vs what is optional in order to be spec compliant.
+                2. Some impl. may not full set of data and will fall back to ‘en’ for everything. This should (?) still be fully spec compliant.
+                3. Steven asks if Segmenter’s `ss` is an example of something that could be optional
+                    1. Dan says that we shouldn’t increase the surface of optionality if possible
+                4. Dan points out that optionality of hourCycle vs caseFirst uses different mechanisms. 
+                5. We’re going to continue the conversation offline
+            * How are we handling regular and irregular grandfathered tags? (also for the [main specification](https://github.com/tc39/ecma402/issues/177))
+                6. Ciric: Are these just for historical reasons?
+                7. Steven: There are a number of these; they are used. For compatibility, we could replace grandfathered tags. We could not bend over backwards, just support them. We should just map the grandfathered tags into new-style tags.
+                8. Daniel: Seems like this should be added to the Intl.Locale specification if we want to do the mapping.
+                9. Zibi: Grandfathered tags add a lot of complexity to the SpiderMonkey locale implementation. Could we switch to a very simple mapping that takes place at the first step?
+                10. Steven: Historically, grandfathered tags have been used for underserved communities. Java does this forcibly in its constructor, where it forcibly maps locale IDs to something else. I think that’s a bit too aggressive, but just in processing, it’s treated as if the other value were used.
+                11. Ciric: What do we expect in the canonicalized version, that it’ll never be grandfathered? Yes
+                12. Steven: we can vet this list and make it hard-coded. There are a number of sources, but the master is [IANA subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
+                13. Dan: Would apply to all locations that locale is input. We also need test262 tests.
+                14. Steven: I’ll take the lead on this project. Should we do those for deprecated locales also?
+                15. Zibi: Android uses the wrong locale for Hebrew, so this comes up.
+                16. Steven: Java forcibly changes he to iw. So you’ll see iw in Java-related things--that’s Java’s code for it.
+                17. Jungshik: it should be as transparent as possible to customers of the API.
+                18. Sounds like we should handle deprecated tags in the same way
+            * Missing notes from last time
+    4. Intl updates for the Kangax compatibility table? (Zibi)
+3. [ICU tickets](https://ssl.icu-project.org/trac/query?status=!closed&keywords=~ecma) to support existing advanced proposals and APIs
+    1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://ssl.icu-project.org/trac/ticket/13256)
+        * icu-design proposal resent; any feedback? Next steps?
+        * ICU patch wanted
+        * Notes:
+        * Steven: We’ll have to get this [into the meeting](https://docs.google.com/document/d/1YheKc9OHt4AegzB0NeaHo5wTzpS4ia2irqXQSYXSUm0/edit#heading=h.9xjrp1cltuqc) to get consideration. I’ll get in touch with Yoshido.
+        * Myles: Why have this feature?
+        * Zibi: For all new formatters, we add this way to get out the parts, so that it’s possible to format different things differently,
+        * Jungshik: people often try to parse and piece things to without parsing and trying to guess the parts, which is often broken.
+    2. [RelativeDateTimeFormatter doesn't handle -0 well](http://bugs.icu-project.org/trac/ticket/12936)
+        * ICU patch wanted
+        * Ciric: Unfortunately the ICU team has limited bandwidth.
+        * Steven: You added a control for +0,-0?
+        * Shane: That doesn’t have to do with this; we’re talking about NumberFormatting
+        * Zibi: Is this the same problem or a differnet one
+        * Shane: Probably RelativeDateTimeFormatter is using < inappropriately, probably a 2-3 line change
+        * Steven: Is there someone willing to make a patch for this?
+        * We are pinged the owner
+        * Steven: Will add an ECMA bug label/keyword for JS-related things
+    3. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](http://bugs.icu-project.org/trac/ticket/13268)
+        * Jungshik wrote a patch, anyone want to review?
+        * Was a proposal sent to icu-design? 
+        * No. Jungshik will propose. 
+        * Jungshik: Not blocked by this issue, (v8 implementation is pending review)
+    4. [Get locales with PluralRules support](https://ssl.icu-project.org/trac/ticket/12756)
+        * Should we close as will-not-fix because all locales will always be considered supported?
+        * Zibi: PluralRules is part of the seed of any locale
+        * Steven: It’s expected that all locale support PluralRules before being accepted into CLDR
+        * Eemeli: Ordinal too, or just cardinal?
+            * Eemeli: According to CLDR’s [Core Data for New Locales](http://cldr.unicode.org/index/cldr-spec/minimaldata), ordinal rules are "not required, but are strongly recommended".
+    5. Are there any remaining APIs that need to be marked as "stable" or ported to C?
+        * specifically, were there APIs [that did not get promoted to stable in ICU 61 that should have been?](http://source.icu-project.org/repos/icu/tags/release-61-rc/icu4c/APIChangeReport.html)
+            * [items that are still draft](http://source.icu-project.org/repos/icu/tags/release-61-rc/icu4c/APIChangeReport.html#other)
+            * [items that were promoted](http://source.icu-project.org/repos/icu/tags/release-61-rc/icu4c/APIChangeReport.html#promoted)
+        * Jeff: there are some APIs (identified by Jack) slated to be promoted to stable in ICU 61 release.
+            * PSA [please test the release candidate](http://site.icu-project.org/download/61)
+        * Jeff: the majority of timezone APIs are currently C++ only. (getOffset-related) ⇒ **TODO(jungshik)**: file a ticket 
+        * Apple/Microsoft: Can only use ICU C APIs, no C++ API usage at all.
+        * Mozilla also prefers C APIs where possible.
+        * **TODO(Apple/Microsoft/Mozilla)**: Add comments to Shane’s NumberFormat [C API](http://bugs.icu-project.org/trac/ticket/13597) ticket 
+    6. Any other support needed from ICU for Intl proposals?
+        * [Implementers feedback on issues when trying to merge ICU 61 into SpiderMonkey](https://bugzilla.mozilla.org/show_bug.cgi?id=1445465)
+            * proposed to be [fixed in ICU61](http://bugs.icu-project.org/trac/ticket/13648)
+        * Any proposed new API needs a C API, not just a C++ API.
+4. New proposals
+    1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
+        * Status update for this proposal?
+        * How is the [C API](http://bugs.icu-project.org/trac/ticket/13597) coming (necessary for ChakraCore and SpiderMonkey, and JSC)
+        * Overall thoughts?
+        * What to do with the style option: "deprecate" it (Option 1) or keep it as a first-class citizen (Option 2)?
+        * Where to put the modifiers for units, like the width and compound units: as a top-level setting (Option A) or as a nested object literal on the unit key (Option B)?
+        * Notes:
+            * **People generally like top-level better (A)**
+            * Dan: Are there any cases where omitting style is ambiguous? Anyone remember why we put it in earlier?
+            * Shane: No ambiguity
+            * Eemeli: As a library developer, it seems easier and cleaner to have the style argument. The semantics are more like, when I pass a currency, that means, "if a currency is needed, that is X", etc. Otherwise, I’d need to maintain different objects depend on what thing is being formatted, so it’s messier.
+            * Dan: Oh, this seems analogous to Intl.Locale, which might specify more of these kinds of options, e.g., from navigator.locale giving a currency.
+            * Zibi: not doing style would require a lot of diligence
+            * Shane: I don’t know if it’s so bad; including the field is the toggle. If you don’t want to use it, you leave it as undefined.
+            * Zibi: Maybe I want to specify a preference without having a particular choice. With your API, I’d have to actually go and remove some of them.
+            * Jungshik: A better example is distance in meter and currency in USD
+            * Caridy: In TC39, the tendency is, if there’s not a signficant improvement, in ergonomics or technical things, we should stick to the status quo. Does this change bring anything that’s considerably better than what we have right now?
+            * Shane: It’s unintuitive how, right now, if you specify a currency and no style, it’s ignored.
+            * Caridy: It’s not possible to change that behavior today. Going forward, we can decide what we want to do on new features. In addition to being inconsistent, it makes a problem for library authors. Library authors are our target audience, as these APIs are relatively low-level
+            * Shane: In a strict sense, it’s a compatibility issue, but I’m not sure if anyone is running into it. Anyway, I can see how keeping the style attribute makes sense. Here at Google, we have design meetups every couple weeks, and the consensus there was against the style attribute. However, those people don’t have background in ECMA 402 and the history and needs of JS users.
+            * Eemeli: I don’t dislike style. It certainly has good uses for library developers. What is the expected thing to happen when you include currency without style? A middle ground would be to relax what happens when style is undefined.
+            * Dan: I don’t think we can change style: currency due to web compat.
+            * Caridy: I definitely know of several cases that would break
+            * Shane: If we have to keep style: currency, I’d want to do style: measure
+            * Jack: Also, for percent, it’s only indicated by style.
+            * Jungshik: Now we don’t have to worry about any sort of priority 
+            * **Conclusion: Keep style**
+            * **A 2**
+            * Follow up on details about naming once we have a specific draft of the spec
+    2. [IntervalFormat](https://github.com/tc39/ecma402/issues/188) (Felipe)
+        * Status update
+        * Which should be the structure of .formatRangeToParts()'s return value?
+        * Any trouble creating a repository? Feel free to contact Dan for help.
+        * Notes:
+            * Felipe: One question is how to formatRangeToParts should represent tokens which are shared between multiple dates (‘start’ and ‘end’ dates). The current thought is at the top level.
+            * Caridy: When specifying the initial set of formatToParts was that you could do a very simple process to zip through the parts and produce the same output as you get from format. If we do a nested object, it could be a lot more difficult to do the same process.
+            * Felipe: I had the same feeling, so the other option is to not have nesting, and add an additional tag which indicates whether something is one date or the other. People can just ignore that if they don’t care.
+            * Zibi: I can see us doing something similar in NumberFormat, so I’d like to create a pattern we can follow in the future. I’d much rather create an additional field than nesting.
+            * Caridy: This was the original intent. We also need to bikeshed on the name.
+            * **Conclusion: Use the second approach with a flat array, and a new attribute**
+            * Felipe: Additional formatter vs a second method to DateFormat? The set of options for one are valid for others. And this could be a nice pattern for the future (e.g., NumberFormat). So, we talked about it and settled on formatRange.
+            * Shane: I like formatRange as a pattern. Better to keep the number of options smaller.
+    3. [UnitFormat](https://github.com/tc39/proposal-intl-unit-format) ([bug](https://github.com/tc39/ecma402/issues/32)) (Stage 1)
+        * Still relevant with Shane's proposal? : No except for list format.
+        * API suggestions for [compound units](https://github.com/tc39/proposal-intl-unit-format/issues/2) (e.g. 9.8 m/s^2) ? Numberformat supports it.
+        * **Conclusion: folded to be a part of new "unified" Number format**
+        * ** "list number format" (e.g. 10 meters and 35 centimeters): Introduce a list format**
+    4. [BigInt.prototype.toLocaleString](https://github.com/tc39/ecma402/issues/218#issuecomment-370789166)
+        * Dan: overload ‘format’ method with NumberFormat?  ‘String’ is coerced to Number instead of BigInt. 
+5. Future meetings
+    1. Does the two-hour, once a month format still work well?
+    2. Feedback about prioritization, running meeting, etc
+    3. Is April 20th at 17:15 UTC a good next meeting time? (Note: DST may shift the effective time by an hour)
+        * Are we missing out on participation from Asia with these meeting times?
+        * Standing request: Find a time which is not Friday evening in some time zones
+6. Other
+    1. Steven: FYI: Node.js considering including full data by default (not English-only).  [https://github.com/nodejs/node/issues/19214](https://github.com/nodejs/node/issues/19214) Feedback wanted, but relevant to discussion here about data size impact implementations. 
+    2. Steven: Q: seprate C++/C library for common implementation of ecma402 related operations (on top of ICU or ported)? (locale/option bag handling might be interesting)  Pro: common code FTW, don't need to wait for Ecma402-focussed API improvements in ICU.   Con: many implementations are already a thin wrapper on ICU.
+Jeff: What would be the Licensing of such a library? What language(s) for implementation?
+        * Rust? (serious proposal: C/C++ FFI, compiles to WASM and JS)
+        * Steven: It could be proposed as an ICU subproject (MIT/X)
+

--- a/meetings/notes-2018-04-20.md
+++ b/meetings/notes-2018-04-20.md
@@ -1,0 +1,116 @@
+Hangout code: chromium.org/ecma402
+
+Attendees:
+
+	Nebojsa, Daniel, Zibi, ...
+
+Agenda and notes
+
+[https://github.com/tc39/ecma402/blob/master/meetings/agenda-2018-04-20.md](https://github.com/tc39/ecma402/blob/master/meetings/agenda-2018-04-20.md)
+
+1. Administrative issues
+    1. Anyone want to help out with cleaning up and publishing notes for this meeting and past meetings?
+        * Jungshik - we should just publish what we have.
+        * **Conclusion** - Dan will publish what we have as .md files
+    2. Meeting time which is not Friday evening? (Poorly affects at least 3 European attendees)
+        * Daniel - we now have more European potential participants. Can we pick another time?
+        * **Conclusion** - let’s use doodle
+2. Questions/issues with existing advanced proposals and APIs
+    1. [Improve handling of non-Gregorian calendars](https://github.com/tc39/ecma402/pull/227)
+        * Add relatedYear option?
+        * Make pattern set take calendar into account?
+        * Jack - A fuzzer generated this case, and found that Edge and Chrome generated very different results for the Chinese and Dangi (Korean) calendars. There’s some discussion on a [Chrome issue](https://bugs.chromium.org/p/chromium/issues/detail?id=826549), and a 402 issue, and the Edge issue. The spec says that all years are numeric, and there’s just one kind of year and no other concept of year. That seems to not be true for all calendars. How do we handle years, or possibly even other month-like or day-like things, etc
+        * Steven - Where is this in the spec?
+        * Jungshik - The issue here is that, regardless of the pattern, we only use the base locale, regardless of the calendar. The V8 implementation didn’t follow the spec to the letter; we switched it to follow the spec, but actually Jack is right that if the calendar is different, we should do something which uses the calendar and presents the relatedYear
+        * Steven - There are two issues--looking up the pattern based on the calendar, and whether they are all numeric
+        * Jack - And there’s the issue of related year vs year name--both, or neither.
+        * Zibi - Does this work without formatToParts
+        * Jack - It prints something, but it can’t select the right calendar type.
+        * Steven - There are two different issues here
+        * Jungshik - I am not sure about the wisdom of the two-digit year out of the 60-year cycle; that’s not so useful.
+        * Steven - The point of related year is to show something useful, so you can have the emperor era and also 2018. It’s not meant to be the main year.
+            * in ICU, getRelatedYear() - ht[tp://www.icu-project.org/apiref/icu4c/classicu_1_1Calendar.html#a68513c08cf1d338cc6f6e450298d1ec9](www.icu-project.org/apiref/icu4c/classicu_1_1Calendar.html#a68513c08cf1d338cc6f6e450298d1ec9) - relatedyear is calculated based on a delta on the extended year
+        * Jungshik - I believe related year in ICU gives the transliteration of the two chinese characters
+        * Jack - That’s what the year name gives; the related year shows the Gregorian thing
+        * Zibi - Does this scale to other calendars as well?
+        * Jungshik - It seems like it’s limited in the spec on purpose
+        * Daniel - no, it seems more like a mistake
+        * Daniel - Yes Steven, you’re right that there are two unrelated bugs
+        * Daniel - Anyone has issue with us making an editorial change?
+        * Jack - I was confused about what to expect out of the implementation when you ask for a year in chinese calendar, but not for related year.
+        * Daniel - Are we in agreement wrt. This patch? Should we land it and present to the next TC39 meeting?
+        * Daniel - One side was already implemented in V8, the other was not yet, but should be pretty simple.
+        * Jack - I think it’s good
+        * Steven - I think it’s good
+        * **Conclusion** - Land the patch
+    2. [Locale processing edge case](https://github.com/tc39/ecma402/issues/223)
+        * Fix seems clear; go for it?
+        * Steve, Zibi - Seems like a bug to be fixed
+        * **Conclusion** - Fix it
+    3. [Copy PluralCategories in Intl.PluralRules.prototype.resolvedOptions?](https://github.com/tc39/ecma402/issues/224)
+        * We had previously resolved to not copy; consider revisiting due to SpiderMonkey implementation?
+        * Zibi - I’d prefer us to copy
+        * Jack - Edge is creating a new array each time
+        * **Conclusion** - We’ll switch the spec to copy
+    4. [PartitionNumberPattern treats -0 as 0](https://github.com/tc39/ecma402/issues/219) (Jack Horton)
+        * Shane - we always handled it differently
+            * (Steven: ICU history: [http://bugs.icu-project.org/trac/ticket/8333#comment:14](http://bugs.icu-project.org/trac/ticket/8333#comment:14) [http://bugs.icu-project.org/trac/ticket/13551](http://bugs.icu-project.org/trac/ticket/13551) )
+        * Daniel - We should only artificially unify -0 and 0 if we have a reason for that.
+        * Zibi - I agree
+        * **Conclusion** - Agreement on Jack’s proposed change
+        * Discussion - how to test it, Daniel proposes trying to add some test data to test262 and extend from there.
+    5. Next steps on resolution on grandfathered tags from last meeting?
+        * Are ECMA-402 changes needed, or is this only about Intl.Locale?
+        * Zibi - Do we want to put Locale processing for ResolveLocale based on Locale?
+        * Nciric - This may cause observable due to the additional canonicalization
+        * Dan - I don’t think the compatibility impact will be high since this path is already weird and full of bugs
+        * Jungshik - Same thing for getCanonicalLocales
+        * **Conclusion** - Make apply new logic for all changes
+    6. [Intl.Locale issues](https://github.com/tc39/proposal-intl-locale/issues)
+        * [Add Intl.Locale.prototype.baseName](https://github.com/tc39/proposal-intl-locale/issues/22)?
+            * Steven, Nciric - baseName = langtag - extensions
+            * **Conclusion** - Add the getter
+        * [Leave minimize/maximize for v2](https://github.com/tc39/proposal-intl-locale/issues/16)?
+            * **Conclusion** - consider adding it to v1. Daniel will look to add it to the spec. As methods returning a new Intl.Locale (preserving extension keys)
+3. ICU tickets to support existing advanced proposals and APIs
+    1. [API design proposal](http://ssl.icu-project.org/trac/ticket/13256) for Intl.RelativeTimeFormat.prototype.formatToParts accepted with modifications
+        * Is anyone interested in implementing? (Small amount of plumbing code)
+    2. [API design proposal](http://ssl.icu-project.org/trac/ticket/13597) for C API for NumberFormatter accepted with modifications
+        * See below under "NumberFormat changes"
+    3. [unum_formatDoubleForFields will be marked as stable in ICU 61](http://ssl.icu-project.org/trac/ticket/13557)
+    4. Dan to write API design proposals for other formatToParts/timezone functions
+4. New proposals
+    1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
+        * Last meeting, settled on top-level settings, and maintaining style. Any further thoughts?
+        * Status of [C API](http://bugs.icu-project.org/trac/ticket/13597) (necessary for 3 browsers)
+        * Next steps on [proposal repository](https://github.com/sffc/proposal-unified-intl-numberformat)
+        * Shane: I need feedback on the C API and the names for the measures
+        * Names for measures: see [https://github.com/sffc/proposal-unified-intl-numberformat/issues/3](https://github.com/sffc/proposal-unified-intl-numberformat/issues/3)
+        * ICU API Proposal: [https://sourceforge.net/p/icu/mailman/message/36276549/](https://sourceforge.net/p/icu/mailman/message/36276549/)
+            * suggestion: SourceForge flattens the email and removes formatting; click "Message as HTML"
+            * Also see [unumberformatter.h](http://bugs.icu-project.org/trac/browser/branches/shane/numberformat4/icu4c/source/i18n/unicode/unumberformatter.h)
+            * To provide feedback, either reply to the email thread (if you are on the list) or post on [the ICU ticket](http://ssl.icu-project.org/trac/ticket/13597)
+    2. [formatRange/formatRangeToParts](https://github.com/tc39/ecma402/issues/188) (Felipe)
+        * Last meeting, settled on the following. Any further thoughts?
+            * formatRangeToParts returns a flat array, with a new attribute
+            * formatRange/formatRangeToParts as methods on Intl.DateFormat, rather than a new class
+        * Next steps
+    3. [BigInt.prototype.toLocaleString](https://github.com/tc39/ecma402/issues/218#issuecomment-370789166)
+        * Should we overload Intl.NumberFormat.prototype.format to support BigInt? Or a new method?
+        * Conclusion - think more about overloading
+5. Status of existing proposals
+    1. Discuss implementation/test development priorities of existing proposals
+    2. Ms2ger is working on test262 tests
+6. May TC39 meeting plans
+    1. Propose NumberFormat options and formatRange for Stage 1?
+    2. [Draft presentation](https://docs.google.com/presentation/d/1wEkpdxC37t4sk64QThcna8c4753-9Ak1I23LNDmZ9KE/edit#slide=id.p)
+    3. Who wants to deliver the presentation?
+7. Future meetings
+    1. Does the two-hour, once a month format still work well?
+    2. Feedback about prioritization, running meeting, etc
+    3. Is May 18th at 17:15 UTC a good next meeting time?
+        * Are we missing out on participation from Asia with these meeting times?
+        * Standing request: Find a time which is not Friday evening in Europe
+8. Ad-hoc questions from a v8 engineer (Sathya Gunasekaran
+I have a spec question: what should be behavior if the options argument to the Intl.Locale constructor is a proxy? Looking at the other intl methods, we explicitly convert the options argument to an ordinary object: [https://tc39.github.io/ecma402/#sec-todatetimeoptions](https://tc39.github.io/ecma402/#sec-todatetimeoptions) (see the unconditional call to ObjectCreate(options)) Should this be done for Intl.Locale too? 
+NumberFormat doesn't seem to do this https://tc39.github.io/ecma402/#sec-initializenumberformat though ..


### PR DESCRIPTION
The Intl call attendees agreed to publish the notes as is, unedited. We've been collecting them in Google docs during meetings. This PR checks them in as Markdown files.