### PR TITLE
Editorial: Use OrdinaryCreateFromConstructor properly

### DIFF
--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -158,7 +158,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(_newTarget_, %PluralRulesPrototype%, &laquo; [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[PluralCategories]] &raquo;).
+        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%PluralRulesPrototype%"`, &laquo; [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[PluralCategories]] &raquo;).
         1. Return ? InitializePluralRules(_pluralRules_, _locales_, _options_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Editorial fix for PluralRules; should consider backporting to ES2018