### PR TITLE
Normative: Remove stray comma from string in SetNumberFormatDigitOptions().

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -16,7 +16,7 @@
         1. Assert: Type(_options_) is Object.
         1. Assert: Type(_mnfdDefault_) is Number.
         1. Assert: Type(_mxfdDefault_) is Number.
-        1. Let _mnid_ be ? GetNumberOption(_options_, `"minimumIntegerDigits,"`, 1, 21, 1).
+        1. Let _mnid_ be ? GetNumberOption(_options_, `"minimumIntegerDigits"`, 1, 21, 1).
         1. Let _mnfd_ be ? GetNumberOption(_options_, `"minimumFractionDigits"`, 0, 20, _mnfdDefault_).
         1. Let _mxfdActualDefault_ be max( _mnfd_, _mxfdDefault_ ).
         1. Let _mxfd_ be ? GetNumberOption(_options_, `"maximumFractionDigits"`, _mnfd_, 20, _mxfdActualDefault_).


### PR DESCRIPTION
This was added in 94045d234762ad107a3d09bb6f7381a65f1a2f9b.