### PR TITLE
editorial: call UnwrapNumberFormat in NumberFormat.prototype.formatTo…

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -625,7 +625,7 @@
       <emu-alg>
         1. Let _nf_ be the *this* value.
         1. If Type(_nf_) is not Object, throw a *TypeError* exception.
-        1. If _nf_ does not have an [[InitializedNumberFormat]] internal slot, throw a *TypeError* exception.
+        1. Let _nf_ be ? UnwrapNumberFormat(_nf_).
         1. Let _x_ be ? ToNumber(_value_).
         1. Return ? FormatNumberToParts(_nf_, _x_).
       </emu-alg>


### PR DESCRIPTION
…Parts

Call UnwrapNumberFormat in Intl.NumberFormat.prototype.formatToParts in
order to make it more consistent to format and resolvedOptions.

Fixes: https://github.com/tc39/ecma402/issues/274

/cc @gsathya 