### PR TITLE
Normative: Don't harden supportedLocalesOf Array

### DIFF
--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -269,12 +269,7 @@
           1. Let _supportedLocales_ be BestFitSupportedLocales(_availableLocales_, _requestedLocales_).
         1. Else,
           1. Let _supportedLocales_ be LookupSupportedLocales(_availableLocales_, _requestedLocales_).
-        1. Let _subset_ be CreateArrayFromList(_supportedLocales_).
-        1. Let _keys_ be _subset_.[[OwnPropertyKeys]]().
-        1. For each element _P_ of _keys_ in List order, do
-          1. Let _desc_ be PropertyDescriptor { [[Configurable]]: *false*, [[Writable]]: *false* }.
-          1. Perform ! DefinePropertyOrThrow(_subset_, _P_, _desc_).
-        1. Return _subset_.
+        1. Return CreateArrayFromList(_supportedLocales_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
This array has nonwritable, nonconfigurable elements to future-proof
for a path that it doesn't seem like we're planning on going down.
Make it an ordinary Array instead, as suggested by @jakobkummerow.

Closes #258