### PR TITLE
Normative: Permit the use of tailorings in CLDR

### DIFF
--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -65,27 +65,21 @@
         1. Else,
           1. Let _requestedLocale_ be DefaultLocale().
         1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with all Unicode locale extension sequences (<emu-xref href="#sec-unicode-locale-extension-sequences"></emu-xref>) removed.
-        1. Let _availableLocales_ be a List with the language tags of the languages for which the Unicode character database contains language sensitive case mappings.
+        1. Let _availableLocales_ be a List with the language tags of the languages for which the Unicode Character Database or CLDR contains language sensitive case mappings.
         1. Let _locale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
         1. If _locale_ is *undefined*, let _locale_ be `"und"`.
         1. Let _cpList_ be a List containing in order the code points of _S_ as defined in ES2019, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, starting at the first element of _S_.
-        1. For each code point _c_ in _cpList_, if the Unicode Character Database provides a lower case equivalent of _c_ that is either language insensitive or for the language _locale_, replace _c_ in _cpList_ with that/those equivalent code point(s).
-        1. Let _cuList_ be a new empty List.
-        1. For each code point _c_ in _cpList_, in order, append to _cuList_ the elements of the UTF-16 Encoding (defined in ES2019, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) of _c_.
+        1. Let _cuList_ be a List where the elements are the result of toLowercase(_cpList_), according to a tailored version of the Unicode Default Case Conversion algorithm, with tailorings based on _locale_ take into account based on data in SpecialCasings.txt and/or CLDR, per the Unicode Standard 3.13.
         1. Let _L_ be a String whose elements are, in order, the elements of _cuList_.
         1. Return _L_.
       </emu-alg>
 
       <p>
-        The result must be derived according to the case mappings in the Unicode character database (this explicitly includes not only the UnicodeData.txt file, but also the SpecialCasings.txt file that accompanies it).
+        The result must be derived according to the case mappings in the Unicode Standard. (This explicitly includes not only the UnicodeData.txt file, but also the SpecialCasings.txt file that accompanies it, as well as any tailorings from CLDR.)
       </p>
 
       <emu-note>
-        As of Unicode 10.0, the _availableLocales_ list contains the elements `"az"`, `"lt"`, and `"tr"`.
-      </emu-note>
-
-      <emu-note>
-        The case mapping of some code points may produce multiple code points. In this case the result String may not be the same length as the source String. Because both *toLocaleUpperCase* and *toLocaleLowerCase* have context-sensitive behaviour, the functions are not symmetrical. In other words, *s.toLocaleUpperCase().toLocaleLowerCase()* is not necessarily equal to *s.toLocaleLowerCase()*.
+        The case mapping of some code points may produce multiple code points. In this case the result String may not be the same length as the source String. Because both `toLocaleUpperCase` and `toLocaleLowerCase` have context-sensitive behaviour, the functions are not symmetrical. In other words, `s.toLocaleUpperCase().toLocaleLowerCase()` is not necessarily equal to `s.toLocaleLowerCase()`.
       </emu-note>
 
       <emu-note>
@@ -102,7 +96,7 @@
       </p>
 
       <p>
-        This function interprets a string value as a sequence of code points, as described in ES2019, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. This function behaves in exactly the same way as `String.prototype.toLocaleLowerCase`, except that characters are mapped to their _uppercase_ equivalents as specified in the Unicode character database.
+        This function interprets a string value as a sequence of code points, as described in ES2019, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. This function behaves in exactly the same way as `String.prototype.toLocaleLowerCase`, except that characters are mapped to their _uppercase_ equivalents as specified in the Unicode Character Database, SpecialCasing.txt and CLDR.
       </p>
 
       <emu-note>


### PR DESCRIPTION
Apparently there was never a deliberate decision to omit these
tailorings, but the specification was written back when all tailorings
were in SpecialCasings.txt. The new spec text permits looking at CLDR
as well, matching the Unicode Standard.

Closes #287