### PR TITLE
Ref UTS35 in IsStructurallyValidLanguageTag

### DIFF
--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -51,7 +51,7 @@
       </ul>
 
       <p>
-        The abstract operation returns true if _locale_ can be generated from the ABNF grammar in section 2.1 of the RFC, starting with Language-Tag, and does not contain duplicate variant or singleton subtags (other than as a private use subtag). It returns false otherwise. Terminal value characters in the grammar are interpreted as the Unicode equivalents of the ASCII octet values given.
+        The abstract operation returns true if _locale_ can be generated from the ABNF grammar in section 3.2 of the Unicode Technical Standard 35, or successor, starting with unicode_locale_id, and does not contain duplicate variant or singleton subtags (other than as a private use subtag). It returns false otherwise. Terminal value characters in the grammar are interpreted as the Unicode equivalents of the ASCII octet values given.
       </p>
     </emu-clause>
 


### PR DESCRIPTION
Additional changes to make IsStructurallyValidLanguageTag follow the UTS35 check (which is more restrict) instead of the RFC.

Sorry, I think I missed this item when I reviewed #289.

@littledan @anba @zbraniecki @gsathya 