### PR TITLE
Bump es2019

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 after_success:
   - ./scripts/auto-deploy.sh
-
 env:
   global:
     - secure: "bXOdBl0KXFzjzlm2+tfzay/hPQGNVMVbb7JlMKxdQdwAovq4w/npw6yHgH5vbGT+m2RuhFwv17+3oaPrHVNwKNWhBPKEDxW0AYe2XmN9rzUHoW9AcqPMc7jMfJrmueENnBjwRCkkJi1smI8dY/1LW4vNTm2RNI3Lt1m9fOqsXJo="
-
 language: node_js
-
 node_js:
-  - "8"
-
+  - "10"
 sudo: false

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "ecma402",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "ECMAScript Internationalization API Specification",
   "scripts": {
-    "build-es2018": "git remote remove origin && git remote add origin \"git@github.com:$TRAVIS_REPO_SLUG.git\" && git fetch --quiet origin && git checkout --quiet es2018 && mkdir \"out/2018\" && cp -R img \"out/2018\" && ecmarkup --verbose spec/index.html out/2018/index.html --css out/2018/ecmarkup.css --js out/2018/ecmarkup.js",
+    "build-es2019": "git remote remove origin && git remote add origin \"git@github.com:$TRAVIS_REPO_SLUG.git\" && git fetch --quiet origin && git checkout --quiet es2019 && mkdir \"out/2019\" && cp -R img \"out/2019\" && ecmarkup --verbose spec/index.html out/2019/index.html --css out/2019/ecmarkup.css --js out/2019/ecmarkup.js",
     "build-master": "mkdir out && cp -R img out && ecmarkup --verbose spec/index.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
     "build": "npm run clean && npm run build-master",
-    "build-travis": "npm run clean && npm run build-master && npm run build-es2018",
+    "build-travis": "npm run clean && npm run build-master && npm run build-es2019",
     "clean": "rm -rf out",
     "test": "exit 0",
     "watch": "npm run clean && mkdir out && cp -R img out && ecmarkup --watch --verbose spec/index.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js"

--- a/spec/introduction.html
+++ b/spec/introduction.html
@@ -30,4 +30,8 @@
     Caridy Patiño<br>
     ECMA-402, 3<sup>rd</sup>, 4<sup>th</sup> and 5<sup>th</sup> Editions Project Editor
   </p>
+  <p>
+    Caridy Patiño, Daniel Ehrenberg, Leo Balter<br>
+    ECMA-402, 6<sup>th</sup> Edition Project Editors
+  </p>
 </emu-intro>

--- a/spec/metablock.html
+++ b/spec/metablock.html
@@ -7,12 +7,19 @@
     <li>Issues: <a href="https://github.com/tc39/ecma402/issues">All Issues</a>, <a href="https://github.com/tc39/ecma402/issues/new">File a New Issue</a></li>
     <li>Pull Requests: <a href="https://github.com/tc39/ecma402/pulls">All Pull Requests</a>, <a href="https://github.com/tc39/ecma402/pulls/new">Create a New Pull Request</a></li>
     <li>Test Suite: <a href="https://github.com/tc39/test262">Test262</a></li>
-    <li>Editor: Caridy Patiño (<a href="mailto:caridy at gmail dot com">E-mail</a>, <a href="https://twitter.com/caridy">Twitter</a>, <a href="https://github.com/caridy">GitHub</a>)</li>
+    <li>Editors:
+      <ul>
+        <li><a href="mailto:caridy at gmail dot com">Caridy Patiño</a> (<a href="https://twitter.com/caridy">@caridy</a>)</li>
+        <li><a href="mailto:littledan at igalia dot com">Daniel Ehrenberg</a> (<a href="https://twitter.com/littledan">@littledan</a>)</li>
+        <li><a href="mailto:leonardo.balter at gmail dot com">Leo Balter</a> (<a href="https://twitter.com/leobalter">@leobalter</a>)</li>
+      </ul>
+    </li>
     <li>
       Community:
       <ul>
         <li>Mailing list: <a href="https://esdiscuss.org">es-discuss</a></li>
         <li>IRC: <a href="ircs://irc.freenode.net:6667">#tc39</a> on <a href="https://freenode.net/kb/answer/chat">freenode</a></li>
+        <li>IRC: <a href="ircs://irc.freenode.net:6667">#tc39-ecma402</a> on <a href="https://freenode.net/kb/answer/chat">freenode</a></li>
       </ul>
     </li>
   </ul>


### PR DESCRIPTION
The Release Candidate for the ES2019 Edition is at https://github.com/tc39/ecma402/tree/es2019

This PR has the same commits but the one adding the Release Candidate status, following the style I've identified for es2018.

I should follow up with the proper bumps to set es2020