### PR TITLE
Editorial: Prefer ssl links over regular http

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@ There are a number of ways to contribute to ECMA402. How to actually contribute 
 
 Ecma TC39 accepts contributions from non-member individuals who have accepted the TC39 copyright and patent policies. Currently all ECMAScript related technical work is done by the TC39 RF TG (Royalty Free Task Group), for which the following IPR Policies apply:
 
-  * [Ecma International RF Patent Policy](http://www.ecma-international.org/memento/Policies/Ecma_Royalty-Free_Patent_Policy_Extension_Option.htm)
-  * [Ecma International Software Copyright Policy](http://www.ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.htm) ([PDF](http://www.ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.pdf))
+  * [Ecma International RF Patent Policy](https://www.ecma-international.org/memento/Policies/Ecma_Royalty-Free_Patent_Policy_Extension_Option.htm)
+  * [Ecma International Software Copyright Policy](https://www.ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.htm) ([PDF](https://www.ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.pdf))
 
 #### Bug Reports & Bug Fixes
 File a bug or pull requests against the current text of ECMA402 in this repository. If the fix is trivial you may not need to sign the CLA. If your fix is involved, signing the CLA will be required.
@@ -13,11 +13,11 @@ File a bug or pull requests against the current text of ECMA402 in this reposito
 Feature requests for future versions of ECMA402 should be made in this repository by creating a new issue. Your goal will be to convince others that your proposal is a useful addition to the language and recruit TC39 members to help turn your request into a proposal and shepherd it into the language.
 
 #### Proposals
-If you have a new proposal you want to get into the language, you first need a TC39 champion. Head to [es-discuss](http://esdiscuss.org) to find one. If you already have a TC39 champion, send a pull request to add a link to your proposal to the Current Proposals list or the stage zero list.
+If you have a new proposal you want to get into the language, you first need a TC39 champion. Head to [es-discuss](https://esdiscuss.org) to find one. If you already have a TC39 champion, send a pull request to add a link to your proposal to the Current Proposals list or the stage zero list.
 
 ### Signing the CLA
 If you wish to submit a proposal and are not a representative of a TC39 member, here are the steps you need to take:
 
   1. Read the [TC39 process document](https://tc39.github.io/process-document/).
-  2. [Register as a TC39 contributor](http://www.ecma-international.org/memento/register_TC39_Royalty_Free_Task_Group.php) (it is not necessary to submit the contribution as attachment to the form)
+  2. [Register as a TC39 contributor](https://tc39.github.io/agreements/contributor/) (it is not necessary to submit the contribution as attachment to the form)
   3. Submit a pull request here for your strawman proposal.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ECMAScript Internationalization API Specification (Ecma-402)
 
 This repository contains the source for the current draft of ECMA-402, the ECMAScript® Internationalization API Specification.
 
-This source is processed to obtain a human-readable version, which you can view [here](http://tc39.github.io/ecma402/).
+This source is processed to obtain a human-readable version, which you can view [here](https://tc39.github.io/ecma402/).
 
 ## Current Proposals
 

--- a/meetings/agenda-2018-01-19.md
+++ b/meetings/agenda-2018-01-19.md
@@ -21,7 +21,7 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
         - Stage 4
         - Implemented and shipped in Chrome and Firefox
         - Standardizing in 2018 edition
-        - Should ICU support [an API for getting the supported locales](https://ssl.icu-project.org/trac/ticket/12756) or should ICU users assume all locales are supported?
+        - Should ICU support [an API for getting the supported locales](https://unicode-org.atlassian.net/browse/ICU-12756) or should ICU users assume all locales are supported?
         - Any concerns?
     1. [hourCycle](https://github.com/tc39/ecma402/pull/135)
         - Landed as a pull request (no stages)
@@ -56,7 +56,7 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
     1. [Intl.RelativeTimeFormat](https://github.com/tc39/proposal-intl-relative-time)
         - Stage 2
         - [Intl.RelativeTimeFormat type: numeric/text naming](https://github.com/tc39/proposal-intl-relative-time/issues/54)
-        - [ICU support](https://ssl.icu-project.org/trac/ticket/13256) for RelativeTimeFormat.prototype.formatToParts?
+        - [ICU support](https://unicode-org.atlassian.net/browse/ICU-13256) for RelativeTimeFormat.prototype.formatToParts?
         - API: Similar to ICU, create a formatter, then use it with a particular unit. No built-in algorithm for choice of unit. [PR](https://github.com/tc39/proposal-intl-relative-time/pull/18)
         - Aesthetics: Unit is passed as a string, accepted in either singular or plural [Bug](https://github.com/tc39/proposal-intl-relative-time/issues/40)
         - Omitted features: Capitalization context, days of the week

--- a/meetings/agenda-2018-02-16.md
+++ b/meetings/agenda-2018-02-16.md
@@ -34,15 +34,15 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
             - How are we handling regular and irregular grandfathered tags? (also for the [main specification](https://github.com/tc39/ecma402/issues/177))
 anba's questions
 1. ICU tickets to support existing advanced proposals and APIs
-    1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://ssl.icu-project.org/trac/ticket/13256)
+    1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://unicode-org.atlassian.net/browse/ICU-13256)
         - Dan sent an icu-design email; does anyone want to review?
         - ICU patch wanted
-    1. [RelativeDateTimeFormatter doesn't handle -0 well](https://ssl.icu-project.org/trac/ticket/12936)
+    1. [RelativeDateTimeFormatter doesn't handle -0 well](https://unicode-org.atlassian.net/browse/ICU-12936)
         - ICU patch wanted
-    1. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://ssl.icu-project.org/trac/ticket/13268)
+    1. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://unicode-org.atlassian.net/browse/ICU-13268)
         - Jungshik wrote a patch, anyone want to review?
         - Was a proposal sent to icu-design? (Dan can't find it)
-    1. [Get locales with PluralRules support](https://ssl.icu-project.org/trac/ticket/12756)
+    1. [Get locales with PluralRules support](https://unicode-org.atlassian.net/browse/ICU-12756)
         - Should we close as will-not-fix because all locales will always be considered supported?
     1. Any other support needed from ICU for Intl proposals?
 1. New proposals

--- a/meetings/agenda-2018-02-16.md
+++ b/meetings/agenda-2018-02-16.md
@@ -37,9 +37,9 @@ anba's questions
     1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://ssl.icu-project.org/trac/ticket/13256)
         - Dan sent an icu-design email; does anyone want to review?
         - ICU patch wanted
-    1. [RelativeDateTimeFormatter doesn't handle -0 well](http://bugs.icu-project.org/trac/ticket/12936)
+    1. [RelativeDateTimeFormatter doesn't handle -0 well](https://ssl.icu-project.org/trac/ticket/12936)
         - ICU patch wanted
-    1. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](http://bugs.icu-project.org/trac/ticket/13268)
+    1. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://ssl.icu-project.org/trac/ticket/13268)
         - Jungshik wrote a patch, anyone want to review?
         - Was a proposal sent to icu-design? (Dan can't find it)
     1. [Get locales with PluralRules support](https://ssl.icu-project.org/trac/ticket/12756)

--- a/meetings/agenda-2018-03-16.md
+++ b/meetings/agenda-2018-03-16.md
@@ -25,22 +25,22 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
             - Missing notes from last time
     1. Intl updates for the Kangax compatibility table? (Zibi)
 1. ICU tickets to support existing advanced proposals and APIs
-    1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://ssl.icu-project.org/trac/ticket/13256)
+    1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://unicode-org.atlassian.net/browse/ICU-13256)
         - icu-design proposal resent; any feedback? Next steps?
         - ICU patch wanted
-    1. [RelativeDateTimeFormatter doesn't handle -0 well](https://ssl.icu-project.org/trac/ticket/12936)
+    1. [RelativeDateTimeFormatter doesn't handle -0 well](https://unicode-org.atlassian.net/browse/ICU-12936)
         - ICU patch wanted
-    1. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://ssl.icu-project.org/trac/ticket/13268)
+    1. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://unicode-org.atlassian.net/browse/ICU-13268)
         - Jungshik wrote a patch, anyone want to review?
         - Was a proposal sent to icu-design? (Dan can't find it)
-    1. [Get locales with PluralRules support](https://ssl.icu-project.org/trac/ticket/12756)
+    1. [Get locales with PluralRules support](https://unicode-org.atlassian.net/browse/ICU-12756)
         - Should we close as will-not-fix because all locales will always be considered supported?
     1. Are there any remaining APIs that need to be marked as "stable" or ported to C?
     1. Any other support needed from ICU for Intl proposals?
 1. New proposals
     1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
         - Status update for this proposal?
-        - How is the [C API](https://ssl.icu-project.org/trac/ticket/13597) coming (necessary for ChakraCore, at least)
+        - How is the [C API](https://unicode-org.atlassian.net/browse/ICU-13597) coming (necessary for ChakraCore, at least)
         - Overall thoughts?
         - What to do with the `style` option: "deprecate" it (Option 1) or keep it as a first-class citizen (Option 2)?
         - Where to put the modifiers for units, like the width and compound units: as a top-level setting (Option A) or as a nested object literal on the `unit` key (Option B)?

--- a/meetings/agenda-2018-03-16.md
+++ b/meetings/agenda-2018-03-16.md
@@ -28,9 +28,9 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
     1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://ssl.icu-project.org/trac/ticket/13256)
         - icu-design proposal resent; any feedback? Next steps?
         - ICU patch wanted
-    1. [RelativeDateTimeFormatter doesn't handle -0 well](http://bugs.icu-project.org/trac/ticket/12936)
+    1. [RelativeDateTimeFormatter doesn't handle -0 well](https://ssl.icu-project.org/trac/ticket/12936)
         - ICU patch wanted
-    1. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](http://bugs.icu-project.org/trac/ticket/13268)
+    1. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://ssl.icu-project.org/trac/ticket/13268)
         - Jungshik wrote a patch, anyone want to review?
         - Was a proposal sent to icu-design? (Dan can't find it)
     1. [Get locales with PluralRules support](https://ssl.icu-project.org/trac/ticket/12756)
@@ -40,7 +40,7 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
 1. New proposals
     1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
         - Status update for this proposal?
-        - How is the [C API](http://bugs.icu-project.org/trac/ticket/13597) coming (necessary for ChakraCore, at least)
+        - How is the [C API](https://ssl.icu-project.org/trac/ticket/13597) coming (necessary for ChakraCore, at least)
         - Overall thoughts?
         - What to do with the `style` option: "deprecate" it (Option 1) or keep it as a first-class citizen (Option 2)?
         - Where to put the modifiers for units, like the width and compound units: as a top-level setting (Option A) or as a nested object literal on the `unit` key (Option B)?

--- a/meetings/agenda-2018-04-20.md
+++ b/meetings/agenda-2018-04-20.md
@@ -24,16 +24,16 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
         - [Add Intl.Locale.prototype.baseName](https://github.com/tc39/proposal-intl-locale/issues/22)?
         - [Leave minimize/maximize for v2](https://github.com/tc39/proposal-intl-locale/issues/16)?
 1. ICU tickets to support existing advanced proposals and APIs
-    1. [API design proposal](https://ssl.icu-project.org/trac/ticket/13256) for Intl.RelativeTimeFormat.prototype.formatToParts accepted with modifications
+    1. [API design proposal](https://unicode-org.atlassian.net/browse/ICU-13256) for Intl.RelativeTimeFormat.prototype.formatToParts accepted with modifications
         - Is anyone interested in implementing? (Small amount of plumbing code)
-    1. [API design proposal](https://ssl.icu-project.org/trac/ticket/13597) for C API for NumberFormatter accepted with modifications
+    1. [API design proposal](https://unicode-org.atlassian.net/browse/ICU-13597) for C API for NumberFormatter accepted with modifications
         - Shane to implement?
-    1. [unum_formatDoubleForFields will be marked as stable in ICU 61](https://ssl.icu-project.org/trac/ticket/13557)
+    1. [unum_formatDoubleForFields will be marked as stable in ICU 61](https://unicode-org.atlassian.net/browse/ICU-13557)
     1. Dan to write API design proposals for other formatToParts/timezone functions
 1. New proposals
     1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
         - Last meeting, settled on top-level settings, and maintaining `style`. Any further thoughts?
-        - Status of [C API](https://ssl.icu-project.org/trac/ticket/13597) (necessary for 3 browsers)
+        - Status of [C API](https://unicode-org.atlassian.net/browse/ICU-13597) (necessary for 3 browsers)
         - Next steps on [proposal repository](https://github.com/sffc/proposal-unified-intl-numberformat)
     1. [formatRange/formatRangeToParts](https://github.com/tc39/ecma402/issues/188) (Felipe)
         - Last meeting, settled on the following. Any further thoughts?

--- a/meetings/agenda-2018-04-20.md
+++ b/meetings/agenda-2018-04-20.md
@@ -24,16 +24,16 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
         - [Add Intl.Locale.prototype.baseName](https://github.com/tc39/proposal-intl-locale/issues/22)?
         - [Leave minimize/maximize for v2](https://github.com/tc39/proposal-intl-locale/issues/16)?
 1. ICU tickets to support existing advanced proposals and APIs
-    1. [API design proposal](http://ssl.icu-project.org/trac/ticket/13256) for Intl.RelativeTimeFormat.prototype.formatToParts accepted with modifications
+    1. [API design proposal](https://ssl.icu-project.org/trac/ticket/13256) for Intl.RelativeTimeFormat.prototype.formatToParts accepted with modifications
         - Is anyone interested in implementing? (Small amount of plumbing code)
-    1. [API design proposal](http://ssl.icu-project.org/trac/ticket/13597) for C API for NumberFormatter accepted with modifications
+    1. [API design proposal](https://ssl.icu-project.org/trac/ticket/13597) for C API for NumberFormatter accepted with modifications
         - Shane to implement?
-    1. [unum_formatDoubleForFields will be marked as stable in ICU 61](http://ssl.icu-project.org/trac/ticket/13557)
+    1. [unum_formatDoubleForFields will be marked as stable in ICU 61](https://ssl.icu-project.org/trac/ticket/13557)
     1. Dan to write API design proposals for other formatToParts/timezone functions
 1. New proposals
     1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
         - Last meeting, settled on top-level settings, and maintaining `style`. Any further thoughts?
-        - Status of [C API](http://bugs.icu-project.org/trac/ticket/13597) (necessary for 3 browsers)
+        - Status of [C API](https://ssl.icu-project.org/trac/ticket/13597) (necessary for 3 browsers)
         - Next steps on [proposal repository](https://github.com/sffc/proposal-unified-intl-numberformat)
     1. [formatRange/formatRangeToParts](https://github.com/tc39/ecma402/issues/188) (Felipe)
         - Last meeting, settled on the following. Any further thoughts?

--- a/meetings/agenda-2018-05-17.md
+++ b/meetings/agenda-2018-05-17.md
@@ -10,7 +10,7 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
     1. [Improve handling of non-Gregorian calendars](https://github.com/tc39/ecma402/pull/227)
         - Address [questions raised by Anba](https://github.com/tc39/ecma402/pull/227#issuecomment-389211876)
         - Plan: Present in May 2018 TC39 meeting
-    1. [unum_formatDoubleForFields is marked as stable in ICU 61](https://ssl.icu-project.org/trac/ticket/13557)
+    1. [unum_formatDoubleForFields is marked as stable in ICU 61](https://unicode-org.atlassian.net/browse/ICU-13557)
         - Are any more APIs to make stable? Needed ASAP to be included in ICU 62. [unofficial 62 changes](https://gist.github.com/srl295/7b44fcb89f7e6d031ab44d2cdd8a1ebe#file-apichange-61-62-html)
     1. [Handling unknown codes for parts](https://github.com/tc39/ecma402/issues/231)
 1. Stage 3 APIs
@@ -35,7 +35,7 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
         1. No tests, no other implementations
     1. Intl.ListFormat
         1. No tests, no implementations
-        1. Missing [ICU API proposal](https://ssl.icu-project.org/trac/ticket/13754)
+        1. Missing [ICU API proposal](https://unicode-org.atlassian.net/browse/ICU-13754)
     1. Intl.Segmenter
         1. No tests, no implementations
         1. ICU APIs sufficient
@@ -45,7 +45,7 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
             - [Measure unit syntax](https://github.com/sffc/proposal-unified-intl-numberformat/issues/3)
             - [Compact and Scientific Notation Syntax](https://github.com/sffc/proposal-unified-intl-numberformat/issues/5)
             - [Sign Display Syntax](https://github.com/sffc/proposal-unified-intl-numberformat/issues/6)
-        - [C API](https://ssl.icu-project.org/trac/ticket/13597) approved (necessary for 3 browsers)
+        - [C API](https://unicode-org.atlassian.net/browse/ICU-13597) approved (necessary for 3 browsers)
            - Shane to implement
         - [Proposal repository](https://github.com/sffc/proposal-unified-intl-numberformat)
         - Plan: "Stage 0" at May 2018 TC39 meeting.

--- a/meetings/agenda-2018-05-17.md
+++ b/meetings/agenda-2018-05-17.md
@@ -10,7 +10,7 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
     1. [Improve handling of non-Gregorian calendars](https://github.com/tc39/ecma402/pull/227)
         - Address [questions raised by Anba](https://github.com/tc39/ecma402/pull/227#issuecomment-389211876)
         - Plan: Present in May 2018 TC39 meeting
-    1. [unum_formatDoubleForFields is marked as stable in ICU 61](http://ssl.icu-project.org/trac/ticket/13557)
+    1. [unum_formatDoubleForFields is marked as stable in ICU 61](https://ssl.icu-project.org/trac/ticket/13557)
         - Are any more APIs to make stable? Needed ASAP to be included in ICU 62. [unofficial 62 changes](https://gist.github.com/srl295/7b44fcb89f7e6d031ab44d2cdd8a1ebe#file-apichange-61-62-html)
     1. [Handling unknown codes for parts](https://github.com/tc39/ecma402/issues/231)
 1. Stage 3 APIs
@@ -45,7 +45,7 @@ Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hango
             - [Measure unit syntax](https://github.com/sffc/proposal-unified-intl-numberformat/issues/3)
             - [Compact and Scientific Notation Syntax](https://github.com/sffc/proposal-unified-intl-numberformat/issues/5)
             - [Sign Display Syntax](https://github.com/sffc/proposal-unified-intl-numberformat/issues/6)
-        - [C API](http://bugs.icu-project.org/trac/ticket/13597) approved (necessary for 3 browsers)
+        - [C API](https://ssl.icu-project.org/trac/ticket/13597) approved (necessary for 3 browsers)
            - Shane to implement
         - [Proposal repository](https://github.com/sffc/proposal-unified-intl-numberformat)
         - Plan: "Stage 0" at May 2018 TC39 meeting.

--- a/meetings/agenda-2018-10-18.md
+++ b/meetings/agenda-2018-10-18.md
@@ -6,7 +6,7 @@ October 18th, 2018, 16:00 UTC
 Contact Daniel Ehrenberg (littledan@igalia.com) for the link to the Google Hangouts link.
 
 1. Bugs/PRs against ECMA-402
-    1. Should locales be general BCP47, or [Unicode BCP47 Locale Identifiers](http://www.unicode.org/reports/tr35/proposed.html#BCP_47_Conformance)? ([issue](https://github.com/tc39/proposal-intl-locale/issues/63)). Implications:
+    1. Should locales be general BCP47, or [Unicode BCP47 Locale Identifiers](https://www.unicode.org/reports/tr35/proposed.html#BCP_47_Conformance)? ([issue](https://github.com/tc39/proposal-intl-locale/issues/63)). Implications:
         1. After canonicalizing, no support for grandfathered tags; private use is always as an extension
         1. Adopt CLDR semantics for some things on top of IANA
         1. Still ban _

--- a/meetings/notes-2017-12-15.md
+++ b/meetings/notes-2017-12-15.md
@@ -50,8 +50,8 @@ Agenda: [https://github.com/tc39/ecma402/blob/master/meetings/agenda-2017-12-15.
     3. [ISO 4217 vs CLDR default currency digits](https://github.com/tc39/ecma402/issues/134)
     4. There are several more bugs [in the bug tracker](https://github.com/tc39/ecma402/issues)
 7. Work to do in ICU to support proposals (~5m)
-    1. RelativeTimeFormat [formatToParts](https://ssl.icu-project.org/trac/ticket/13256)
-    2. (possibly) [API for PluralRules supported locales](https://ssl.icu-project.org/trac/ticket/12756)
+    1. RelativeTimeFormat [formatToParts](https://unicode-org.atlassian.net/browse/ICU-13256)
+    2. (possibly) [API for PluralRules supported locales](https://unicode-org.atlassian.net/browse/ICU-12756)
     3. Anything more?
     4. *[srl] ICU-TC Liason? [this was in a mistargetted agenda PR]*
 8. Future (~10m)

--- a/meetings/notes-2018-01-19.md
+++ b/meetings/notes-2018-01-19.md
@@ -29,7 +29,7 @@ Attendees:
         * Standardized in 2017 edition (DateTimeFormat) and standardizing 2018 edition (NumberFormat)
         * Any concerns?
             * DIV: NumberFormat formatToParts is exposed as "draft" in ICU 60, so it’s not exposed in the Windows ICU API, which only exposes stable things. Plan is to expose it as Stable in ICU 61.
-            * SL: You could also just pull [the implementation](https://ssl.icu-project.org/trac/ticket/12684). Maybe we should discuss this offline further with MS ICU people to make it available earlier.
+            * SL: You could also just pull [the implementation](https://unicode-org.atlassian.net/browse/ICU-12684). Maybe we should discuss this offline further with MS ICU people to make it available earlier.
             * ZB: Are you concerned about putting it in the 2018 edition before you’re able to ship it?
             * JH: I think it’s reasonable to say that we can ship it later, though I can’t make promises for what we will ship.
             * DIV: The [MSFT] ICU team in general is hesitant about specifying an unstable API for use here.
@@ -40,7 +40,7 @@ Attendees:
         * Stage 4
         * Implemented and shipped in Chrome and Firefox
         * Standardizing in 2018 edition
-        * Should ICU support [an API for getting the supported locales](https://ssl.icu-project.org/trac/ticket/12756) or should ICU users assume all locales are supported?
+        * Should ICU support [an API for getting the supported locales](https://unicode-org.atlassian.net/browse/ICU-12756) or should ICU users assume all locales are supported?
         * Any concerns?
             * CP: This is a new API merged into the specification.
             * ZB: Six years since we added a new constructor in ECMA 402!
@@ -153,7 +153,7 @@ Attendees:
     1. [Intl.RelativeTimeFormat](https://github.com/tc39/proposal-intl-relative-time)
         * Stage 2
         * [Intl.RelativeTimeFormat type: numeric/text naming](https://github.com/tc39/proposal-intl-relative-time/issues/54)
-        * [ICU support](https://ssl.icu-project.org/trac/ticket/13256) for RelativeTimeFormat.prototype.formatToParts?
+        * [ICU support](https://unicode-org.atlassian.net/browse/ICU-13256) for RelativeTimeFormat.prototype.formatToParts?
         * API: Similar to ICU, create a formatter, then use it with a particular unit. No built-in algorithm for choice of unit. [PR](https://github.com/tc39/proposal-intl-relative-time/pull/18)
         * Aesthetics: Unit is passed as a string, accepted in either singular or plural [Bug](https://github.com/tc39/proposal-intl-relative-time/issues/40)
         * Omitted features: Capitalization context, days of the week, compound uni

--- a/meetings/notes-2018-01-19.md
+++ b/meetings/notes-2018-01-19.md
@@ -29,7 +29,7 @@ Attendees:
         * Standardized in 2017 edition (DateTimeFormat) and standardizing 2018 edition (NumberFormat)
         * Any concerns?
             * DIV: NumberFormat formatToParts is exposed as "draft" in ICU 60, so it’s not exposed in the Windows ICU API, which only exposes stable things. Plan is to expose it as Stable in ICU 61.
-            * SL: You could also just pull [the implementation](http://bugs.icu-project.org/trac/ticket/12684). Maybe we should discuss this offline further with MS ICU people to make it available earlier.
+            * SL: You could also just pull [the implementation](https://ssl.icu-project.org/trac/ticket/12684). Maybe we should discuss this offline further with MS ICU people to make it available earlier.
             * ZB: Are you concerned about putting it in the 2018 edition before you’re able to ship it?
             * JH: I think it’s reasonable to say that we can ship it later, though I can’t make promises for what we will ship.
             * DIV: The [MSFT] ICU team in general is hesitant about specifying an unstable API for use here.

--- a/meetings/notes-2018-02-16.md
+++ b/meetings/notes-2018-02-16.md
@@ -31,15 +31,15 @@ Agenda:
             * Do we want to carry forward the optionality of kf and kn?
             * How are we handling regular and irregular grandfathered tags? (also for the[ main specification](https://github.com/tc39/ecma402/issues/177)) anba's questions
 3. ICU tickets to support existing advanced proposals and APIs
-    1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://ssl.icu-project.org/trac/ticket/13256)
+    1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://unicode-org.atlassian.net/browse/ICU-13256)
         * Dan sent an icu-design email; does anyone want to review?
         * ICU patch wanted
-    2. [RelativeDateTimeFormatter doesn't handle -0 well](https://ssl.icu-project.org/trac/ticket/12936)
+    2. [RelativeDateTimeFormatter doesn't handle -0 well](https://unicode-org.atlassian.net/browse/ICU-12936)
         * ICU patch wanted
-    3. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://ssl.icu-project.org/trac/ticket/13268)
+    3. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://unicode-org.atlassian.net/browse/ICU-13268)
         * Jungshik wrote a patch, anyone want to review?
         * Was a proposal sent to icu-design? (Dan can't find it)
-    4. [Get locales with PluralRules support](https://ssl.icu-project.org/trac/ticket/12756)
+    4. [Get locales with PluralRules support](https://unicode-org.atlassian.net/browse/ICU-12756)
         * Should we close as will-not-fix because all locales will always be x1considered supported?
     5. Any other support needed from ICU for Intl proposals?
 4. New proposals
@@ -191,7 +191,7 @@ JS: Even with the current ICU, it is possible to do the right thing.
 
 ZB: any locale that we support have plural rules. Basically, the list of supported languages in plural rules is the same everywhere.
 
-ZB: ICU [does not have a separate ](https://ssl.icu-project.org/trac/ticket/12756)[list](https://ssl.icu-project.org/trac/ticket/12756)[ for locales that support plural rules](https://ssl.icu-project.org/trac/ticket/12756). The assumption is that you can have different data for date, number, etc., but it is not well defined for plural rules.
+ZB: ICU [does not have a separate ](https://unicode-org.atlassian.net/browse/ICU-12756)[list](https://unicode-org.atlassian.net/browse/ICU-12756)[ for locales that support plural rules](https://unicode-org.atlassian.net/browse/ICU-12756). The assumption is that you can have different data for date, number, etc., but it is not well defined for plural rules.
 
 DI: This sounds like a bug in ICU, and should not affect the spec in any way.
 

--- a/meetings/notes-2018-02-16.md
+++ b/meetings/notes-2018-02-16.md
@@ -34,9 +34,9 @@ Agenda:
     1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://ssl.icu-project.org/trac/ticket/13256)
         * Dan sent an icu-design email; does anyone want to review?
         * ICU patch wanted
-    2. [RelativeDateTimeFormatter doesn't handle -0 well](http://bugs.icu-project.org/trac/ticket/12936)
+    2. [RelativeDateTimeFormatter doesn't handle -0 well](https://ssl.icu-project.org/trac/ticket/12936)
         * ICU patch wanted
-    3. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](http://bugs.icu-project.org/trac/ticket/13268)
+    3. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://ssl.icu-project.org/trac/ticket/13268)
         * Jungshik wrote a patch, anyone want to review?
         * Was a proposal sent to icu-design? (Dan can't find it)
     4. [Get locales with PluralRules support](https://ssl.icu-project.org/trac/ticket/12756)
@@ -191,7 +191,7 @@ JS: Even with the current ICU, it is possible to do the right thing.
 
 ZB: any locale that we support have plural rules. Basically, the list of supported languages in plural rules is the same everywhere.
 
-ZB: ICU [does not have a separate ](http://bugs.icu-project.org/trac/ticket/12756)[list](http://bugs.icu-project.org/trac/ticket/12756)[ for locales that support plural rules](http://bugs.icu-project.org/trac/ticket/12756). The assumption is that you can have different data for date, number, etc., but it is not well defined for plural rules.
+ZB: ICU [does not have a separate ](https://ssl.icu-project.org/trac/ticket/12756)[list](https://ssl.icu-project.org/trac/ticket/12756)[ for locales that support plural rules](https://ssl.icu-project.org/trac/ticket/12756). The assumption is that you can have different data for date, number, etc., but it is not well defined for plural rules.
 
 DI: This sounds like a bug in ICU, and should not affect the spec in any way.
 

--- a/meetings/notes-2018-03-16.md
+++ b/meetings/notes-2018-03-16.md
@@ -101,7 +101,7 @@ Agenda and minutes (take notes inline)
         * Myles: Why have this feature?
         * Zibi: For all new formatters, we add this way to get out the parts, so that it’s possible to format different things differently,
         * Jungshik: people often try to parse and piece things to without parsing and trying to guess the parts, which is often broken.
-    2. [RelativeDateTimeFormatter doesn't handle -0 well](http://bugs.icu-project.org/trac/ticket/12936)
+    2. [RelativeDateTimeFormatter doesn't handle -0 well](https://ssl.icu-project.org/trac/ticket/12936)
         * ICU patch wanted
         * Ciric: Unfortunately the ICU team has limited bandwidth.
         * Steven: You added a control for +0,-0?
@@ -111,7 +111,7 @@ Agenda and minutes (take notes inline)
         * Steven: Is there someone willing to make a patch for this?
         * We are pinged the owner
         * Steven: Will add an ECMA bug label/keyword for JS-related things
-    3. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](http://bugs.icu-project.org/trac/ticket/13268)
+    3. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://ssl.icu-project.org/trac/ticket/13268)
         * Jungshik wrote a patch, anyone want to review?
         * Was a proposal sent to icu-design? 
         * No. Jungshik will propose. 
@@ -123,23 +123,23 @@ Agenda and minutes (take notes inline)
         * Eemeli: Ordinal too, or just cardinal?
             * Eemeli: According to CLDR’s [Core Data for New Locales](http://cldr.unicode.org/index/cldr-spec/minimaldata), ordinal rules are "not required, but are strongly recommended".
     5. Are there any remaining APIs that need to be marked as "stable" or ported to C?
-        * specifically, were there APIs [that did not get promoted to stable in ICU 61 that should have been?](http://source.icu-project.org/repos/icu/tags/release-61-rc/icu4c/APIChangeReport.html)
-            * [items that are still draft](http://source.icu-project.org/repos/icu/tags/release-61-rc/icu4c/APIChangeReport.html#other)
-            * [items that were promoted](http://source.icu-project.org/repos/icu/tags/release-61-rc/icu4c/APIChangeReport.html#promoted)
+        * specifically, were there APIs [that did not get promoted to stable in ICU 61 that should have been?](https://ssl.icu-project.org/repos/icu/tags/release-61-rc/icu4c/APIChangeReport.html)
+            * [items that are still draft](https://ssl.icu-project.org/repos/icu/tags/release-61-rc/icu4c/APIChangeReport.html#other)
+            * [items that were promoted](https://ssl.icu-project.org/repos/icu/tags/release-61-rc/icu4c/APIChangeReport.html#promoted)
         * Jeff: there are some APIs (identified by Jack) slated to be promoted to stable in ICU 61 release.
             * PSA [please test the release candidate](http://site.icu-project.org/download/61)
         * Jeff: the majority of timezone APIs are currently C++ only. (getOffset-related) ⇒ **TODO(jungshik)**: file a ticket 
         * Apple/Microsoft: Can only use ICU C APIs, no C++ API usage at all.
         * Mozilla also prefers C APIs where possible.
-        * **TODO(Apple/Microsoft/Mozilla)**: Add comments to Shane’s NumberFormat [C API](http://bugs.icu-project.org/trac/ticket/13597) ticket 
+        * **TODO(Apple/Microsoft/Mozilla)**: Add comments to Shane’s NumberFormat [C API](https://ssl.icu-project.org/trac/ticket/13597) ticket 
     6. Any other support needed from ICU for Intl proposals?
         * [Implementers feedback on issues when trying to merge ICU 61 into SpiderMonkey](https://bugzilla.mozilla.org/show_bug.cgi?id=1445465)
-            * proposed to be [fixed in ICU61](http://bugs.icu-project.org/trac/ticket/13648)
+            * proposed to be [fixed in ICU61](https://ssl.icu-project.org/trac/ticket/13648)
         * Any proposed new API needs a C API, not just a C++ API.
 4. New proposals
     1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
         * Status update for this proposal?
-        * How is the [C API](http://bugs.icu-project.org/trac/ticket/13597) coming (necessary for ChakraCore and SpiderMonkey, and JSC)
+        * How is the [C API](https://ssl.icu-project.org/trac/ticket/13597) coming (necessary for ChakraCore and SpiderMonkey, and JSC)
         * Overall thoughts?
         * What to do with the style option: "deprecate" it (Option 1) or keep it as a first-class citizen (Option 2)?
         * Where to put the modifiers for units, like the width and compound units: as a top-level setting (Option A) or as a nested object literal on the unit key (Option B)?

--- a/meetings/notes-2018-03-16.md
+++ b/meetings/notes-2018-03-16.md
@@ -93,7 +93,7 @@ Agenda and minutes (take notes inline)
             * Missing notes from last time
     4. Intl updates for the Kangax compatibility table? (Zibi)
 3. [ICU tickets](https://ssl.icu-project.org/trac/query?status=!closed&keywords=~ecma) to support existing advanced proposals and APIs
-    1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://ssl.icu-project.org/trac/ticket/13256)
+    1. [Add RelativeDateTimeFormatter.format(FieldPositionIterator)?](https://unicode-org.atlassian.net/browse/ICU-13256)
         * icu-design proposal resent; any feedback? Next steps?
         * ICU patch wanted
         * Notes:
@@ -101,7 +101,7 @@ Agenda and minutes (take notes inline)
         * Myles: Why have this feature?
         * Zibi: For all new formatters, we add this way to get out the parts, so that it’s possible to format different things differently,
         * Jungshik: people often try to parse and piece things to without parsing and trying to guess the parts, which is often broken.
-    2. [RelativeDateTimeFormatter doesn't handle -0 well](https://ssl.icu-project.org/trac/ticket/12936)
+    2. [RelativeDateTimeFormatter doesn't handle -0 well](https://unicode-org.atlassian.net/browse/ICU-12936)
         * ICU patch wanted
         * Ciric: Unfortunately the ICU team has limited bandwidth.
         * Steven: You added a control for +0,-0?
@@ -111,12 +111,12 @@ Agenda and minutes (take notes inline)
         * Steven: Is there someone willing to make a patch for this?
         * We are pinged the owner
         * Steven: Will add an ECMA bug label/keyword for JS-related things
-    3. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://ssl.icu-project.org/trac/ticket/13268)
+    3. [TimeZone::getOffset() : add two params to control repeated/skipped wall time](https://unicode-org.atlassian.net/browse/ICU-13268)
         * Jungshik wrote a patch, anyone want to review?
         * Was a proposal sent to icu-design? 
         * No. Jungshik will propose. 
         * Jungshik: Not blocked by this issue, (v8 implementation is pending review)
-    4. [Get locales with PluralRules support](https://ssl.icu-project.org/trac/ticket/12756)
+    4. [Get locales with PluralRules support](https://unicode-org.atlassian.net/browse/ICU-12756)
         * Should we close as will-not-fix because all locales will always be considered supported?
         * Zibi: PluralRules is part of the seed of any locale
         * Steven: It’s expected that all locale support PluralRules before being accepted into CLDR
@@ -131,15 +131,15 @@ Agenda and minutes (take notes inline)
         * Jeff: the majority of timezone APIs are currently C++ only. (getOffset-related) ⇒ **TODO(jungshik)**: file a ticket 
         * Apple/Microsoft: Can only use ICU C APIs, no C++ API usage at all.
         * Mozilla also prefers C APIs where possible.
-        * **TODO(Apple/Microsoft/Mozilla)**: Add comments to Shane’s NumberFormat [C API](https://ssl.icu-project.org/trac/ticket/13597) ticket 
+        * **TODO(Apple/Microsoft/Mozilla)**: Add comments to Shane’s NumberFormat [C API](https://unicode-org.atlassian.net/browse/ICU-13597) ticket 
     6. Any other support needed from ICU for Intl proposals?
         * [Implementers feedback on issues when trying to merge ICU 61 into SpiderMonkey](https://bugzilla.mozilla.org/show_bug.cgi?id=1445465)
-            * proposed to be [fixed in ICU61](https://ssl.icu-project.org/trac/ticket/13648)
+            * proposed to be [fixed in ICU61](https://unicode-org.atlassian.net/browse/ICU-13648)
         * Any proposed new API needs a C API, not just a C++ API.
 4. New proposals
     1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
         * Status update for this proposal?
-        * How is the [C API](https://ssl.icu-project.org/trac/ticket/13597) coming (necessary for ChakraCore and SpiderMonkey, and JSC)
+        * How is the [C API](https://unicode-org.atlassian.net/browse/ICU-13597) coming (necessary for ChakraCore and SpiderMonkey, and JSC)
         * Overall thoughts?
         * What to do with the style option: "deprecate" it (Option 1) or keep it as a first-class citizen (Option 2)?
         * Where to put the modifiers for units, like the width and compound units: as a top-level setting (Option A) or as a nested object literal on the unit key (Option B)?

--- a/meetings/notes-2018-04-20.md
+++ b/meetings/notes-2018-04-20.md
@@ -54,7 +54,7 @@ Agenda and notes
         * **Conclusion** - We’ll switch the spec to copy
     4. [PartitionNumberPattern treats -0 as 0](https://github.com/tc39/ecma402/issues/219) (Jack Horton)
         * Shane - we always handled it differently
-            * (Steven: ICU history: [http://bugs.icu-project.org/trac/ticket/8333#comment:14](http://bugs.icu-project.org/trac/ticket/8333#comment:14) [http://bugs.icu-project.org/trac/ticket/13551](http://bugs.icu-project.org/trac/ticket/13551) )
+            * (Steven: ICU history: [https://ssl.icu-project.org/trac/ticket/8333#comment:14](https://ssl.icu-project.org/trac/ticket/8333#comment:14) [https://ssl.icu-project.org/trac/ticket/13551](https://ssl.icu-project.org/trac/ticket/13551) )
         * Daniel - We should only artificially unify -0 and 0 if we have a reason for that.
         * Zibi - I agree
         * **Conclusion** - Agreement on Jack’s proposed change
@@ -73,23 +73,23 @@ Agenda and notes
         * [Leave minimize/maximize for v2](https://github.com/tc39/proposal-intl-locale/issues/16)?
             * **Conclusion** - consider adding it to v1. Daniel will look to add it to the spec. As methods returning a new Intl.Locale (preserving extension keys)
 3. ICU tickets to support existing advanced proposals and APIs
-    1. [API design proposal](http://ssl.icu-project.org/trac/ticket/13256) for Intl.RelativeTimeFormat.prototype.formatToParts accepted with modifications
+    1. [API design proposal](https://ssl.icu-project.org/trac/ticket/13256) for Intl.RelativeTimeFormat.prototype.formatToParts accepted with modifications
         * Is anyone interested in implementing? (Small amount of plumbing code)
-    2. [API design proposal](http://ssl.icu-project.org/trac/ticket/13597) for C API for NumberFormatter accepted with modifications
+    2. [API design proposal](https://ssl.icu-project.org/trac/ticket/13597) for C API for NumberFormatter accepted with modifications
         * See below under "NumberFormat changes"
-    3. [unum_formatDoubleForFields will be marked as stable in ICU 61](http://ssl.icu-project.org/trac/ticket/13557)
+    3. [unum_formatDoubleForFields will be marked as stable in ICU 61](https://ssl.icu-project.org/trac/ticket/13557)
     4. Dan to write API design proposals for other formatToParts/timezone functions
 4. New proposals
     1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
         * Last meeting, settled on top-level settings, and maintaining style. Any further thoughts?
-        * Status of [C API](http://bugs.icu-project.org/trac/ticket/13597) (necessary for 3 browsers)
+        * Status of [C API](https://ssl.icu-project.org/trac/ticket/13597) (necessary for 3 browsers)
         * Next steps on [proposal repository](https://github.com/sffc/proposal-unified-intl-numberformat)
         * Shane: I need feedback on the C API and the names for the measures
         * Names for measures: see [https://github.com/sffc/proposal-unified-intl-numberformat/issues/3](https://github.com/sffc/proposal-unified-intl-numberformat/issues/3)
         * ICU API Proposal: [https://sourceforge.net/p/icu/mailman/message/36276549/](https://sourceforge.net/p/icu/mailman/message/36276549/)
             * suggestion: SourceForge flattens the email and removes formatting; click "Message as HTML"
-            * Also see [unumberformatter.h](http://bugs.icu-project.org/trac/browser/branches/shane/numberformat4/icu4c/source/i18n/unicode/unumberformatter.h)
-            * To provide feedback, either reply to the email thread (if you are on the list) or post on [the ICU ticket](http://ssl.icu-project.org/trac/ticket/13597)
+            * Also see [unumberformatter.h](https://ssl.icu-project.org/trac/browser/branches/shane/numberformat4/icu4c/source/i18n/unicode/unumberformatter.h)
+            * To provide feedback, either reply to the email thread (if you are on the list) or post on [the ICU ticket](https://ssl.icu-project.org/trac/ticket/13597)
     2. [formatRange/formatRangeToParts](https://github.com/tc39/ecma402/issues/188) (Felipe)
         * Last meeting, settled on the following. Any further thoughts?
             * formatRangeToParts returns a flat array, with a new attribute

--- a/meetings/notes-2018-04-20.md
+++ b/meetings/notes-2018-04-20.md
@@ -54,7 +54,7 @@ Agenda and notes
         * **Conclusion** - We’ll switch the spec to copy
     4. [PartitionNumberPattern treats -0 as 0](https://github.com/tc39/ecma402/issues/219) (Jack Horton)
         * Shane - we always handled it differently
-            * (Steven: ICU history: [https://ssl.icu-project.org/trac/ticket/8333#comment:14](https://ssl.icu-project.org/trac/ticket/8333#comment:14) [https://ssl.icu-project.org/trac/ticket/13551](https://ssl.icu-project.org/trac/ticket/13551) )
+            * (Steven: ICU history: [https://unicode-org.atlassian.net/browse/ICU-8333#comment:14](https://unicode-org.atlassian.net/browse/ICU-8333#comment:14) [https://unicode-org.atlassian.net/browse/ICU-13551](https://unicode-org.atlassian.net/browse/ICU-13551) )
         * Daniel - We should only artificially unify -0 and 0 if we have a reason for that.
         * Zibi - I agree
         * **Conclusion** - Agreement on Jack’s proposed change
@@ -73,23 +73,23 @@ Agenda and notes
         * [Leave minimize/maximize for v2](https://github.com/tc39/proposal-intl-locale/issues/16)?
             * **Conclusion** - consider adding it to v1. Daniel will look to add it to the spec. As methods returning a new Intl.Locale (preserving extension keys)
 3. ICU tickets to support existing advanced proposals and APIs
-    1. [API design proposal](https://ssl.icu-project.org/trac/ticket/13256) for Intl.RelativeTimeFormat.prototype.formatToParts accepted with modifications
+    1. [API design proposal](https://unicode-org.atlassian.net/browse/ICU-13256) for Intl.RelativeTimeFormat.prototype.formatToParts accepted with modifications
         * Is anyone interested in implementing? (Small amount of plumbing code)
-    2. [API design proposal](https://ssl.icu-project.org/trac/ticket/13597) for C API for NumberFormatter accepted with modifications
+    2. [API design proposal](https://unicode-org.atlassian.net/browse/ICU-13597) for C API for NumberFormatter accepted with modifications
         * See below under "NumberFormat changes"
-    3. [unum_formatDoubleForFields will be marked as stable in ICU 61](https://ssl.icu-project.org/trac/ticket/13557)
+    3. [unum_formatDoubleForFields will be marked as stable in ICU 61](https://unicode-org.atlassian.net/browse/ICU-13557)
     4. Dan to write API design proposals for other formatToParts/timezone functions
 4. New proposals
     1. [NumberFormat changes](https://github.com/tc39/ecma402/issues/215), including (a) restructuring the spec, (b) minor changes to behavior, (c) support for measure units, and (d) support for scientific and compact notation.
         * Last meeting, settled on top-level settings, and maintaining style. Any further thoughts?
-        * Status of [C API](https://ssl.icu-project.org/trac/ticket/13597) (necessary for 3 browsers)
+        * Status of [C API](https://unicode-org.atlassian.net/browse/ICU-13597) (necessary for 3 browsers)
         * Next steps on [proposal repository](https://github.com/sffc/proposal-unified-intl-numberformat)
         * Shane: I need feedback on the C API and the names for the measures
         * Names for measures: see [https://github.com/sffc/proposal-unified-intl-numberformat/issues/3](https://github.com/sffc/proposal-unified-intl-numberformat/issues/3)
         * ICU API Proposal: [https://sourceforge.net/p/icu/mailman/message/36276549/](https://sourceforge.net/p/icu/mailman/message/36276549/)
             * suggestion: SourceForge flattens the email and removes formatting; click "Message as HTML"
             * Also see [unumberformatter.h](https://ssl.icu-project.org/trac/browser/branches/shane/numberformat4/icu4c/source/i18n/unicode/unumberformatter.h)
-            * To provide feedback, either reply to the email thread (if you are on the list) or post on [the ICU ticket](https://ssl.icu-project.org/trac/ticket/13597)
+            * To provide feedback, either reply to the email thread (if you are on the list) or post on [the ICU ticket](https://unicode-org.atlassian.net/browse/ICU-13597)
     2. [formatRange/formatRangeToParts](https://github.com/tc39/ecma402/issues/188) (Felipe)
         * Last meeting, settled on the following. Any further thoughts?
             * formatRangeToParts returns a flat array, with a new attribute

--- a/meetings/notes-2018-04-20.md
+++ b/meetings/notes-2018-04-20.md
@@ -54,7 +54,7 @@ Agenda and notes
         * **Conclusion** - We’ll switch the spec to copy
     4. [PartitionNumberPattern treats -0 as 0](https://github.com/tc39/ecma402/issues/219) (Jack Horton)
         * Shane - we always handled it differently
-            * (Steven: ICU history: [https://unicode-org.atlassian.net/browse/ICU-8333#comment:14](https://unicode-org.atlassian.net/browse/ICU-8333#comment:14) [https://unicode-org.atlassian.net/browse/ICU-13551](https://unicode-org.atlassian.net/browse/ICU-13551) )
+            * (Steven: ICU history: [https://unicode-org.atlassian.net/browse/ICU-8333?focusedCommentId=46005#comment-46005](https://unicode-org.atlassian.net/browse/ICU-8333?focusedCommentId=46005#comment-46005) [https://unicode-org.atlassian.net/browse/ICU-13551](https://unicode-org.atlassian.net/browse/ICU-13551) )
         * Daniel - We should only artificially unify -0 and 0 if we have a reason for that.
         * Zibi - I agree
         * **Conclusion** - Agreement on Jack’s proposed change

--- a/meetings/notes-2018-05-17.md
+++ b/meetings/notes-2018-05-17.md
@@ -34,7 +34,7 @@ Agenda and notes:
         * NC: Leave for an expert? Did anyone file a request?
         * DE: I think the request came from Anba who saw it in CLDR
         * Conclusion: Don’t include cyclic year for now, wait for use case/request. Stick to "numeric" only for related year.
-    2. [unum_formatDoubleForFields is marked as stable in ICU 61](http://ssl.icu-project.org/trac/ticket/13557)
+    2. [unum_formatDoubleForFields is marked as stable in ICU 61](https://ssl.icu-project.org/trac/ticket/13557)
         * Are any more APIs to make stable? Needed ASAP to be included in ICU 62. [unofficial 62 changes](https://gist.github.com/srl295/7b44fcb89f7e6d031ab44d2cdd8a1ebe#file-apichange-61-62-html)
         * JH: selecting plural rules with a specific number formatter is missing from 61, but that’s deliberate as it’s not the way forward.
         * DE: Should we be pushing that feature request?
@@ -123,7 +123,7 @@ NC: Yes.
     4. Intl.Segmenter
         * No tests, no implementations
         * Tests:
-            * Unicode testing: [https://www.unicode.org/reports/tr14/#Testing](https://www.unicode.org/reports/tr14/#Testing) and related, ICU has [http://source.icu-project.org/repos/icu/trunk/icu4c/source/test/testdata/rbbitst.txt](http://source.icu-project.org/repos/icu/trunk/icu4c/source/test/testdata/rbbitst.txt) / [http://source.icu-project.org/repos/icu/trunk/icu4c/source/test/intltest/rbbitst.cpp](http://source.icu-project.org/repos/icu/trunk/icu4c/source/test/intltest/rbbitst.cpp)
+            * Unicode testing: [https://www.unicode.org/reports/tr14/#Testing](https://www.unicode.org/reports/tr14/#Testing) and related, ICU has [https://ssl.icu-project.org/repos/icu/trunk/icu4c/source/test/testdata/rbbitst.txt](https://ssl.icu-project.org/repos/icu/trunk/icu4c/source/test/testdata/rbbitst.txt) / [https://ssl.icu-project.org/repos/icu/trunk/icu4c/source/test/intltest/rbbitst.cpp](https://ssl.icu-project.org/repos/icu/trunk/icu4c/source/test/intltest/rbbitst.cpp)
             * [https://github.com/twitter/twitter-cldr-js#text-segmentation](https://github.com/twitter/twitter-cldr-js#text-segmentation) might be interesting
         * ICU APIs sufficient
             * JH: Is V8 Break-Iterator a sufficient implementation?
@@ -176,7 +176,7 @@ NC: Yes.
                 31. SC: Accounting is always currency.
                 32. NC: Maybe instead of sign, it could be showSign. I like the removal of accounting over to currency. I do still like the single enum for ICU, but for JS it makes sense to move it to something that is seperatate
                 33. Conclusion: Find a new key for currencyAccounting
-        * [C API](http://bugs.icu-project.org/trac/ticket/13597) approved (necessary for 3 browsers)
+        * [C API](https://ssl.icu-project.org/trac/ticket/13597) approved (necessary for 3 browsers)
             * Shane to implement
                 34. Actually implemented and going out as draft in ICU 62
         * [Proposal repository](https://github.com/sffc/proposal-unified-intl-numberformat)

--- a/meetings/notes-2018-05-17.md
+++ b/meetings/notes-2018-05-17.md
@@ -34,7 +34,7 @@ Agenda and notes:
         * NC: Leave for an expert? Did anyone file a request?
         * DE: I think the request came from Anba who saw it in CLDR
         * Conclusion: Don’t include cyclic year for now, wait for use case/request. Stick to "numeric" only for related year.
-    2. [unum_formatDoubleForFields is marked as stable in ICU 61](https://ssl.icu-project.org/trac/ticket/13557)
+    2. [unum_formatDoubleForFields is marked as stable in ICU 61](https://unicode-org.atlassian.net/browse/ICU-13557)
         * Are any more APIs to make stable? Needed ASAP to be included in ICU 62. [unofficial 62 changes](https://gist.github.com/srl295/7b44fcb89f7e6d031ab44d2cdd8a1ebe#file-apichange-61-62-html)
         * JH: selecting plural rules with a specific number formatter is missing from 61, but that’s deliberate as it’s not the way forward.
         * DE: Should we be pushing that feature request?
@@ -119,7 +119,7 @@ NC: Yes.
             * V8: On our list, but lower priority
             * Spidermonkey: The same
             * Charka: The same
-        * Missing [ICU API proposal](https://ssl.icu-project.org/trac/ticket/13754)
+        * Missing [ICU API proposal](https://unicode-org.atlassian.net/browse/ICU-13754)
     4. Intl.Segmenter
         * No tests, no implementations
         * Tests:
@@ -176,7 +176,7 @@ NC: Yes.
                 31. SC: Accounting is always currency.
                 32. NC: Maybe instead of sign, it could be showSign. I like the removal of accounting over to currency. I do still like the single enum for ICU, but for JS it makes sense to move it to something that is seperatate
                 33. Conclusion: Find a new key for currencyAccounting
-        * [C API](https://ssl.icu-project.org/trac/ticket/13597) approved (necessary for 3 browsers)
+        * [C API](https://unicode-org.atlassian.net/browse/ICU-13597) approved (necessary for 3 browsers)
             * Shane to implement
                 34. Actually implemented and going out as draft in ICU 62
         * [Proposal repository](https://github.com/sffc/proposal-unified-intl-numberformat)

--- a/meetings/notes-2018-06-15.md
+++ b/meetings/notes-2018-06-15.md
@@ -76,8 +76,8 @@ Agenda and notes
                     1. Is there a ticket for fixing/changing ICU?
                 33. DE: Could we permit implementation-defined mappings to eliminate all grandfathered tags (in practice, ICU mappings)
                 34. JS: ICU has several bugs in this mapping area
-                35. SL: [http://bugs.icu-project.org/trac/ticket/13650](http://bugs.icu-project.org/trac/ticket/13650) is one filed to update ICU's behavior. (probably just a bug/outdated instead of a policy difference); 
-                36. JS: there are also a series of bugs filed on this issue. I have a fix for Chrome and will plan to upstream the fix to ICU.  e.g. [http://bugs.icu-project.org/trac/ticket/13720](http://bugs.icu-project.org/trac/ticket/13720) (13721, 13723, 13726 , 13719, 9562)
+                35. SL: [https://ssl.icu-project.org/trac/ticket/13650](https://ssl.icu-project.org/trac/ticket/13650) is one filed to update ICU's behavior. (probably just a bug/outdated instead of a policy difference); 
+                36. JS: there are also a series of bugs filed on this issue. I have a fix for Chrome and will plan to upstream the fix to ICU.  e.g. [https://ssl.icu-project.org/trac/ticket/13720](https://ssl.icu-project.org/trac/ticket/13720) (13721, 13723, 13726 , 13719, 9562)
                 37. JW: full list of grandfathered, no Prefix is ["i-default", "i-enochian", "i-mingo", "cel-gaulish", "zh-min"]
                 38. DE: Conclusion: Keep IANA grandfathered tags translation, and when there is no official mapping, throw/replace as described earlier/
         * New questions raised by @anba

--- a/meetings/notes-2018-06-15.md
+++ b/meetings/notes-2018-06-15.md
@@ -76,8 +76,8 @@ Agenda and notes
                     1. Is there a ticket for fixing/changing ICU?
                 33. DE: Could we permit implementation-defined mappings to eliminate all grandfathered tags (in practice, ICU mappings)
                 34. JS: ICU has several bugs in this mapping area
-                35. SL: [https://ssl.icu-project.org/trac/ticket/13650](https://ssl.icu-project.org/trac/ticket/13650) is one filed to update ICU's behavior. (probably just a bug/outdated instead of a policy difference); 
-                36. JS: there are also a series of bugs filed on this issue. I have a fix for Chrome and will plan to upstream the fix to ICU.  e.g. [https://ssl.icu-project.org/trac/ticket/13720](https://ssl.icu-project.org/trac/ticket/13720) (13721, 13723, 13726 , 13719, 9562)
+                35. SL: [https://unicode-org.atlassian.net/browse/ICU-13650](https://unicode-org.atlassian.net/browse/ICU-13650) is one filed to update ICU's behavior. (probably just a bug/outdated instead of a policy difference); 
+                36. JS: there are also a series of bugs filed on this issue. I have a fix for Chrome and will plan to upstream the fix to ICU.  e.g. [https://unicode-org.atlassian.net/browse/ICU-13720](https://unicode-org.atlassian.net/browse/ICU-13720) (13721, 13723, 13726 , 13719, 9562)
                 37. JW: full list of grandfathered, no Prefix is ["i-default", "i-enochian", "i-mingo", "cel-gaulish", "zh-min"]
                 38. DE: Conclusion: Keep IANA grandfathered tags translation, and when there is no official mapping, throw/replace as described earlier/
         * New questions raised by @anba

--- a/meetings/notes-2018-08-16.md
+++ b/meetings/notes-2018-08-16.md
@@ -50,7 +50,7 @@ Agenda and minutes
                 2. ZB: I don't think it does
                 3. JW: The SpiderMonkey implementation doesn't have formatToParts
             24. V8
-                1. FB: The implementation in V8 is complete except formatToParts; maybe we have a workaround that SG would know about. We found a bug in ICU ([ICU-12171](http://unicode-org.atlassian.net/browse/ICU-12171)) and are waiting for a fix to complete
+                1. FB: The implementation in V8 is complete except formatToParts; maybe we have a workaround that SG would know about. We found a bug in ICU ([ICU-12171](https://unicode-org.atlassian.net/browse/ICU-12171)) and are waiting for a fix to complete
                     1. SL: the bug above has outstanding design questions from 2016
                     2. FB: Someone from our team in Google is going to work on this issue
                 2. SG: Are the test262 tests done?
@@ -153,7 +153,7 @@ Agenda and minutes
         * SL: A question here is whether liason is with ECMA as a whole, or TC39 or specifically this WG.
         * DE will follow up with ECMA secretariat and get back to SL
 
-    3. Working with the [W3C i18n](http://w3c.github.io/i18n-activity/i18n-wg/) WG
+    3. Working with the [W3C i18n](https://w3c.github.io/i18n-activity/i18n-wg/) WG
 6. Future meetings
     1. Any topics to discuss at the next meeting?
     2. Is September 20, 2018 at 16:00 UTC a good next meeting time?

--- a/meetings/notes-2018-10-18.md
+++ b/meetings/notes-2018-10-18.md
@@ -3,7 +3,7 @@ Attendees: Zibi Braniecki (ZB), Ms2ger (MS), Shane Carr (SC), Jeff Walden (JW), 
 Notes:
 
 1. Bugs/PRs against ECMA-402
-    1. Should locales be general BCP47, or[ Unicode BCP47 Locale Identifiers](http://www.unicode.org/reports/tr35/proposed.html#BCP_47_Conformance)? ([issue](https://github.com/tc39/proposal-intl-locale/issues/63)). Implications:
+    1. Should locales be general BCP47, or[ Unicode BCP47 Locale Identifiers](https://www.unicode.org/reports/tr35/proposed.html#BCP_47_Conformance)? ([issue](https://github.com/tc39/proposal-intl-locale/issues/63)). Implications:
         1. After canonicalizing, no support for grandfathered tags; private use is always as an extension
         2. Adopt CLDR semantics for some things on top of IANA
         3. Still ban _

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -252,7 +252,7 @@
         </p>
 
         <emu-note>
-          It is recommended that the CompareStrings abstract operation be implemented following Unicode Technical Standard 10, Unicode Collation Algorithm (available at <a href="https://unicode.org/reports/tr10/">https://unicode.org/reports/tr10/</a>), using tailorings for the effective locale and collation options of _collator_. It is recommended that implementations use the tailorings provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>).
+          It is recommended that the CompareStrings abstract operation be implemented following Unicode Technical Standard 10, Unicode Collation Algorithm (available at <a href="https://unicode.org/reports/tr10/">https://unicode.org/reports/tr10/</a>), using tailorings for the effective locale and collation options of _collator_. It is recommended that implementations use the tailorings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>).
         </emu-note>
 
         <emu-note>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -252,7 +252,7 @@
         </p>
 
         <emu-note>
-          It is recommended that the CompareStrings abstract operation be implemented following Unicode Technical Standard 10, Unicode Collation Algorithm (available at <a href="https://unicode.org/reports/tr10/">https://unicode.org/reports/tr10/</a>), using tailorings for the effective locale and collation options of _collator_. It is recommended that implementations use the tailorings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
+          It is recommended that the CompareStrings abstract operation be implemented following Unicode Technical Standard 10, Unicode Collation Algorithm (available at <a href="https://unicode.org/reports/tr10/">https://unicode.org/reports/tr10/</a>), using tailorings for the effective locale and collation options of _collator_. It is recommended that implementations use the tailorings provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>).
         </emu-note>
 
         <emu-note>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -315,7 +315,7 @@
       </emu-alg>
 
       <emu-note>
-        It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>), and use CLDR `"abbreviated"` strings for DateTimeFormat `"short"` strings, and CLDR `"wide"` strings for DateTimeFormat `"long"` strings.
+        It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>), and use CLDR `"abbreviated"` strings for DateTimeFormat `"short"` strings, and CLDR `"wide"` strings for DateTimeFormat `"long"` strings.
       </emu-note>
 
       <emu-note>
@@ -524,7 +524,7 @@
       </p>
 
       <emu-note>
-        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
+        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>).
       </emu-note>
     </emu-clause>
   </emu-clause>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -315,7 +315,7 @@
       </emu-alg>
 
       <emu-note>
-        It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>), and use CLDR `"abbreviated"` strings for DateTimeFormat `"short"` strings, and CLDR `"wide"` strings for DateTimeFormat `"long"` strings.
+        It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>), and use CLDR `"abbreviated"` strings for DateTimeFormat `"short"` strings, and CLDR `"wide"` strings for DateTimeFormat `"long"` strings.
       </emu-note>
 
       <emu-note>
@@ -524,7 +524,7 @@
       </p>
 
       <emu-note>
-        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>).
+        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>).
       </emu-note>
     </emu-clause>
   </emu-clause>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -21,7 +21,7 @@
     <h1>Language Tags</h1>
 
     <p>
-      The ECMAScript 2020 Internationalization API Specification identifies locales using language tags as by the Unicode BCP 47 locale identifiers, which may include extensions such as those registered through RFC 6067. Their canonical form is that of a Unicode BCP 47 Locale Identifier, as specified in <a href="http://unicode.org/reports/tr35/#BCP_47_Conformance">Unicode Technical Standard #35 LDML § 3.3 BCP 47 Conformance</a>.
+      The ECMAScript 2020 Internationalization API Specification identifies locales using language tags as by the Unicode BCP 47 locale identifiers, which may include extensions such as those registered through RFC 6067. Their canonical form is that of a Unicode BCP 47 Locale Identifier, as specified in <a href="https://unicode.org/reports/tr35/#BCP_47_Conformance">Unicode Technical Standard #35 LDML § 3.3 BCP 47 Conformance</a>.
     </p>
 
     <p>
@@ -59,7 +59,7 @@
 
       <p>
         The CanonicalizeLanguageTag abstract operation returns the canonical and case-regularized form of the _locale_ argument (which must be a String value that is a structurally valid Unicode BCP 47 Locale Identifier as verified by the IsStructurallyValidLanguageTag abstract operation).
-        A conforming implementation shall take the steps specified in the &ldquo;BCP 47 Language Tag to Unicode BCP 47 Locale Identifier&rdquo; algorithm, from <a href="http://unicode.org/reports/tr35/#BCP_47_Language_Tag_Conversion">Unicode Technical Standard #35 LDML § 3.3.1 BCP 47 Language Tag Conversion</a>.
+        A conforming implementation shall take the steps specified in the &ldquo;BCP 47 Language Tag to Unicode BCP 47 Locale Identifier&rdquo; algorithm, from <a href="https://unicode.org/reports/tr35/#BCP_47_Language_Tag_Conversion">Unicode Technical Standard #35 LDML § 3.3.1 BCP 47 Language Tag Conversion</a>.
       </p>
     </emu-clause>
 

--- a/spec/normative-references.html
+++ b/spec/normative-references.html
@@ -46,7 +46,7 @@
       <a href="https://www.unicode.org/versions/latest">The Unicode Standard</a>
     </li>
     <li>
-      <a href="https://www.unicode.org/reports/tr35/">Unicode Technical Standard 35, Unicode Locale Data Markup Language</a>
+      <a href="https://unicode.org/reports/tr35/">Unicode Technical Standard 35, Unicode Locale Data Markup Language</a>
     </li>
   </ul>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -331,7 +331,7 @@
       </emu-note>
 
       <emu-note>
-        It is recommended that implementations use the locale provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>).
+        It is recommended that implementations use the locale provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>).
       </emu-note>
     </emu-clause>
 
@@ -560,7 +560,7 @@
       </ul>
 
       <emu-note>
-        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>).
+        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>).
       </emu-note>
     </emu-clause>
   </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -331,7 +331,7 @@
       </emu-note>
 
       <emu-note>
-        It is recommended that implementations use the locale provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
+        It is recommended that implementations use the locale provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>).
       </emu-note>
     </emu-clause>
 
@@ -560,7 +560,7 @@
       </ul>
 
       <emu-note>
-        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
+        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>).
       </emu-note>
     </emu-clause>
   </emu-clause>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -218,7 +218,7 @@
       </p>
 
       <emu-note>
-        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
+        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>).
       </emu-note>
 
     </emu-clause>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -218,7 +218,7 @@
       </p>
 
       <emu-note>
-        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="https://unicode.org/cldr/trac/wiki">https://unicode.org/cldr/trac/wiki</a>).
+        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>).
       </emu-note>
 
     </emu-clause>


### PR DESCRIPTION
Ref #330 

cc @anba 

---

There are still some http links that I couldn't find any alternative using https. Mostly for cldr.unicode.org.