### PR TITLE
Editorial: clarification how to calculate gregorian date and time values

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -372,17 +372,19 @@
 
       <emu-alg>
         1. Assert: Type(_t_) is Number.
-        1. Apply calendrical calculations on _t_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules.
-        1. If the _calendar_ is `"gregory"`, then the calculations of weekday, year, month, day, hour, minute and second must match the algorithms specified in ES2020, <emu-xref href="#sec-overview-of-date-objects-and-definitions-of-abstract-operations"></emu-xref>. In these calculations, use the value _tz_, which is the time value _t_ + _timeZoneOffset_. The value _timeZoneOffset_ must be calculated according to <emu-xref href="#sec-local-time-zone-adjustment">LocalTZA(_t_, *true*)</emu-xre> where `local time zone` is replaced with timezone `timeZone`.
-          <ul>
-            <li>The value for weekday must be the result of `WeekDay(tz)` specified in ES2020's <emu-xref href="#sec-week-day">Week Day</emu-xref>.</li>
-            <li>The value for year must be the result of `YearFromTime(tz)` specified in ES2020's <emu-xref href="#sec-year-number">Year Number</emu-xref>.</li>
-            <li>The value for month must be the result of `MonthFromTime(tz)` specified in ES2020's <emu-xref href="#sec-month-number">Month Number</emu-xref>.</li>
-            <li>The value for date must be the result of `DateFromTime(tz)` specified in ES2020's <emu-xref href="#sec-date-number">Date Number</emu-xref>.</li>
-            <li>The value for hour must be the result of `HourFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
-            <li>The value for minute must be the result of `MinuteFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
-            <li>The value for second must be the result of `SecondFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
-          </ul>
+        1. If _calendar_ is `"gregory"`,
+          1. Apply calendrical calculations on _t_ to produce values for weekday, year, month, day, hour, minute and second according to the algorithms specified in ES2020, <emu-xref href="#sec-overview-of-date-objects-and-definitions-of-abstract-operations"></emu-xref>. In these calculations, use the value _tz_, which is the time value _t_ + _timeZoneOffset_. The value _timeZoneOffset_ must be calculated according to <emu-xref href="#sec-local-time-zone-adjustment">LocalTZA(_t_, *true*)</emu-xref> where the local time zone is replaced with timezone _timeZone_.
+            <ul>
+              <li>The value for weekday must be the result of `WeekDay(tz)` specified in ES2020's <emu-xref href="#sec-week-day">Week Day</emu-xref>.</li>
+              <li>The value for year must be the result of `YearFromTime(tz)` specified in ES2020's <emu-xref href="#sec-year-number">Year Number</emu-xref>.</li>
+              <li>The value for month must be the result of `MonthFromTime(tz)` specified in ES2020's <emu-xref href="#sec-month-number">Month Number</emu-xref>.</li>
+              <li>The value for date must be the result of `DateFromTime(tz)` specified in ES2020's <emu-xref href="#sec-date-number">Date Number</emu-xref>.</li>
+              <li>The value for hour must be the result of `HourFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
+              <li>The value for minute must be the result of `MinuteFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
+              <li>The value for second must be the result of `SecondFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
+            </ul>
+        1. Else,
+          1. Apply calendrical calculations on _t_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules.
         1. Return a Record with fields [[weekday]], [[era]], [[year]], [[month]], [[day]], [[hour]], [[minute]], [[second]], and [[inDST]], each with the corresponding calculated value.
       </emu-alg>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -373,15 +373,15 @@
       <emu-alg>
         1. Assert: Type(_t_) is Number.
         1. Apply calendrical calculations on _t_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules.
-        1. If the _calendar_ is `"gregory"`, then the calculations of weekday, year, month, day, hour, minute and second must match the algorithms specified in ES2020, <emu-xref href="#sec-overview-of-date-objects-and-definitions-of-abstract-operations"></emu-xref>:
+        1. If the _calendar_ is `"gregory"`, then the calculations of weekday, year, month, day, hour, minute and second must match the algorithms specified in ES2020, <emu-xref href="#sec-overview-of-date-objects-and-definitions-of-abstract-operations"></emu-xref>. In these calculations, use the value _tz_, which is the time value _t_ + _timeZoneOffset_. The value _timeZoneOffset_ must be calculated according to <emu-xref href="#sec-local-time-zone-adjustment">LocalTZA(_t_, *true*)</emu-xre> where `local time zone` is replaced with timezone `timeZone`.
           <ul>
-            <li>The value for weekday must be the result of `WeekDay(t)` specified in ES2020's <emu-xref href="#sec-week-day">Week Day</emu-xref>.</li>
-            <li>The value for year must be the result of `YearFromTime(t)` specified in ES2020's <emu-xref href="#sec-year-number">Year Number</emu-xref>.</li>
-            <li>The value for month must be the result of `MonthFromTime(t)` specified in ES2020's <emu-xref href="#sec-month-number">Month Number</emu-xref>.</li>
-            <li>The value for date must be the result of `DateFromTime(t)` specified in ES2020's <emu-xref href="#sec-date-number">Date Number</emu-xref>.</li>
-            <li>The value for hour must be the result of `HourFromTime(t)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
-            <li>The value for minute must be the result of `MinuteFromTime(t)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
-            <li>The value for second must be the result of `SecondFromTime(t)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
+            <li>The value for weekday must be the result of `WeekDay(tz)` specified in ES2020's <emu-xref href="#sec-week-day">Week Day</emu-xref>.</li>
+            <li>The value for year must be the result of `YearFromTime(tz)` specified in ES2020's <emu-xref href="#sec-year-number">Year Number</emu-xref>.</li>
+            <li>The value for month must be the result of `MonthFromTime(tz)` specified in ES2020's <emu-xref href="#sec-month-number">Month Number</emu-xref>.</li>
+            <li>The value for date must be the result of `DateFromTime(tz)` specified in ES2020's <emu-xref href="#sec-date-number">Date Number</emu-xref>.</li>
+            <li>The value for hour must be the result of `HourFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
+            <li>The value for minute must be the result of `MinuteFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
+            <li>The value for second must be the result of `SecondFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
           </ul>
         1. Return a Record with fields [[weekday]], [[era]], [[year]], [[month]], [[day]], [[hour]], [[minute]], [[second]], and [[inDST]], each with the corresponding calculated value.
       </emu-alg>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -373,20 +373,60 @@
       <emu-alg>
         1. Assert: Type(_t_) is Number.
         1. If _calendar_ is `"gregory"`,
-          1. Apply calendrical calculations on _t_ to produce values for weekday, year, month, day, hour, minute and second according to the algorithms specified in ES2020, <emu-xref href="#sec-overview-of-date-objects-and-definitions-of-abstract-operations"></emu-xref>. In these calculations, use the value _tz_, which is the time value _t_ + _timeZoneOffset_. The value _timeZoneOffset_ must be calculated according to <emu-xref href="#sec-local-time-zone-adjustment">LocalTZA(_t_, *true*)</emu-xref> where the local time zone is replaced with timezone _timeZone_.
-            <ul>
-              <li>The value for weekday must be the result of `WeekDay(tz)` specified in ES2020's <emu-xref href="#sec-week-day">Week Day</emu-xref>.</li>
-              <li>The value for year must be the result of `YearFromTime(tz)` specified in ES2020's <emu-xref href="#sec-year-number">Year Number</emu-xref>.</li>
-              <li>The value for month must be the result of `MonthFromTime(tz)` specified in ES2020's <emu-xref href="#sec-month-number">Month Number</emu-xref>.</li>
-              <li>The value for date must be the result of `DateFromTime(tz)` specified in ES2020's <emu-xref href="#sec-date-number">Date Number</emu-xref>.</li>
-              <li>The value for hour must be the result of `HourFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
-              <li>The value for minute must be the result of `MinuteFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
-              <li>The value for second must be the result of `SecondFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
-            </ul>
+          1. Let _timeZoneOffset_ be the value calculated according to <emu-xref href="#sec-local-time-zone-adjustment">LocalTZA(_t_, *true*)</emu-xref> where the local time zone is replaced with timezone _timeZone_.
+          1. Let _tz_ be the time value _t_ + _timeZoneOffset_.
+          1. Return a record with fields calculated from _tz_ according to <emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref>.
         1. Else,
-          1. Apply calendrical calculations on _t_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules.
-        1. Return a Record with fields [[weekday]], [[era]], [[year]], [[month]], [[day]], [[hour]], [[minute]], [[second]], and [[inDST]], each with the corresponding calculated value.
+          1. Return a record with the fields of Column 1 of <emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref> calculated from _t_ for the given _calendar_ and _timeZone_. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules.
       </emu-alg>
+
+      <emu-table id="table-datetimeformat-tolocaltime-record">
+        <emu-caption>Record returned by ToLocalTime</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>Value Calculation for Gregorian Calendar</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[weekday]]</td>
+            <td>`WeekDay(tz)` specified in ES2020's <emu-xref href="#sec-week-day">Week Day</emu-xref></td>
+          </tr>
+          <tr>
+            <td>[[era]]</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>[[year]]</td>
+            <td>`YearFromTime(tz)` specified in ES2020's <emu-xref href="#sec-year-number">Year Number</emu-xref></td>
+          </tr>
+          <tr>
+            <td>[[month]]</td>
+            <td>`MonthFromTime(tz)` specified in ES2020's <emu-xref href="#sec-month-number">Month Number</emu-xref></td>
+          </tr>
+          <tr>
+            <td>[[day]]</td>
+            <td>`DateFromTime(tz)` specified in ES2020's <emu-xref href="#sec-date-number">Date Number</emu-xref></td>
+          </tr>
+          <tr>
+            <td>[[hour]]</td>
+            <td>`HourFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
+          </tr>
+          <tr>
+            <td>[[minute]]</td>
+            <td>`MinuteFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
+          </tr>
+          <tr>
+            <td>[[second]]</td>
+            <td>`SecondFromTime(tz)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
+          </tr>
+          <tr>
+            <td>[[inDST]]</td>
+            <td>Calculate *true* or *false* using the best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules.</td>
+          </tr>
+        </table>
+      </emu-table>
 
       <emu-note>
         It is recommended that implementations use the time zone information of the IANA Time Zone Database.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -364,14 +364,25 @@
     </emu-clause>
 
     <emu-clause id="sec-tolocaltime" aoid="ToLocalTime">
-      <h1>ToLocalTime ( _date_, _calendar_, _timeZone_ )</h1>
+      <h1>ToLocalTime ( _t_, _calendar_, _timeZone_ )</h1>
 
       <p>
-        When the ToLocalTime abstract operation is called with arguments _date_, _calendar_, and _timeZone_, the following steps are taken:
+        When the ToLocalTime abstract operation is called with arguments _t_, _calendar_, and _timeZone_, the following steps are taken:
       </p>
 
       <emu-alg>
-        1. Apply calendrical calculations on _date_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules. If the _calendar_ is `"gregory"`, then the calculations must match the algorithms specified in ES2020, <emu-xref href="#sec-overview-of-date-objects-and-definitions-of-abstract-operations"></emu-xref>.
+        1. Assert: Type(_t_) is Number.
+        1. Apply calendrical calculations on _t_ for the given _calendar_ and _timeZone_ to produce weekday, era, year, month, day, hour, minute, second, and inDST values. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules.
+        1. If the _calendar_ is `"gregory"`, then the calculations of weekday, year, month, day, hour, minute and second must match the algorithms specified in ES2020, <emu-xref href="#sec-overview-of-date-objects-and-definitions-of-abstract-operations"></emu-xref>:
+          <ul>
+            <li>The value for weekday must be the result of `WeekDay(t)` specified in ES2020's <emu-xref href="#sec-week-day">Week Day</emu-xref>.</li>
+            <li>The value for year must be the result of `YearFromTime(t)` specified in ES2020's <emu-xref href="#sec-year-number">Year Number</emu-xref>.</li>
+            <li>The value for month must be the result of `MonthFromTime(t)` specified in ES2020's <emu-xref href="#sec-month-number">Month Number</emu-xref>.</li>
+            <li>The value for date must be the result of `DateFromTime(t)` specified in ES2020's <emu-xref href="#sec-date-number">Date Number</emu-xref>.</li>
+            <li>The value for hour must be the result of `HourFromTime(t)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
+            <li>The value for minute must be the result of `MinuteFromTime(t)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
+            <li>The value for second must be the result of `SecondFromTime(t)` specified in ES2020's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref>.</li>
+          </ul>
         1. Return a Record with fields [[weekday]], [[era]], [[year]], [[month]], [[day]], [[hour]], [[minute]], [[second]], and [[inDST]], each with the corresponding calculated value.
       </emu-alg>
 


### PR DESCRIPTION
This PR should not change the outcome of this abstract operation. The intent of these changes is only to make clear which algorithms to use for which values from [ECMA-262's date-values-from-time algorithms](https://tc39.github.io/ecma262/#sec-overview-of-date-objects-and-definitions-of-abstract-operations).

Here is the html for easy reading:
https://spectranaut.github.io/ecma402/#sec-tolocaltime