### PR TITLE
Normative: Allow calendar to determine choice of pattern

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -87,7 +87,8 @@
         1. Let _localeData_ be %DateTimeFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale( %DateTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %DateTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _dateTimeFormat_.[[Locale]] to _r_.[[locale]].
-        1. Set _dateTimeFormat_.[[Calendar]] to _r_.[[ca]].
+        1. Let _calendar_ be _r_.[[ca]].
+        1. Set _dateTimeFormat_.[[Calendar]] to _calendar_.
         1. Set _dateTimeFormat_.[[HourCycle]] to _r_.[[hc]].
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
@@ -106,7 +107,7 @@
           1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
           1. Set _opt_.[[&lt;_prop_&gt;]] to _value_.
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _formats_ be _dataLocaleData_.[[formats]].
+        1. Let _formats_ be _dataLocaleData_.[[formats]].[[&lt;_calendar_&gt;]].
         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
         1. If _matcher_ is *"basic"*, then
           1. Let _bestFormat_ be BasicFormatMatcher(_opt_, _formats_).
@@ -561,7 +562,7 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle]] must be a String value equal to *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[formats]] must be a List of records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a List may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field for all locale values _locale_. This formats field must have a [[&lt;_calendar_&gt;]] field for all calendar values _calendar_. The value of this field must be a list of records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
           <ul>
             <li>weekday, year, month, day, hour, minute, second</li>
             <li>weekday, year, month, day</li>


### PR DESCRIPTION
In CLDR, the set of patterns is based on the the calendar, not
simply the language-region-script. Previously, however, the set
was based purely on the base name. This patch switches to a two-level
lookup to permit implementations to have more accuracy.

Splitting off part of #227. Fixes part of #225.