### PR TITLE
Normative: Permit relatedYear and yearName in output

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -296,6 +296,13 @@
             1. Else,
               1. Let _fv_ be an implementation and locale dependent String value representing `"ante meridiem"`.
             1. Add new part record { [[Type]]: `"dayPeriod"`, [[Value]]: _fv_ } as a new element of the list _result_.
+          1. Else if _p_ is equal to `"relatedYear"`, then
+            1. Let _v_ be _tm_.[[relatedYear]].
+            1. Let _fv_ be FormatNumber(_nf_, _v_).
+            1. Add new part record { [[Type]]: `"relatedYear"`, [[Value]]: _fv_ } as a new element of the list _result_.
+          1. Else if _p_ is equal to `"yearName"`, then
+            1. Let _v_ be _tm_.[[yearName]].
+            1. Add new part record { [[Type]]: `"yearName"`, [[Value]]: _v_ } as a new element of the list _result_.
           1. Else,
             1. Let _unknown_ be an implementation-, locale-, and numbering system-dependent String based on _x_ and _p_.
             1. Append a new Record { [[Type]]: `"unknown"`, [[Value]]: _unknown_ } as the last element of _result_.
@@ -388,6 +395,14 @@
           <tr>
             <td>[[year]]</td>
             <td>`YearFromTime(tz)` specified in ES2020's <emu-xref href="#sec-year-number">Year Number</emu-xref></td>
+          </tr>
+          <tr>
+            <td>[[relatedYear]]</td>
+            <td>*undefined*</td>
+          </tr>
+          <tr>
+            <td>[[yearName]]</td>
+            <td>*undefined*</td>
           </tr>
           <tr>
             <td>[[month]]</td>
@@ -556,7 +571,7 @@
             <li>hour, minute, second</li>
             <li>hour, minute</li>
           </ul>
-          Each of the records must also have a [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with `"{"`, followed by the name of the field, followed by `"}"`. If the record has an hour field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the [[pattern]] field, contains a substring `"{ampm}"`.
+          Each of the records must also have a [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with `"{"`, followed by the name of the field, followed by `"}"`. If the record has an hour field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the [[pattern]] field, contains a substring `"{ampm}"`. If the record has a [[year]] field, the [[pattern]] and [[pattern12]] values may contain the substrings `"{yearName}"` and `"{relatedYear}"`.
         </li>
       </ul>
 


### PR DESCRIPTION
These fields are present in, e.g., some Chinese calendars.

Broken out from #227. Fixes part of #225.