### PR TITLE
Normative: Align currency handling in NumberFormat constructor with the Unified API proposal.

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -57,16 +57,14 @@
         1. Let _style_ be ? GetOption(_options_, `"style"`, `"string"`, &laquo; `"decimal"`, `"percent"`, `"currency"` &raquo;, `"decimal"`).
         1. Set _numberFormat_.[[Style]] to _style_.
         1. Let _currency_ be ? GetOption(_options_, `"currency"`, `"string"`, *undefined*, *undefined*).
-        1. If _currency_ is not *undefined*, then
-          1. If the result of IsWellFormedCurrencyCode(_currency_) is *false*, throw a *RangeError* exception.
-        1. If _style_ is `"currency"` and _currency_ is *undefined*, throw a *TypeError* exception.
+        1. Let _currencyDisplay_ be ? GetOption(_options_, `"currencyDisplay"`, `"string"`, &laquo; `"code"`, `"symbol"`, `"name"` &raquo;, `"symbol"`).
         1. If _style_ is `"currency"`, then
+          1. If _currency_ is *undefined*, throw a *TypeError* exception.
+          1. If the result of IsWellFormedCurrencyCode(_currency_) is *false*, throw a *RangeError* exception.
           1. Let _currency_ be the result of converting _currency_ to upper case as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
           1. Set _numberFormat_.[[Currency]] to _currency_.
+          1. Set _numberFormat_.[[CurrencyDisplay]] to _currencyDisplay_.
           1. Let _cDigits_ be CurrencyDigits(_currency_).
-        1. Let _currencyDisplay_ be ? GetOption(_options_, `"currencyDisplay"`, `"string"`, &laquo; `"code"`, `"symbol"`, `"name"` &raquo;, `"symbol"`).
-        1. If _style_ is `"currency"`, set _numberFormat_.[[CurrencyDisplay]] to _currencyDisplay_.
-        1. If _style_ is `"currency"`, then
           1. Let _mnfdDefault_ be _cDigits_.
           1. Let _mxfdDefault_ be _cDigits_.
         1. Else,


### PR DESCRIPTION
This contains a few minor but script-observable changes to the NumberFormat constructor from the Unified API proposal.