### PR TITLE
Normative: Apply kebab-case for best-fit

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -27,7 +27,8 @@
         1. Else,
           1. Let _localeData_ be %Collator%.[[SearchLocaleData]].
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
+        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best-fit"`, `"best fit"` &raquo;, `"best-fit"`).
+        1. If _matcher_ is `"best fit"`, let _matcher_ be `"best-fit"`.
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _numeric_ be ? GetOption(_options_, `"numeric"`, `"boolean"`, *undefined*, *undefined*).
         1. If _numeric_ is not *undefined*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -77,7 +77,8 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Let _options_ be ? ToDateTimeOptions(_options_, `"any"`, `"date"`).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
+        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best-fit"`, `"best fit"` &raquo;, `"best-fit"`).
+        1. If _matcher_ is `"best fit"`, let _matcher_ be `"best-fit"`.
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _hour12_ be ? GetOption(_options_, `"hour12"`, `"boolean"`, *undefined*, *undefined*).
         1. Let _hourCycle_ be ? GetOption(_options_, `"hourCycle"`, `"string"`, &laquo; `"h11"`, `"h12"`, `"h23"`, `"h24"` &raquo;, *undefined*).
@@ -107,7 +108,7 @@
           1. Set _opt_.[[&lt;_prop_&gt;]] to _value_.
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _formats_ be _dataLocaleData_.[[formats]].
-        1. Let _matcher_ be ? GetOption(_options_, `"formatMatcher"`, `"string"`, &laquo; `"basic"`, `"best fit"` &raquo;, `"best fit"`).
+        1. Let _matcher_ be ? GetOption(_options_, `"formatMatcher"`, `"string"`, &laquo; `"basic"`, `"best-fit"` &raquo;, `"best-fit"`).
         1. If _matcher_ is `"basic"`, then
           1. Let _bestFormat_ be BasicFormatMatcher(_opt_, _formats_).
         1. Else,

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -264,9 +264,10 @@
       <emu-alg>
         1. If _options_ is not *undefined*, then
           1. Let _options_ be ? ToObject(_options_).
-          1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
-        1. Else, let _matcher_ be `"best fit"`.
-        1. If _matcher_ is `"best fit"`, then
+          1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best-fit"`, `"best fit"` &raquo;, `"best-fit"`).
+          1. If _matcher_ is `"best fit"`, let _matcher_ be `"best-fit"`.
+        1. Else, let _matcher_ be `"best-fit"`.
+        1. If _matcher_ is `"best-fit"`, then
           1. Let _supportedLocales_ be BestFitSupportedLocales(_availableLocales_, _requestedLocales_).
         1. Else,
           1. Let _supportedLocales_ be LookupSupportedLocales(_availableLocales_, _requestedLocales_).

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -47,7 +47,8 @@
         1. Else,
           1. Let _options_ be ? ToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
+        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best-fit"`, `"best fit"` &raquo;, `"best-fit"`).
+        1. If _matcher_ is `"best fit"`, let _matcher_ be `"best-fit"`.
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %NumberFormat%.[[RelevantExtensionKeys]], _localeData_).

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -18,7 +18,8 @@
         1. Else
           1. Let _options_ be ? ToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
+        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best-fit"`, `"best fit"` &raquo;, `"best-fit"`).
+        1. If _matcher_ is `"best fit"`, let _matcher_ be `"best-fit"`.
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _t_ be ? GetOption(_options_, `"type"`, `"string"`, &laquo; `"cardinal"`, `"ordinal"` &raquo;, `"cardinal"`).
         1. Set _pluralRules_.[[Type]] to _t_.


### PR DESCRIPTION
This is an initial effort to apply kebab-case for enumeration string values in ECMA-402.

This style follow convention set at the W3C Tag Design Principles. Ref:
https://w3ctag.github.io/design-principles/#casing-rules

The goal is to illustrate a change in an experimental way, it first needs discussion from
the Intl team to confirm if 'best fit' should also be included in a possible set of changes
to match style convention.