### PR TITLE
Editorial: add [[era]] calculation for gregorian date

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -395,7 +395,7 @@
           </tr>
           <tr>
             <td>[[era]]</td>
-            <td></td>
+            <td>Let `year` be `YearFromTime(tz)` specified in ES2020's <emu-xref href="#sec-year-number">Year Number</emu-xref>. If `year` is less than 0, return 'BC', else, return 'AD'.</td>
           </tr>
           <tr>
             <td>[[year]]</td>


### PR DESCRIPTION
This commit was missing from the merged PR: https://github.com/tc39/ecma402/pull/348

Relevant discussion: https://github.com/tc39/ecma402/pull/348#discussion_r307534254