### PR TITLE
Editorial: Add question marks to Format calls.

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -239,7 +239,7 @@
           1. Let _x_ be Call(%Date_now%, *undefined*).
         1. Else,
           1. Let _x_ be ? ToNumber(_date_).
-        1. Return FormatDateTime(_dtf_, _x_).
+        1. Return ? FormatDateTime(_dtf_, _x_).
       </emu-alg>
 
       <p>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -128,7 +128,7 @@
       <emu-alg>
         1. Let _x_ be ? thisNumberValue(*this* value).
         1. Let _numberFormat_ be ? Construct(%NumberFormat%, &laquo; _locales_, _options_ &raquo;).
-        1. Return FormatNumeric(_numberFormat_, _x_).
+        1. Return ? FormatNumeric(_numberFormat_, _x_).
       </emu-alg>
 
     </emu-clause>
@@ -156,7 +156,7 @@
       <emu-alg>
         1. Let _x_ be ? thisBigIntValue(*this* value).
         1. Let _numberFormat_ be ? Construct(%NumberFormat%, &laquo; _locales_, _options_ &raquo;).
-        1. Return FormatNumeric(_numberFormat_, _x_).
+        1. Return ? FormatNumeric(_numberFormat_, _x_).
       </emu-alg>
 
     </emu-clause>
@@ -185,7 +185,7 @@
         1. If _x_ is *NaN*, return `"Invalid Date"`.
         1. Let _options_ be ? ToDateTimeOptions(_options_, `"any"`, `"all"`).
         1. Let _dateFormat_ be ? Construct(%DateTimeFormat%, &laquo; _locales_, _options_ &raquo;).
-        1. Return FormatDateTime(_dateFormat_, _x_).
+        1. Return ? FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
 
     </emu-clause>
@@ -206,7 +206,7 @@
         1. If _x_ is *NaN*, return `"Invalid Date"`.
         1. Let _options_ be ? ToDateTimeOptions(_options_, `"date"`, `"date"`).
         1. Let _dateFormat_ be ? Construct(%DateTimeFormat%, &laquo; _locales_, _options_ &raquo;).
-        1. Return FormatDateTime(_dateFormat_, _x_).
+        1. Return ? FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
 
     </emu-clause>
@@ -227,7 +227,7 @@
         1. If _x_ is *NaN*, return `"Invalid Date"`.
         1. Let _options_ be ? ToDateTimeOptions(_options_, `"time"`, `"time"`).
         1. Let _timeFormat_ be ? Construct(%DateTimeFormat%, &laquo; _locales_, _options_ &raquo;).
-        1. Return FormatDateTime(_timeFormat_, _x_).
+        1. Return ? FormatDateTime(_timeFormat_, _x_).
       </emu-alg>
 
     </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -111,7 +111,7 @@
         1. Assert: Type(_nf_) is Object and _nf_ has an [[InitializedNumberFormat]] internal slot.
         1. If _value_ is not provided, let _value_ be *undefined*.
         1. Let _x_ be ? ToNumeric(_value_).
-        1. Return FormatNumeric(_nf_, _x_).
+        1. Return ? FormatNumeric(_nf_, _x_).
       </emu-alg>
 
       <p>


### PR DESCRIPTION
This is not strictly necessary, as it can be interpreted as returning the
Completion Record. However, using the question mark seems to be the more
common approach.