### PR TITLE
Editorial: Fix consistency over instances that are ordinary objects

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -340,7 +340,7 @@
     <h1>Properties of Intl.Collator Instances</h1>
 
     <p>
-      Intl.Collator instances inherit properties from %CollatorPrototype%.
+      Intl.Collator instances are ordinary objects that inherit properties from %CollatorPrototype%.
     </p>
 
     <p>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -771,7 +771,7 @@
     <h1>Properties of Intl.DateTimeFormat Instances</h1>
 
     <p>
-      Intl.DateTimeFormat instances inherit properties from %DateTimeFormatPrototype%.
+      Intl.DateTimeFormat instances are ordinary objects that inherit properties from %DateTimeFormatPrototype%.
     </p>
 
     <p>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -702,7 +702,7 @@
     <h1>Properties of Intl.NumberFormat Instances</h1>
 
     <p>
-      Intl.NumberFormat instances inherit properties from %NumberFormatPrototype%.
+      Intl.NumberFormat instances are ordinary objects that inherit properties from %NumberFormatPrototype%.
     </p>
 
     <p>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -334,7 +334,7 @@
     <h1>Properties of Intl.PluralRules Instances</h1>
 
     <p>
-      Intl.PluralRules instances inherit properties from %PluralRulesPrototype%.
+      Intl.PluralRules instances are ordinary objects that inherit properties from %PluralRulesPrototype%.
     </p>
 
     <p>


### PR DESCRIPTION
Ref #386

The consistency matches the text from ECMA-262

cc @anba @gibson042 