### PR TITLE
Editorial: Fix off-by-1 error in PartitionPattern

### DIFF
--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -353,7 +353,7 @@
           1. Set _nextIndex_ to _endIndex_ + 1.
           1. Set _beginIndex_ to ! Call(%String.prototype.indexOf%, _pattern_, &laquo; *"{"*, _nextIndex_ &raquo;).
         1. If _nextIndex_ is less than _length_, then
-          1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, exclusive, to position _length_, exclusive.
+          1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, inclusive, to position _length_, exclusive.
           1. Add new part record { [[Type]]: *"literal"*, [[Value]]: _literal_ } as a new element of the list _result_.
         1. Return _result_.
       </emu-alg>


### PR DESCRIPTION
Right now after the loop finishes, the remainder is
`pattern.substring(nextIndex + 1, len)` (bc it's exclusive) but should
be `pattern.substring(nextIndex, len)` instead since `nextIndex` is
already set to `endIndex + 1` in the loop.

Take `AA{0}BB` as an example, after the loop finishes:
- beginIndex = -1
- endIndex = 4
- nextIndex = 5

so `pattern.substring(5, 7)` yields `BB` (correct) vs the old behavior
would just yield `B`

Reference impl: https://github.com/formatjs/formatjs/blob/master/packages/intl-utils/src/polyfill-utils.ts#L220
Reference test: https://github.com/formatjs/formatjs/blob/master/packages/intl-utils/tests/polyfill-utils.ts