### PR TITLE
Editorial: Stylize strings as values.

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -39,13 +39,13 @@
           Support for the Unicode extensions keys kn, kf and the parallel options properties numeric, caseFirst (<emu-xref href="#sec-initializecollator"></emu-xref>)
         </li>
         <li>
-          The set of supported `"co"` key values (collations) per locale beyond a default collation (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
+          The set of supported *"co"* key values (collations) per locale beyond a default collation (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
         </li>
         <li>
-          The set of supported `"kn"` key values (numeric collation) per locale (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
+          The set of supported *"kn"* key values (numeric collation) per locale (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
         </li>
         <li>
-          The set of supported `"kf"` key values (case order) per locale (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
+          The set of supported *"kf"* key values (case order) per locale (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
         </li>
         <li>
           The default search sensitivity per locale (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
@@ -59,7 +59,7 @@
       In NumberFormat:
       <ul>
         <li>
-          The set of supported `"nu"` key values (numbering systems) per locale (<emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>)
+          The set of supported *"nu"* key values (numbering systems) per locale (<emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>)
         </li>
         <li>
           The patterns used for formatting positive and negative values as decimal, percent, or currency values per locale (<emu-xref href="#sec-formatnumber"></emu-xref>)
@@ -87,10 +87,10 @@
           The BestFitFormatMatcher algorithm (<emu-xref href="#sec-initializedatetimeformat"></emu-xref>)
         </li>
         <li>
-          The set of supported `"ca"` key values (calendars) per locale (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
+          The set of supported *"ca"* key values (calendars) per locale (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
         </li>
         <li>
-          The set of supported `"nu"` key values (numbering systems) per locale (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
+          The set of supported *"nu"* key values (numbering systems) per locale (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
         </li>
         <li>
           The default hourCycle setting per locale (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
@@ -102,7 +102,7 @@
           Localized weekday names, era names, month names, am/pm indicators, and time zone names (<emu-xref href="#sec-formatdatetime"></emu-xref>)
         </li>
         <li>
-          The calendric calculations used for calendars other than `"gregory"`, and adjustments for local time zones and daylight saving time (<emu-xref href="#sec-formatdatetime"></emu-xref>)
+          The calendric calculations used for calendars other than *"gregory"*, and adjustments for local time zones and daylight saving time (<emu-xref href="#sec-formatdatetime"></emu-xref>)
         </li>
       </ul>
     </li>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -20,41 +20,41 @@
           1. Let _options_ be ObjectCreate(*null*).
         1. Else,
           1. Let _options_ be ? ToObject(_options_).
-        1. Let _usage_ be ? GetOption(_options_, `"usage"`, `"string"`, &laquo; `"sort"`, `"search"` &raquo;, `"sort"`).
+        1. Let _usage_ be ? GetOption(_options_, *"usage"*, *"string"*, &laquo; *"sort"*, *"search"* &raquo;, *"sort"*).
         1. Set _collator_.[[Usage]] to _usage_.
-        1. If _usage_ is `"sort"`, then
+        1. If _usage_ is *"sort"*, then
           1. Let _localeData_ be %Collator%.[[SortLocaleData]].
         1. Else,
           1. Let _localeData_ be %Collator%.[[SearchLocaleData]].
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _numeric_ be ? GetOption(_options_, `"numeric"`, `"boolean"`, *undefined*, *undefined*).
+        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, *"boolean"*, *undefined*, *undefined*).
         1. If _numeric_ is not *undefined*, then
           1. Let _numeric_ be ! ToString(_numeric_).
         1. Set _opt_.[[kn]] to _numeric_.
-        1. Let _caseFirst_ be ? GetOption(_options_, `"caseFirst"`, `"string"`, &laquo; `"upper"`, `"lower"`, `"false"` &raquo;, *undefined*).
+        1. Let _caseFirst_ be ? GetOption(_options_, *"caseFirst"*, *"string"*, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
         1. Set _opt_.[[kf]] to _caseFirst_.
         1. Let _relevantExtensionKeys_ be %Collator%.[[RelevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(%Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
         1. Set _collator_.[[Locale]] to _r_.[[locale]].
         1. Let _collation_ be _r_.[[co]].
-        1. If _collation_ is *null*, let _collation_ be `"default"`.
+        1. If _collation_ is *null*, let _collation_ be *"default"*.
         1. Set _collator_.[[Collation]] to _collation_.
-        1. If _relevantExtensionKeys_ contains `"kn"`, then
-          1. Set _collator_.[[Numeric]] to ! SameValue(_r_.[[kn]], `"true"`).
-        1. If _relevantExtensionKeys_ contains `"kf"`, then
+        1. If _relevantExtensionKeys_ contains *"kn"*, then
+          1. Set _collator_.[[Numeric]] to ! SameValue(_r_.[[kn]], *"true"*).
+        1. If _relevantExtensionKeys_ contains *"kf"*, then
           1. Set _collator_.[[CaseFirst]] to _r_.[[kf]].
-        1. Let _sensitivity_ be ? GetOption(_options_, `"sensitivity"`, `"string"`, &laquo; `"base"`, `"accent"`, `"case"`, `"variant"` &raquo;, *undefined*).
+        1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, *"string"*, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
         1. If _sensitivity_ is *undefined*, then
-          1. If _usage_ is `"sort"`, then
-            1. Let _sensitivity_ be `"variant"`.
+          1. If _usage_ is *"sort"*, then
+            1. Let _sensitivity_ be *"variant"*.
           1. Else,
             1. Let _dataLocale_ be _r_.[[dataLocale]].
             1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
             1. Let _sensitivity_ be _dataLocaleData_.[[sensitivity]].
         1. Set _collator_.[[Sensitivity]] to _sensitivity_.
-        1. Let _ignorePunctuation_ be ? GetOption(_options_, `"ignorePunctuation"`, `"boolean"`, *undefined*, *false*).
+        1. Let _ignorePunctuation_ be ? GetOption(_options_, *"ignorePunctuation"*, *"boolean"*, *undefined*, *false*).
         1. Set _collator_.[[IgnorePunctuation]] to _ignorePunctuation_.
         1. Return _collator_.
       </emu-alg>
@@ -71,11 +71,11 @@
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
         1. Let _internalSlotsList_ be &laquo; [[InitializedCollator]], [[Locale]], [[Usage]], [[Sensitivity]], [[IgnorePunctuation]], [[Collation]], [[BoundCompare]] &raquo;.
-        1. If %Collator%.[[RelevantExtensionKeys]] contains `"kn"`, then
+        1. If %Collator%.[[RelevantExtensionKeys]] contains *"kn"*, then
           1. Append [[Numeric]] as the last element of _internalSlotsList_.
-        1. If %Collator%.[[RelevantExtensionKeys]] contains `"kf"`, then
+        1. If %Collator%.[[RelevantExtensionKeys]] contains *"kf"*, then
           1. Append [[CaseFirst]] as the last element of _internalSlotsList_.
-        1. Let _collator_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%CollatorPrototype%"`, _internalSlotsList_).
+        1. Let _collator_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%CollatorPrototype%"*, _internalSlotsList_).
         1. Return ? InitializeCollator(_collator_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -122,11 +122,11 @@
       <h1>Internal Slots</h1>
 
       <p>
-        The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref>. The value of the [[RelevantExtensionKeys]] internal slot is a List that must include the element `"co"`, may include any or all of the elements `"kn"` and `"kf"`, and must not include any other elements.
+        The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref>. The value of the [[RelevantExtensionKeys]] internal slot is a List that must include the element *"co"*, may include any or all of the elements *"kn"* and *"kf"*, and must not include any other elements.
       </p>
 
       <emu-note>
-        Unicode Technical Standard 35 describes ten locale extension keys that are relevant to collation: `"co"` for collator usage and specializations, `"ka"` for alternate handling, `"kb"` for backward second level weight, `"kc"` for case level, `"kn"` for numeric, `"kh"` for hiragana quaternary, `"kk"` for normalization, `"kf"` for case first, `"kr"` for reordering, `"ks"` for collation strength, and `"vt"` for variable top. Collator, however, requires that the usage is specified through the usage property of the options object, alternate handling through the ignorePunctuation property of the options object, and case level and the strength through the sensitivity property of the options object. The `"co"` key in the language tag is supported only for collator specializations, and the keys `"kb"`, `"kh"`, `"kk"`, `"kr"`, and `"vt"` are not allowed in this version of the Internationalization API. Support for the remaining keys is implementation dependent.
+        Unicode Technical Standard 35 describes ten locale extension keys that are relevant to collation: *"co"* for collator usage and specializations, *"ka"* for alternate handling, *"kb"* for backward second level weight, *"kc"* for case level, *"kn"* for numeric, *"kh"* for hiragana quaternary, *"kk"* for normalization, *"kf"* for case first, *"kr"* for reordering, *"ks"* for collation strength, and *"vt"* for variable top. Collator, however, requires that the usage is specified through the usage property of the options object, alternate handling through the ignorePunctuation property of the options object, and case level and the strength through the sensitivity property of the options object. The *"co"* key in the language tag is supported only for collator specializations, and the keys *"kb"*, *"kh"*, *"kk"*, *"kr"*, and *"vt"* are not allowed in this version of the Internationalization API. Support for the remaining keys is implementation dependent.
       </emu-note>
 
       <p>
@@ -135,8 +135,8 @@
 
       <ul>
         <li>The first element of [[SortLocaleData]][[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]][[&lt;_locale_&gt;]].[[co]] must be *null* for all locale values.</li>
-        <li>The values `"standard"` and `"search"` must not be used as elements in any [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] list.</li>
-        <li>[[SearchLocaleData]][[&lt;_locale_&gt;]] must have a sensitivity field with a String value equal to `"base"`, `"accent"`, `"case"`, or `"variant"` for all locale values.</li>
+        <li>The values *"standard"* and *"search"* must not be used as elements in any [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] list.</li>
+        <li>[[SearchLocaleData]][[&lt;_locale_&gt;]] must have a sensitivity field with a String value equal to *"base"*, *"accent"*, *"case"*, or *"variant"* for all locale values.</li>
       </ul>
 
     </emu-clause>
@@ -161,7 +161,7 @@
       <h1>Intl.Collator.prototype [ @@toStringTag ]</h1>
 
       <p>
-        The initial value of the @@toStringTag property is the String value `"Object"`.
+        The initial value of the @@toStringTag property is the String value *"Object"*.
       </p>
 
       <p>
@@ -296,37 +296,37 @@
           </thead>
           <tr>
             <td>[[Locale]]</td>
-            <td>`"locale"`</td>
+            <td>*"locale"*</td>
             <td></td>
           </tr>
           <tr>
             <td>[[Usage]]</td>
-            <td>`"usage"`</td>
+            <td>*"usage"*</td>
             <td></td>
           </tr>
           <tr>
             <td>[[Sensitivity]]</td>
-            <td>`"sensitivity"`</td>
+            <td>*"sensitivity"*</td>
             <td></td>
           </tr>
           <tr>
             <td>[[IgnorePunctuation]]</td>
-            <td>`"ignorePunctuation"`</td>
+            <td>*"ignorePunctuation"*</td>
             <td></td>
           </tr>
           <tr>
             <td>[[Collation]]</td>
-            <td>`"collation"`</td>
+            <td>*"collation"*</td>
             <td></td>
           </tr>
           <tr>
             <td>[[Numeric]]</td>
-            <td>`"numeric"`</td>
+            <td>*"numeric"*</td>
             <td>kn</td>
           </tr>
           <tr>
             <td>[[CaseFirst]]</td>
-            <td>`"caseFirst"`</td>
+            <td>*"caseFirst"*</td>
             <td>kf</td>
           </tr>
         </table>
@@ -351,10 +351,10 @@
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for collation.</li>
-      <li>[[Usage]] is one of the String values `"sort"` or `"search"`, identifying the collator usage.</li>
-      <li>[[Sensitivity]] is one of the String values `"base"`, `"accent"`, `"case"`, or `"variant"`, identifying the collator's sensitivity.</li>
+      <li>[[Usage]] is one of the String values *"sort"* or *"search"*, identifying the collator usage.</li>
+      <li>[[Sensitivity]] is one of the String values *"base"*, *"accent"*, *"case"*, or *"variant"*, identifying the collator's sensitivity.</li>
       <li>[[IgnorePunctuation]] is a Boolean value, specifying whether punctuation should be ignored in comparisons.</li>
-      <li>[[Collation]] is a String value with the `"type"` given in Unicode Technical Standard 35 for the collation, except that the values `"standard"` and `"search"` are not allowed, while the value `"default"` is allowed.</li>
+      <li>[[Collation]] is a String value with the *"type"* given in Unicode Technical Standard 35 for the collation, except that the values *"standard"* and *"search"* are not allowed, while the value *"default"* is allowed.</li>
     </ul>
 
     <p>
@@ -363,7 +363,7 @@
 
     <ul>
       <li>[[Numeric]] is a Boolean value, specifying whether numeric sorting is used.</li>
-      <li>[[CaseFirst]] is one of the String values `"upper"`, `"lower"`, or `"false"`.</li>
+      <li>[[CaseFirst]] is one of the String values *"upper"*, *"lower"*, or *"false"*.</li>
     </ul>
 
     <p>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -7,7 +7,7 @@
 
   <ul>
     <li>Object Internal Methods and Internal Slots, as described in ES2020, <emu-xref href="#sec-object-internal-methods-and-internal-slots"></emu-xref>.</li>
-    <li>Algorithm conventions, including the use of abstract operations, as described in ES2020, <emu-xref href="#sec-type-conversion"></emu-xref>, <emu-xref href="#sec-testing-and-comparison-operations"></emu-xref>, <emu-xref href="#sec-operations-on-objects"></emu-xref>.</li>
+    <li>Algorithm conventions, as described in ES2020, <emu-xref href="#sec-algorithm-conventions"></emu-xref>, and the use of abstract operations, as described in ES2020, <emu-xref href="#sec-type-conversion"></emu-xref>, <emu-xref href="#sec-testing-and-comparison-operations"></emu-xref>, <emu-xref href="#sec-operations-on-objects"></emu-xref>.</li>
     <li>Internal Slots, as described in ES2020, <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.</li>
     <li>The List and Record Specification Type, as described in ES2020, <emu-xref href="#sec-list-and-record-specification-type"></emu-xref>.</li>
   </ul>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -17,7 +17,7 @@
   </emu-note>
 
   <p>
-    As an extension to the Record Specification Type, the notation &ldquo;[[&lt;_name_&gt;]]&rdquo; denotes a field whose name is given by the variable _name_, which must have a String value. For example, if a variable _s_ has the value `"a"`, then [[&lt;_s_&gt;]] denotes the field [[a]].
+    As an extension to the Record Specification Type, the notation &ldquo;[[&lt;_name_&gt;]]&rdquo; denotes a field whose name is given by the variable _name_, which must have a String value. For example, if a variable _s_ has the value *"a"*, then [[&lt;_s_&gt;]] denotes the field [[a]].
   </p>
 
   <p>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -20,48 +20,48 @@
         </thead>
         <tr>
           <td>[[Weekday]]</td>
-          <td>`"weekday"`</td>
-          <td>`"narrow"`, `"short"`, `"long"`</td>
+          <td>*"weekday"*</td>
+          <td>*"narrow"*, *"short"*, *"long"*</td>
         </tr>
         <tr>
           <td>[[Era]]</td>
-          <td>`"era"`</td>
-          <td>`"narrow"`, `"short"`, `"long"`</td>
+          <td>*"era"*</td>
+          <td>*"narrow"*, *"short"*, *"long"*</td>
         </tr>
         <tr>
           <td>[[Year]]</td>
-          <td>`"year"`</td>
-          <td>`"2-digit"`, `"numeric"`</td>
+          <td>*"year"*</td>
+          <td>*"2-digit"*, *"numeric"*</td>
         </tr>
         <tr>
           <td>[[Month]]</td>
-          <td>`"month"`</td>
-          <td>`"2-digit"`, `"numeric"`, `"narrow"`, `"short"`, `"long"`</td>
+          <td>*"month"*</td>
+          <td>*"2-digit"*, *"numeric"*, *"narrow"*, *"short"*, *"long"*</td>
         </tr>
         <tr>
           <td>[[Day]]</td>
-          <td>`"day"`</td>
-          <td>`"2-digit"`, `"numeric"`</td>
+          <td>*"day"*</td>
+          <td>*"2-digit"*, *"numeric"*</td>
         </tr>
         <tr>
           <td>[[Hour]]</td>
-          <td>`"hour"`</td>
-          <td>`"2-digit"`, `"numeric"`</td>
+          <td>*"hour"*</td>
+          <td>*"2-digit"*, *"numeric"*</td>
         </tr>
         <tr>
           <td>[[Minute]]</td>
-          <td>`"minute"`</td>
-          <td>`"2-digit"`, `"numeric"`</td>
+          <td>*"minute"*</td>
+          <td>*"2-digit"*, *"numeric"*</td>
         </tr>
         <tr>
           <td>[[Second]]</td>
-          <td>`"second"`</td>
-          <td>`"2-digit"`, `"numeric"`</td>
+          <td>*"second"*</td>
+          <td>*"2-digit"*, *"numeric"*</td>
         </tr>
         <tr>
           <td>[[TimeZoneName]]</td>
-          <td>`"timeZoneName"`</td>
-          <td>`"short"`, `"long"`</td>
+          <td>*"timeZoneName"*</td>
+          <td>*"short"*, *"long"*</td>
         </tr>
       </table>
     </emu-table>
@@ -75,12 +75,12 @@
 
       <emu-alg>
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Let _options_ be ? ToDateTimeOptions(_options_, `"any"`, `"date"`).
+        1. Let _options_ be ? ToDateTimeOptions(_options_, *"any"*, *"date"*).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _hour12_ be ? GetOption(_options_, `"hour12"`, `"boolean"`, *undefined*, *undefined*).
-        1. Let _hourCycle_ be ? GetOption(_options_, `"hourCycle"`, `"string"`, &laquo; `"h11"`, `"h12"`, `"h23"`, `"h24"` &raquo;, *undefined*).
+        1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
+        1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
         1. If _hour12_ is not *undefined*, then
           1. Let _hourCycle_ be *null*.
         1. Set _opt_.[[hc]] to _hourCycle_.
@@ -91,7 +91,7 @@
         1. Set _dateTimeFormat_.[[HourCycle]] to _r_.[[hc]].
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _timeZone_ be ? Get(_options_, `"timeZone"`).
+        1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is not *undefined*, then
           1. Let _timeZone_ be ? ToString(_timeZone_).
           1. If the result of IsValidTimeZoneName(_timeZone_) is *false*, then
@@ -103,12 +103,12 @@
         1. Let _opt_ be a new Record.
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
           1. Let _prop_ be the name given in the Property column of the row.
-          1. Let _value_ be ? GetOption(_options_, _prop_, `"string"`, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
+          1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
           1. Set _opt_.[[&lt;_prop_&gt;]] to _value_.
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _formats_ be _dataLocaleData_.[[formats]].
-        1. Let _matcher_ be ? GetOption(_options_, `"formatMatcher"`, `"string"`, &laquo; `"basic"`, `"best fit"` &raquo;, `"best fit"`).
-        1. If _matcher_ is `"basic"`, then
+        1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
+        1. If _matcher_ is *"basic"*, then
           1. Let _bestFormat_ be BasicFormatMatcher(_opt_, _formats_).
         1. Else,
           1. Let _bestFormat_ be BestFitFormatMatcher(_opt_, _formats_).
@@ -124,18 +124,18 @@
             1. Set _hc_ to _hcDefault_.
           1. If _hour12_ is not *undefined*, then
             1. If _hour12_ is *true*, then
-              1. If _hcDefault_ is `"h11"` or `"h23"`, then
-                1. Set _hc_ to `"h11"`.
+              1. If _hcDefault_ is *"h11"* or *"h23"*, then
+                1. Set _hc_ to *"h11"*.
               1. Else,
-                1. Set _hc_ to `"h12"`.
+                1. Set _hc_ to *"h12"*.
             1. Else,
               1. Assert: _hour12_ is *false*.
-              1. If _hcDefault_ is `"h11"` or `"h23"`, then
-                1. Set _hc_ to `"h23"`.
+              1. If _hcDefault_ is *"h11"* or *"h23"*, then
+                1. Set _hc_ to *"h23"*.
               1. Else,
-                1. Set _hc_ to `"h24"`.
+                1. Set _hc_ to *"h24"*.
           1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
-          1. If _dateTimeformat_.[[HourCycle]] is `"h11"` or `"h12"`, then
+          1. If _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then
             1. Let _pattern_ be _bestFormat_.[[pattern12]].
           1. Else,
             1. Let _pattern_ be _bestFormat_.[[pattern]].
@@ -158,22 +158,22 @@
         1. If _options_ is *undefined*, let _options_ be *null*; otherwise let _options_ be ? ToObject(_options_).
         1. Let _options_ be ObjectCreate(_options_).
         1. Let _needDefaults_ be *true*.
-        1. If _required_ is `"date"` or `"any"`, then
-          1. For each of the property names `"weekday"`, `"year"`, `"month"`, `"day"`, do
+        1. If _required_ is *"date"* or *"any"*, then
+          1. For each of the property names *"weekday"*, *"year"*, *"month"*, *"day"*, do
             1. Let _prop_ be the property name.
             1. Let _value_ be ? Get(_options_, _prop_).
             1. If _value_ is not *undefined*, let _needDefaults_ be *false*.
-        1. If _required_ is `"time"` or `"any"`, then
-          1. For each of the property names `"hour"`, `"minute"`, `"second"`, do
+        1. If _required_ is *"time"* or *"any"*, then
+          1. For each of the property names *"hour"*, *"minute"*, *"second"*, do
             1. Let _prop_ be the property name.
             1. Let _value_ be ? Get(_options_, _prop_).
             1. If _value_ is not *undefined*, let _needDefaults_ be *false*.
-        1. If _needDefaults_ is *true* and _defaults_ is either `"date"` or `"all"`, then
-          1. For each of the property names `"year"`, `"month"`, `"day"`, do
-            1. Perform ? CreateDataPropertyOrThrow(_options_, _prop_, `"numeric"`).
-        1. If _needDefaults_ is *true* and _defaults_ is either `"time"` or `"all"`, then
-          1. For each of the property names `"hour"`, `"minute"`, `"second"`, do
-            1. Perform ? CreateDataPropertyOrThrow(_options_, _prop_, `"numeric"`).
+        1. If _needDefaults_ is *true* and _defaults_ is either *"date"* or *"all"*, then
+          1. For each of the property names *"year"*, *"month"*, *"day"*, do
+            1. Perform ? CreateDataPropertyOrThrow(_options_, _prop_, *"numeric"*).
+        1. If _needDefaults_ is *true* and _defaults_ is either *"time"* or *"all"*, then
+          1. For each of the property names *"hour"*, *"minute"*, *"second"*, do
+            1. Perform ? CreateDataPropertyOrThrow(_options_, _prop_, *"numeric"*).
         1. Return _options_.
       </emu-alg>
     </emu-clause>
@@ -203,7 +203,7 @@
             1. If _optionsProp_ is *undefined* and _formatProp_ is not *undefined*, then decrease _score_ by _additionPenalty_.
             1. Else if _optionsProp_ is not *undefined* and _formatProp_ is *undefined*, then decrease _score_ by _removalPenalty_.
             1. Else if _optionsProp_ ≠ _formatProp_,
-              1. Let _values_ be &laquo; `"2-digit"`, `"numeric"`, `"narrow"`, `"short"`, `"long"` &raquo;.
+              1. Let _values_ be &laquo; *"2-digit"*, *"numeric"*, *"narrow"*, *"short"*, *"long"* &raquo;.
               1. Let _optionsPropIndex_ be the index of _optionsProp_ within _values_.
               1. Let _formatPropIndex_ be the index of _formatProp_ within _values_.
               1. Let _delta_ be max(min(_formatPropIndex_ - _optionsPropIndex_, 2), -2).
@@ -259,58 +259,58 @@
         1. If _x_ is *NaN*, throw a *RangeError* exception.
         1. Let _locale_ be _dateTimeFormat_.[[Locale]].
         1. Let _nfOptions_ be ObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, `"useGrouping"`, *false*).
+        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"useGrouping"*, *false*).
         1. Let _nf_ be ? Construct(%NumberFormat%, &laquo; _locale_, _nfOptions_ &raquo;).
         1. Let _nf2Options_ be ObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, `"minimumIntegerDigits"`, 2).
-        1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, `"useGrouping"`, *false*).
+        1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"minimumIntegerDigits"*, 2).
+        1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"useGrouping"*, *false*).
         1. Let _nf2_ be ? Construct(%NumberFormat%, &laquo; _locale_, _nf2Options_ &raquo;).
         1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _result_ be a new empty List.
         1. Let _patternParts_ be PartitionPattern(_dateTimeFormat_.[[Pattern]]).
         1. For each element _patternPart_ of _patternParts_, in List order, do
           1. Let _p_ be _patternPart_.[[Type]].
-          1. If _p_ is `"literal"`, then
-            1. Add new part record { [[Type]]: `"literal"`, [[Value]]: _patternPart_.[[Value]] } as a new element of the list _result_.
+          1. If _p_ is *"literal"*, then
+            1. Add new part record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } as a new element of the list _result_.
           1. If _p_ matches a Property column of the row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, then
             1. Let _f_ be the value of _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the matching row.
             1. Let _v_ be the value of _tm_'s field whose name is the Internal Slot column of the matching row.
-            1. If _p_ is `"year"` and _v_ ≤ 0, let _v_ be 1 - _v_.
-            1. If _p_ is `"month"`, increase _v_ by 1.
-            1. If _p_ is `"hour"` and _dateTimeFormat_.[[HourCycle]] is `"h11"` or `"h12"`, then
+            1. If _p_ is *"year"* and _v_ ≤ 0, let _v_ be 1 - _v_.
+            1. If _p_ is *"month"*, increase _v_ by 1.
+            1. If _p_ is *"hour"* and _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
               1. Let _v_ be _v_ modulo 12.
-              1. If _v_ is 0 and _dateTimeFormat_.[[HourCycle]] is `"h12"`, let _v_ be 12.
-            1. If _p_ is `"hour"` and _dateTimeFormat_.[[HourCycle]] is `"h24"`, then
+              1. If _v_ is 0 and _dateTimeFormat_.[[HourCycle]] is *"h12"*, let _v_ be 12.
+            1. If _p_ is *"hour"* and _dateTimeFormat_.[[HourCycle]] is *"h24"*, then
               1. If _v_ is 0, let _v_ be 24.
-            1. If _f_ is `"numeric"`, then
+            1. If _f_ is *"numeric"*, then
               1. Let _fv_ be FormatNumeric(_nf_, _v_).
-            1. Else if _f_ is `"2-digit"`, then
+            1. Else if _f_ is *"2-digit"*, then
               1. Let _fv_ be FormatNumeric(_nf2_, _v_).
               1. If the `length` property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
-            1. Else if _f_ is `"narrow"`, `"short"`, or `"long"`, then let _fv_ be a String value representing _f_ in the desired form; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is `"month"`, then the String value may also depend on whether _dateTimeFormat_ has a [[Day]] internal slot. If _p_ is `"timeZoneName"`, then the String value may also depend on the value of the [[inDST]] field of _tm_. If _p_ is `"era"`, then the String value may also depend on whether _dateTimeFormat_ has a [[Era]] internal slot and if the implementation does not have a localized representation of _f_, then use _f_ itself.
+            1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _f_ in the desired form; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _dateTimeFormat_ has a [[Day]] internal slot. If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[inDST]] field of _tm_. If _p_ is *"era"*, then the String value may also depend on whether _dateTimeFormat_ has a [[Era]] internal slot and if the implementation does not have a localized representation of _f_, then use _f_ itself.
             1. Add new part record { [[Type]]: _p_, [[Value]]: _fv_ } as a new element of the list _result_.
-          1. Else if _p_ is equal to `"ampm"`, then
+          1. Else if _p_ is equal to *"ampm"*, then
             1. Let _v_ be _tm_.[[hour]].
             1. If _v_ is greater than 11, then
-              1. Let _fv_ be an implementation and locale dependent String value representing `"post meridiem"`.
+              1. Let _fv_ be an implementation and locale dependent String value representing *"post meridiem"*.
             1. Else,
-              1. Let _fv_ be an implementation and locale dependent String value representing `"ante meridiem"`.
-            1. Add new part record { [[Type]]: `"dayPeriod"`, [[Value]]: _fv_ } as a new element of the list _result_.
-          1. Else if _p_ is equal to `"relatedYear"`, then
+              1. Let _fv_ be an implementation and locale dependent String value representing *"ante meridiem"*.
+            1. Add new part record { [[Type]]: *"dayPeriod"*, [[Value]]: _fv_ } as a new element of the list _result_.
+          1. Else if _p_ is equal to *"relatedYear"*, then
             1. Let _v_ be _tm_.[[relatedYear]].
             1. Let _fv_ be FormatNumber(_nf_, _v_).
-            1. Add new part record { [[Type]]: `"relatedYear"`, [[Value]]: _fv_ } as a new element of the list _result_.
-          1. Else if _p_ is equal to `"yearName"`, then
+            1. Add new part record { [[Type]]: *"relatedYear"*, [[Value]]: _fv_ } as a new element of the list _result_.
+          1. Else if _p_ is equal to *"yearName"*, then
             1. Let _v_ be _tm_.[[yearName]].
-            1. Add new part record { [[Type]]: `"yearName"`, [[Value]]: _v_ } as a new element of the list _result_.
+            1. Add new part record { [[Type]]: *"yearName"*, [[Value]]: _v_ } as a new element of the list _result_.
           1. Else,
             1. Let _unknown_ be an implementation-, locale-, and numbering system-dependent String based on _x_ and _p_.
-            1. Append a new Record { [[Type]]: `"unknown"`, [[Value]]: _unknown_ } as the last element of _result_.
+            1. Append a new Record { [[Type]]: *"unknown"*, [[Value]]: _unknown_ } as the last element of _result_.
         1. Return _result_.
       </emu-alg>
 
       <emu-note>
-        It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>), and use CLDR `"abbreviated"` strings for DateTimeFormat `"short"` strings, and CLDR `"wide"` strings for DateTimeFormat `"long"` strings.
+        It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>), and use CLDR *"abbreviated"* strings for DateTimeFormat *"short"* strings, and CLDR *"wide"* strings for DateTimeFormat *"long"* strings.
       </emu-note>
 
       <emu-note>
@@ -349,8 +349,8 @@
         1. Let _n_ be 0.
         1. For each _part_ in _parts_, do
           1. Let _O_ be ObjectCreate(%ObjectPrototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, `"type"`, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, `"value"`, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
           1. Perform ! CreateDataProperty(_result_, ! ToString(_n_), _O_).
           1. Increment _n_ by 1.
         1. Return _result_.
@@ -367,7 +367,7 @@
 
       <emu-alg>
         1. Assert: Type(_t_) is Number.
-        1. If _calendar_ is `"gregory"`,
+        1. If _calendar_ is *"gregory"*,
           1. Let _timeZoneOffset_ be the value calculated according to <emu-xref href="#sec-local-time-zone-adjustment">LocalTZA(_t_, *true*)</emu-xref> where the local time zone is replaced with timezone _timeZone_.
           1. Let _tz_ be the time value _t_ + _timeZoneOffset_.
           1. Return a record with fields calculated from _tz_ according to <emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref>.
@@ -477,7 +477,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%DateTimeFormatPrototype%"`, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]], [[HourCycle]], [[Pattern]], [[BoundFormat]] &raquo;).
+        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%DateTimeFormatPrototype%"*, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]], [[HourCycle]], [[Pattern]], [[BoundFormat]] &raquo;).
         1. Perform ? InitializeDateTimeFormat(_dateTimeFormat_, _locales_, _options_).
       </emu-alg>
       <emu-normative-optional>
@@ -539,11 +539,11 @@
       </p>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; `"ca"`, `"nu"`, `"hc"` &raquo;.
+        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; *"ca"*, *"nu"*, *"hc"* &raquo;.
       </p>
 
       <emu-note>
-        Unicode Technical Standard 35 describes three locale extension keys that are relevant to date and time formatting, `"ca"` for calendar, `"tz"` for time zone, `"hc"` for hour cycle, and implicitly `"nu"` for the numbering system of the number format used for numbers within the date format. DateTimeFormat, however, requires that the time zone is specified through the timeZone property in the options objects.
+        Unicode Technical Standard 35 describes three locale extension keys that are relevant to date and time formatting, *"ca"* for calendar, *"tz"* for time zone, *"hc"* for hour cycle, and implicitly *"nu"* for the numbering system of the number format used for numbers within the date format. DateTimeFormat, however, requires that the time zone is specified through the timeZone property in the options objects.
       </emu-note>
 
       <p>
@@ -552,13 +552,13 @@
 
       <ul>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[nu]] must be a List that does not include the values `"native"`, `"traditio"`, or `"finance"`.
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[nu]] must be a List that does not include the values *"native"*, *"traditio"*, or *"finance"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[hc]] must be &laquo; *null*, `"h11"`, `"h12"`, `"h23"`, `"h24"` &raquo;.
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[hc]] must be &laquo; *null*, *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle]] must be a String value equal to `"h11"`, `"h12"`, `"h23"`, or `"h24"`.
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle]] must be a String value equal to *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
         </li>
         <li>
           [[LocaleData]].[[&lt;_locale_&gt;]].[[formats]] must be a List of records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a List may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
@@ -571,12 +571,12 @@
             <li>hour, minute, second</li>
             <li>hour, minute</li>
           </ul>
-          Each of the records must also have a [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with `"{"`, followed by the name of the field, followed by `"}"`. If the record has an hour field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the [[pattern]] field, contains a substring `"{ampm}"`. If the record has a [[year]] field, the [[pattern]] and [[pattern12]] values may contain the substrings `"{yearName}"` and `"{relatedYear}"`.
+          Each of the records must also have a [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*. If the record has an hour field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the [[pattern]] field, contains a substring *"{ampm}"*. If the record has a [[year]] field, the [[pattern]] and [[pattern12]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.
         </li>
       </ul>
 
       <p>
-        EXAMPLE     An implementation might include the following record as part of its English locale data: {[[hour]]: `"numeric"`, [[minute]]: `"2-digit"`, [[second]]: `"2-digit"`, [[pattern]]: `"{hour}:{minute}:{second}"`, [[pattern12]]: `"{hour}:{minute}:{second} {ampm}"`}.
+        EXAMPLE     An implementation might include the following record as part of its English locale data: {[[hour]]: *"numeric"*, [[minute]]: *"2-digit"*, [[second]]: *"2-digit"*, [[pattern]]: *"{hour}:{minute}:{second}"*, [[pattern12]]: *"{hour}:{minute}:{second} {ampm}"*}.
       </p>
 
       <emu-note>
@@ -604,7 +604,7 @@
       <h1>Intl.DateTimeFormat.prototype [ @@toStringTag ]</h1>
 
       <p>
-        The initial value of the @@toStringTag property is the String value `"Object"`.
+        The initial value of the @@toStringTag property is the String value *"Object"*.
       </p>
 
       <p>
@@ -668,10 +668,10 @@
         1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).
         1. For each row of <emu-xref href="#table-datetimeformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
           1. Let _p_ be the Property value of the current row.
-          1. If _p_ is `"hour12"`, then
+          1. If _p_ is *"hour12"*, then
             1. Let _hc_ be _dtf_.[[HourCycle]].
-            1. If _hc_ is `"h11"` or `"h12"`, let _v_ be *true*.
-            1. Else if, _hc_ is `"h23"` or `"h24"`, let _v_ be *false*.
+            1. If _hc_ is *"h11"* or *"h12"*, let _v_ be *true*.
+            1. Else if, _hc_ is *"h23"* or *"h24"*, let _v_ be *false*.
             1. Else, let _v_ be *undefined*.
           1. Else,
             1. Let _v_ be the value of _dtf_'s internal slot whose name is the Internal Slot value of the current row.
@@ -691,69 +691,69 @@
           </thead>
           <tr>
             <td>[[Locale]]</td>
-            <td>`"locale"`</td>
+            <td>*"locale"*</td>
           </tr>
           <tr>
             <td>[[Calendar]]</td>
-            <td>`"calendar"`</td>
+            <td>*"calendar"*</td>
           </tr>
           <tr>
             <td>[[NumberingSystem]]</td>
-            <td>`"numberingSystem"`</td>
+            <td>*"numberingSystem"*</td>
           </tr>
           <tr>
             <td>[[TimeZone]]</td>
-            <td>`"timeZone"`</td>
+            <td>*"timeZone"*</td>
           </tr>
           <tr>
             <td>[[HourCycle]]</td>
-            <td>`"hourCycle"`</td>
+            <td>*"hourCycle"*</td>
           </tr>
           <tr>
             <td></td>
-            <td>`"hour12"`</td>
+            <td>*"hour12"*</td>
           </tr>
           <tr>
             <td>[[Weekday]]</td>
-            <td>`"weekday"`</td>
+            <td>*"weekday"*</td>
           </tr>
           <tr>
             <td>[[Era]]</td>
-            <td>`"era"`</td>
+            <td>*"era"*</td>
           </tr>
           <tr>
             <td>[[Year]]</td>
-            <td>`"year"`</td>
+            <td>*"year"*</td>
           </tr>
           <tr>
             <td>[[Month]]</td>
-            <td>`"month"`</td>
+            <td>*"month"*</td>
           </tr>
           <tr>
             <td>[[Day]]</td>
-            <td>`"day"`</td>
+            <td>*"day"*</td>
           </tr>
           <tr>
             <td>[[Hour]]</td>
-            <td>`"hour"`</td>
+            <td>*"hour"*</td>
           </tr>
           <tr>
             <td>[[Minute]]</td>
-            <td>`"minute"`</td>
+            <td>*"minute"*</td>
           </tr>
           <tr>
             <td>[[Second]]</td>
-            <td>`"second"`</td>
+            <td>*"second"*</td>
           </tr>
           <tr>
             <td>[[TimeZoneName]]</td>
-            <td>`"timeZoneName"`</td>
+            <td>*"timeZoneName"*</td>
           </tr>
         </table>
       </emu-table>
 
       <p>
-        For web compatibility reasons, if the property hourCycle is set, the hour12 property should be set to *true* when hourCycle is `"h11"` or `"h12"`, or to *false* when hourCycle is `"h23"` or `"h24"`.
+        For web compatibility reasons, if the property hourCycle is set, the hour12 property should be set to *true* when hourCycle is *"h11"* or *"h12"*, or to *false* when hourCycle is *"h23"* or *"h24"*.
       </p>
 
       <emu-note>
@@ -761,7 +761,7 @@
       </emu-note>
 
       <emu-note>
-        For compatibility with versions prior to the fifth edition, the `"hour12"` property is set in addition to the `"hourCycle"` property.
+        For compatibility with versions prior to the fifth edition, the *"hour12"* property is set in addition to the *"hourCycle"* property.
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -783,11 +783,11 @@
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[Calendar]] is a String value with the `"type"` given in Unicode Technical Standard 35 for the calendar used for formatting.</li>
-      <li>[[NumberingSystem]] is a String value with the `"type"` given in Unicode Technical Standard 35 for the numbering system used for formatting.</li>
+      <li>[[Calendar]] is a String value with the *"type"* given in Unicode Technical Standard 35 for the calendar used for formatting.</li>
+      <li>[[NumberingSystem]] is a String value with the *"type"* given in Unicode Technical Standard 35 for the numbering system used for formatting.</li>
       <li>[[TimeZone]] is a String value with the IANA time zone name of the time zone used for formatting.</li>
       <li>[[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]] are each either *undefined*, indicating that the component is not used for formatting, or one of the String values given in <emu-xref href="#table-datetimeformat-components"></emu-xref>, indicating how the component should be presented in the formatted output.</li>
-      <li>[[HourCycle]] is a String value indicating whether the 12-hour format (`"h11"`, `"h12"`) or the 24-hour format (`"h23"`, `"h24"`) should be used. `"h11"` and `"h23"` start with hour 0 and go up to 11 and 23 respectively. `"h12"` and `"h24"` start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[Hour]] is not *undefined*.</li>
+      <li>[[HourCycle]] is a String value indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[Hour]] is not *undefined*.</li>
       <li>[[Pattern]] is a String value as described in <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>.</li>
     </ul>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -13,7 +13,7 @@
   </p>
 
   <p>
-    The Intl object has an internal slot, [[FallbackSymbol]], which is a new %Symbol% in the current realm with the [[Description]] `"IntlLegacyConstructedSymbol"`
+    The Intl object has an internal slot, [[FallbackSymbol]], which is a new %Symbol% in the current realm with the [[Description]] *"IntlLegacyConstructedSymbol"*
   </p>
 
   <emu-clause id="sec-constructor-properties-of-the-intl-object">

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -67,7 +67,7 @@
         1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with all Unicode locale extension sequences (<emu-xref href="#sec-unicode-locale-extension-sequences"></emu-xref>) removed.
         1. Let _availableLocales_ be a List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
         1. Let _locale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
-        1. If _locale_ is *undefined*, let _locale_ be `"und"`.
+        1. If _locale_ is *undefined*, let _locale_ be *"und"*.
         1. Let _cpList_ be a List containing in order the code points of _S_ as defined in ES2020, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, starting at the first element of _S_.
         1. Let _cuList_ be a List where the elements are the result of a lower case transformation of the ordered code points in _cpList_ according to the Unicode Default Case Conversion algorithm or an implementation defined conversion algorithm. A conforming implementation's lower case transformation algorithm must always yield the same _cpList_ given the same _cuList_ and locale.
         1. Let _L_ be a String whose elements are the UTF-16 Encoding (defined in ES2020, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) of the code points of _cuList_.
@@ -182,8 +182,8 @@
 
       <emu-alg>
         1. Let _x_ be ? thisTimeValue(*this* value).
-        1. If _x_ is *NaN*, return `"Invalid Date"`.
-        1. Let _options_ be ? ToDateTimeOptions(_options_, `"any"`, `"all"`).
+        1. If _x_ is *NaN*, return *"Invalid Date"*.
+        1. Let _options_ be ? ToDateTimeOptions(_options_, *"any"*, *"all"*).
         1. Let _dateFormat_ be ? Construct(%DateTimeFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return ? FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
@@ -203,8 +203,8 @@
 
       <emu-alg>
         1. Let _x_ be ? thisTimeValue(*this* value).
-        1. If _x_ is *NaN*, return `"Invalid Date"`.
-        1. Let _options_ be ? ToDateTimeOptions(_options_, `"date"`, `"date"`).
+        1. If _x_ is *NaN*, return *"Invalid Date"*.
+        1. Let _options_ be ? ToDateTimeOptions(_options_, *"date"*, *"date"*).
         1. Let _dateFormat_ be ? Construct(%DateTimeFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return ? FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
@@ -224,8 +224,8 @@
 
       <emu-alg>
         1. Let _x_ be ? thisTimeValue(*this* value).
-        1. If _x_ is *NaN*, return `"Invalid Date"`.
-        1. Let _options_ be ? ToDateTimeOptions(_options_, `"time"`, `"time"`).
+        1. If _x_ is *NaN*, return *"Invalid Date"*.
+        1. Let _options_ be ? ToDateTimeOptions(_options_, *"time"*, *"time"*).
         1. Let _timeFormat_ be ? Construct(%DateTimeFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return ? FormatDateTime(_timeFormat_, _x_).
       </emu-alg>
@@ -249,7 +249,7 @@
 
       <emu-alg>
         1. Let _array_ be ? ToObject(*this* value).
-        1. Let _len_ be ? ToLength(? Get(_array_, `"length"`)).
+        1. Let _len_ be ? ToLength(? Get(_array_, *"length"*)).
         1. Let _separator_ be the String value for the list-separator String appropriate for the host environment's current locale (this is derived in an implementation-defined way).
         1. Let _R_ be the empty String.
         1. Let _k_ be 0.
@@ -258,14 +258,14 @@
             1. Set _R_ to the string-concatenation of _R_ and _separator_.
           1. Let _nextElement_ be ? Get(_array_, ! ToString(_k_)).
           1. If _nextElement_ is not *undefined* or *null*, then
-            1. Let _S_ be ? ToString(? Invoke(_nextElement_, `"toLocaleString"`, &laquo; _locales_, _options_ &raquo;)).
+            1. Let _S_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*, &laquo; _locales_, _options_ &raquo;)).
             1. Set _R_ to the string-concatenation of _R_ and _S_.
           1. Increase _k_ by 1.
         1. Return _R_.
       </emu-alg>
 
       <emu-note>
-        This algorithm's steps mirror the steps taken in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref>, with the exception that Invoke(_nextElement_, `"toLocaleString"`) now takes _locales_ and _options_ as arguments.
+        This algorithm's steps mirror the steps taken in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref>, with the exception that Invoke(_nextElement_, *"toLocaleString"*) now takes _locales_ and _options_ as arguments.
       </emu-note>
 
       <emu-note>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -9,11 +9,11 @@
     <h1>Case Sensitivity and Case Mapping</h1>
 
     <p>
-      The String values used to identify locales, currencies, and time zones are interpreted in a case-insensitive manner, treating the Unicode Basic Latin characters `"A"` to `"Z"` (U+0041 to U+005A) as equivalent to the corresponding Basic Latin characters `"a"` to `"z"` (U+0061 to U+007A). No other case folding equivalences are applied. When mapping to upper case, a mapping shall be used that maps characters in the range `"a"` to `"z"` (U+0061 to U+007A) to the corresponding characters in the range `"A"` to `"Z"` (U+0041 to U+005A) and maps no other characters to the latter range.
+      The String values used to identify locales, currencies, and time zones are interpreted in a case-insensitive manner, treating the Unicode Basic Latin characters *"A"* to *"Z"* (U+0041 to U+005A) as equivalent to the corresponding Basic Latin characters *"a"* to *"z"* (U+0061 to U+007A). No other case folding equivalences are applied. When mapping to upper case, a mapping shall be used that maps characters in the range *"a"* to *"z"* (U+0061 to U+007A) to the corresponding characters in the range *"A"* to *"Z"* (U+0041 to U+005A) and maps no other characters to the latter range.
     </p>
 
     <p>
-      EXAMPLES `"ß"` (U+00DF) must not match or be mapped to `"SS"` (U+0053, U+0053). `"ı"` (U+0131) must not match or be mapped to `"I"` (U+0049).
+      EXAMPLES *"ß"* (U+00DF) must not match or be mapped to *"SS"* (U+0053, U+0053). *"ı"* (U+0131) must not match or be mapped to *"I"* (U+0049).
     </p>
   </emu-clause>
 
@@ -32,7 +32,7 @@
       <h1>Unicode Locale Extension Sequences</h1>
 
       <p>
-        This standard uses the term `"Unicode locale extension sequence"` - as described in <a href="https://unicode.org/reports/tr35/#unicode_locale_extensions">`unicode_locale_extensions`</a> in Unicode BCP 47 - for any substring of a language tag that is not part of a private use subtag sequence, starts with a separator `"-"` and the singleton `"u"`, and includes the maximum sequence of following non-singleton subtags and their preceding `"-"` separators.
+        This standard uses the term *"Unicode locale extension sequence"* - as described in <a href="https://unicode.org/reports/tr35/#unicode_locale_extensions">`unicode_locale_extensions`</a> in Unicode BCP 47 - for any substring of a language tag that is not part of a private use subtag sequence, starts with a separator *"-"* and the singleton *"u"*, and includes the maximum sequence of following non-singleton subtags and their preceding *"-"* separators.
       </p>
     </emu-clause>
 
@@ -94,7 +94,7 @@
       <emu-alg>
         1. Let _normalized_ be the result of mapping _currency_ to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
         1. If the number of elements in _normalized_ is not 3, return *false*.
-        1. If _normalized_ contains any character that is not in the range `"A"` to `"Z"` (U+0041 to U+005A), return *false*.
+        1. If _normalized_ contains any character that is not in the range *"A"* to *"Z"* (U+0041 to U+005A), return *false*.
         1. Return *true*.
       </emu-alg>
     </emu-clause>
@@ -132,8 +132,8 @@
 
       <emu-alg>
         1. Let _ianaTimeZone_ be the Zone or Link name of the IANA Time Zone Database such that _timeZone_, converted to  upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>, is equal to _ianaTimeZone_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
-        1. If _ianaTimeZone_ is a Link name, let _ianaTimeZone_ be the corresponding Zone name as specified in the `"backward"` file of the IANA Time Zone Database.
-        1. If _ianaTimeZone_ is `"Etc/UTC"` or `"Etc/GMT"`, return `"UTC"`.
+        1. If _ianaTimeZone_ is a Link name, let _ianaTimeZone_ be the corresponding Zone name as specified in the *"backward"* file of the IANA Time Zone Database.
+        1. If _ianaTimeZone_ is *"Etc/UTC"* or *"Etc/GMT"*, return *"UTC"*.
         1. Return _ianaTimeZone_.
       </emu-alg>
 

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -13,13 +13,13 @@
     </p>
 
     <ul>
-      <li>[[AvailableLocales]] is a List that contains structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizelanguagetag"></emu-xref>) BCP 47 language tags identifying the locales for which the implementation provides the functionality of the constructed objects. Language tags on the list must not have a Unicode locale extension sequence. The list must include the value returned by the DefaultLocale abstract operation (<emu-xref href="#sec-defaultlocale"></emu-xref>), and must not include duplicates. Implementations must include in [[AvailableLocales]] locales that can serve as fallbacks in the algorithm used to resolve locales (see <emu-xref href="#sec-resolvelocale"></emu-xref>). For example, implementations that provide a `"de-DE"` locale must include a `"de"` locale that can serve as a fallback for requests such as `"de-AT"` and `"de-CH"`. For locales that in current usage would include a script subtag (such as Chinese locales), old-style language tags without script subtags must be included such that, for example, requests for `"zh-TW"` and `"zh-HK"` lead to output in traditional Chinese rather than the default simplified Chinese. The ordering of the locales within [[AvailableLocales]] is irrelevant.</li>
+      <li>[[AvailableLocales]] is a List that contains structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizelanguagetag"></emu-xref>) BCP 47 language tags identifying the locales for which the implementation provides the functionality of the constructed objects. Language tags on the list must not have a Unicode locale extension sequence. The list must include the value returned by the DefaultLocale abstract operation (<emu-xref href="#sec-defaultlocale"></emu-xref>), and must not include duplicates. Implementations must include in [[AvailableLocales]] locales that can serve as fallbacks in the algorithm used to resolve locales (see <emu-xref href="#sec-resolvelocale"></emu-xref>). For example, implementations that provide a *"de-DE"* locale must include a *"de"* locale that can serve as a fallback for requests such as *"de-AT"* and *"de-CH"*. For locales that in current usage would include a script subtag (such as Chinese locales), old-style language tags without script subtags must be included such that, for example, requests for *"zh-TW"* and *"zh-HK"* lead to output in traditional Chinese rather than the default simplified Chinese. The ordering of the locales within [[AvailableLocales]] is irrelevant.</li>
       <li>[[RelevantExtensionKeys]] is a List of keys of the language tag extensions defined in Unicode Technical Standard 35 that are relevant for the functionality of the constructed objects.</li>
       <li>[[SortLocaleData]] and [[SearchLocaleData]] (for Intl.Collator) and [[LocaleData]] (for Intl.NumberFormat, Intl.DateTimeFormat, and Intl.PluralRules) are records that have fields for each locale contained in [[AvailableLocales]]. The value of each of these fields must be a record that has fields for each key contained in [[RelevantExtensionKeys]]. The value of each of these fields must be a non-empty list of those values defined in Unicode Technical Standard 35 for the given key that are supported by the implementation for the given locale, with the first element providing the default value.</li>
     </ul>
 
     <p>
-      EXAMPLE     An implementation of DateTimeFormat might include the language tag `"th"` in its [[AvailableLocales]] internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>) include the key `"ca"` in its [[RelevantExtensionKeys]] internal slot. For Thai, the `"buddhist"` calendar is usually the default, but an implementation might also support the calendars `"gregory"`, `"chinese"`, and `"islamicc"` for the locale `"th"`. The [[LocaleData]] internal slot would therefore at least include {[[th]]: {[[ca]]: &laquo; `"buddhist"`, `"gregory"`, `"chinese"`, `"islamicc"` &raquo;}}.
+      EXAMPLE     An implementation of DateTimeFormat might include the language tag *"th"* in its [[AvailableLocales]] internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>) include the key *"ca"* in its [[RelevantExtensionKeys]] internal slot. For Thai, the *"buddhist"* calendar is usually the default, but an implementation might also support the calendars *"gregory"*, *"chinese"*, and *"islamicc"* for the locale *"th"*. The [[LocaleData]] internal slot would therefore at least include {[[th]]: {[[ca]]: &laquo; *"buddhist"*, *"gregory"*, *"chinese"*, *"islamicc"* &raquo;}}.
     </p>
   </emu-clause>
 
@@ -45,7 +45,7 @@
           1. Let _O_ be CreateArrayFromList(&laquo; _locales_ &raquo;).
         1. Else,
           1. Let _O_ be ? ToObject(_locales_).
-        1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
+        1. Let _len_ be ? ToLength(? Get(_O_, *"length"*)).
         1. Let _k_ be 0.
         1. Repeat, while _k_ < _len_
           1. Let _Pk_ be ToString(_k_).
@@ -66,7 +66,7 @@
       </emu-note>
 
       <emu-note>
-        Requiring _kValue_ to be a String or Object means that the Number value *NaN* will not be interpreted as the language tag `"nan"`, which stands for Min Nan Chinese.
+        Requiring _kValue_ to be a String or Object means that the Number value *NaN* will not be interpreted as the language tag *"nan"*, which stands for Min Nan Chinese.
       </emu-note>
     </emu-clause>
 
@@ -81,8 +81,8 @@
         1. Let _candidate_ be _locale_.
         1. Repeat,
           1. If _availableLocales_ contains an element equal to _candidate_, return _candidate_.
-          1. Let _pos_ be the character index of the last occurrence of `"-"` (U+002D) within _candidate_. If that character does not occur, return *undefined*.
-          1. If _pos_ ≥ 2 and the character `"-"` occurs at index _pos_-2 of candidate, decrease _pos_ by 2.
+          1. Let _pos_ be the character index of the last occurrence of *"-"* (U+002D) within _candidate_. If that character does not occur, return *undefined*.
+          1. If _pos_ ≥ 2 and the character *"-"* occurs at index _pos_-2 of candidate, decrease _pos_ by 2.
           1. Let _candidate_ be the substring of _candidate_ from position 0, inclusive, to position _pos_, exclusive.
       </emu-alg>
     </emu-clause>
@@ -131,7 +131,7 @@
       <emu-alg>
         1. Assert: The number of elements in _key_ is 2.
         1. Let _size_ be the number of elements in _extension_.
-        1. Let _searchValue_ be the string-concatenation of `"-"`, _key_, and `"-"`.
+        1. Let _searchValue_ be the string-concatenation of *"-"*, _key_, and *"-"*.
         1. Let _pos_ be Call(%StringProto_indexOf%, _extension_, &laquo; _searchValue_ &raquo;).
         1. If _pos_ ≠ -1, then
           1. Let _start_ be _pos_ + 4.
@@ -139,7 +139,7 @@
           1. Let _k_ be _start_.
           1. Let _done_ be *false*.
           1. Repeat, while _done_ is *false*
-            1. Let _e_ be Call(%StringProto_indexOf%, _extension_, &laquo; `"-"`, _k_ &raquo;).
+            1. Let _e_ be Call(%StringProto_indexOf%, _extension_, &laquo; *"-"*, _k_ &raquo;).
             1. If _e_ = -1, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
             1. If _len_ = 2, then
               1. Let _done_ be *true*.
@@ -150,7 +150,7 @@
               1. Let _end_ be _e_.
               1. Let _k_ be _e_ + 1.
           1. Return the String value equal to the substring of _extension_ consisting of the code units at indices _start_ (inclusive) through _end_ (exclusive).
-        1. Let _searchValue_ be the string-concatenation of `"-"` and _key_.
+        1. Let _searchValue_ be the string-concatenation of *"-"* and _key_.
         1. Let _pos_ be Call(%StringProto_indexOf%, _extension_, &laquo; _searchValue_ &raquo;).
         1. If _pos_ ≠ -1 and _pos_ + 3 = _size_, then
           1. Return the empty String.
@@ -158,7 +158,7 @@
       </emu-alg>
 
       <emu-note>
-        Non-normative summary: UnicodeExtensionValue returns the type subtags of the first keyword for a given key. For example, UnicodeExtensionValue(`"u-ca-ethiopic-amete-alem-ca-ethioaa"`, `"ca"`) returns `"ethiopic-amete-alem"`. If the keyword for _key_ has no type subtags, UnicodeExtensionValue returns the empty String. If _extension_ contains no keyword for _key_, *undefined* is returned.
+        Non-normative summary: UnicodeExtensionValue returns the type subtags of the first keyword for a given key. For example, UnicodeExtensionValue(*"u-ca-ethiopic-amete-alem-ca-ethioaa"*, *"ca"*) returns *"ethiopic-amete-alem"*. If the keyword for _key_ has no type subtags, UnicodeExtensionValue returns the empty String. If _extension_ contains no keyword for _key_, *undefined* is returned.
       </emu-note>
     </emu-clause>
 
@@ -175,14 +175,14 @@
 
       <emu-alg>
         1. Let _matcher_ be _options_.[[localeMatcher]].
-        1. If _matcher_ is `"lookup"`, then
+        1. If _matcher_ is *"lookup"*, then
           1. Let _r_ be LookupMatcher(_availableLocales_, _requestedLocales_).
         1. Else,
           1. Let _r_ be BestFitMatcher(_availableLocales_, _requestedLocales_).
         1. Let _foundLocale_ be _r_.[[locale]].
         1. Let _result_ be a new Record.
         1. Set _result_.[[dataLocale]] to _foundLocale_.
-        1. Let _supportedExtension_ be `"-u"`.
+        1. Let _supportedExtension_ be *"-u"*.
         1. For each element _key_ of _relevantExtensionKeys_ in List order, do
           1. Let _foundLocaleData_ be _localeData_.[[&lt;_foundLocale_&gt;]].
           1. Assert: Type(_foundLocaleData_) is Record.
@@ -190,28 +190,28 @@
           1. Assert: Type(_keyLocaleData_) is List.
           1. Let _value_ be _keyLocaleData_[0].
           1. Assert: Type(_value_) is either String or Null.
-          1. Let _supportedExtensionAddition_ be `""`.
+          1. Let _supportedExtensionAddition_ be *""*.
           1. If _r_ has an [[extension]] field, then
             1. Let _requestedValue_ be UnicodeExtensionValue(_r_.[[extension]], _key_).
             1. If _requestedValue_ is not *undefined*, then
               1. If _requestedValue_ is not the empty String, then
                 1. If _keyLocaleData_ contains _requestedValue_, then
                   1. Let _value_ be _requestedValue_.
-                  1. Let _supportedExtensionAddition_ be the string-concatenation of `"-"`, _key_, `"-"`, and _value_.
-              1. Else if _keyLocaleData_ contains `"true"`, then
-                1. Let _value_ be `"true"`.
-                1. Let _supportedExtensionAddition_ be the string-concatenation of `"-"` and _key_.
+                  1. Let _supportedExtensionAddition_ be the string-concatenation of *"-"*, _key_, *"-"*, and _value_.
+              1. Else if _keyLocaleData_ contains *"true"*, then
+                1. Let _value_ be *"true"*.
+                1. Let _supportedExtensionAddition_ be the string-concatenation of *"-"* and _key_.
           1. If _options_ has a field [[&lt;_key_&gt;]], then
             1. Let _optionsValue_ be _options_.[[&lt;_key_&gt;]].
             1. Assert: Type(_optionsValue_) is either String, Undefined, or Null.
             1. If _keyLocaleData_ contains _optionsValue_, then
               1. If SameValue(_optionsValue_, _value_) is *false*, then
                 1. Let _value_ be _optionsValue_.
-                1. Let _supportedExtensionAddition_ be `""`.
+                1. Let _supportedExtensionAddition_ be *""*.
           1. Set _result_.[[&lt;_key_&gt;]] to _value_.
           1. Append _supportedExtensionAddition_ to _supportedExtension_.
         1. If the number of elements in _supportedExtension_ is greater than 2, then
-          1. Let _privateIndex_ be Call(%StringProto_indexOf%, _foundLocale_, &laquo; `"-x-"` &raquo;).
+          1. Let _privateIndex_ be Call(%StringProto_indexOf%, _foundLocale_, &laquo; *"-x-"* &raquo;).
           1. If _privateIndex_ = -1, then
             1. Let _foundLocale_ be the string-concatenation of _foundLocale_ and _supportedExtension_.
           1. Else,
@@ -264,9 +264,9 @@
       <emu-alg>
         1. If _options_ is not *undefined*, then
           1. Let _options_ be ? ToObject(_options_).
-          1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
-        1. Else, let _matcher_ be `"best fit"`.
-        1. If _matcher_ is `"best fit"`, then
+          1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Else, let _matcher_ be *"best fit"*.
+        1. If _matcher_ is *"best fit"*, then
           1. Let _supportedLocales_ be BestFitSupportedLocales(_availableLocales_, _requestedLocales_).
         1. Else,
           1. Let _supportedLocales_ be LookupSupportedLocales(_availableLocales_, _requestedLocales_).
@@ -284,10 +284,10 @@
       <emu-alg>
         1. Let _value_ be ? Get(_options_, _property_).
         1. If _value_ is not *undefined*, then
-          1. Assert: _type_ is `"boolean"` or `"string"`.
-          1. If _type_ is `"boolean"`, then
+          1. Assert: _type_ is *"boolean"* or *"string"*.
+          1. If _type_ is *"boolean"*, then
             1. Let _value_ be ToBoolean(_value_).
-          1. If _type_ is `"string"`, then
+          1. If _type_ is *"string"*, then
             1. Let _value_ be ? ToString(_value_).
           1. If _values_ is not *undefined*, then
             1. If _values_ does not contain an element equal to _value_, throw a *RangeError* exception.
@@ -331,30 +331,30 @@
       <p>
         The PartitionPattern abstract operation is called with argument _pattern_.
         This abstract operation parses an abstract pattern string into a list of Records with two fields, [[Type]] and [[Value]].
-        The [[Value]] field will be a String value if [[Type]] is `"literal"`, and *undefined* otherwise.
+        The [[Value]] field will be a String value if [[Type]] is *"literal"*, and *undefined* otherwise.
         The syntax of the abstract pattern strings is an implementation detail and is not exposed to users of ECMA-402.
         The following steps are taken:
       </p>
 
       <emu-alg>
         1. Let _result_ be a new empty List.
-        1. Let _beginIndex_ be ! Call(%String.prototype.indexOf%, _pattern_, &laquo; `"{"`, 0 &raquo;).
+        1. Let _beginIndex_ be ! Call(%String.prototype.indexOf%, _pattern_, &laquo; *"{"*, 0 &raquo;).
         1. Let _endIndex_ be 0.
         1. Let _nextIndex_ be 0.
         1. Let _length_ be the number of code units in _pattern_.
         1. Repeat, while _beginIndex_ is an integer index into _pattern_
-          1. Set _endIndex_ to ! Call(%String.prototype.indexOf%, _pattern_, &laquo; `"}"`, _beginIndex_ &raquo;).
+          1. Set _endIndex_ to ! Call(%String.prototype.indexOf%, _pattern_, &laquo; *"}"*, _beginIndex_ &raquo;).
           1. Assert: _endIndex_ is greater than _beginIndex_.
           1. If _beginIndex_ is greater than _nextIndex_, then
             1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
-            1. Add new part record { [[Type]]: `"literal"`, [[Value]]: _literal_ } as a new element of the list _result_.
+            1. Add new part record { [[Type]]: *"literal"*, [[Value]]: _literal_ } as a new element of the list _result_.
           1. Let _p_ be the substring of _pattern_ from position _beginIndex_, exclusive, to position _endIndex_, exclusive.
           1. Add new part record { [[Type]]: _p_, [[Value]]: *undefined* } as a new element of the list _result_.
           1. Set _nextIndex_ to _endIndex_ + 1.
-          1. Set _beginIndex_ to ! Call(%String.prototype.indexOf%, _pattern_, &laquo; `"{"`, _nextIndex_ &raquo;).
+          1. Set _beginIndex_ to ! Call(%String.prototype.indexOf%, _pattern_, &laquo; *"{"*, _nextIndex_ &raquo;).
         1. If _nextIndex_ is less than _length_, then
           1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, exclusive, to position _length_, exclusive.
-          1. Add new part record { [[Type]]: `"literal"`, [[Value]]: _literal_ } as a new element of the list _result_.
+          1. Add new part record { [[Type]]: *"literal"*, [[Value]]: _literal_ } as a new element of the list _result_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -16,12 +16,12 @@
         1. Assert: Type(_options_) is Object.
         1. Assert: Type(_mnfdDefault_) is Number.
         1. Assert: Type(_mxfdDefault_) is Number.
-        1. Let _mnid_ be ? GetNumberOption(_options_, `"minimumIntegerDigits"`, 1, 21, 1).
-        1. Let _mnfd_ be ? GetNumberOption(_options_, `"minimumFractionDigits"`, 0, 20, _mnfdDefault_).
+        1. Let _mnid_ be ? GetNumberOption(_options_, *"minimumIntegerDigits"*, 1, 21, 1).
+        1. Let _mnfd_ be ? GetNumberOption(_options_, *"minimumFractionDigits"*, 0, 20, _mnfdDefault_).
         1. Let _mxfdActualDefault_ be max( _mnfd_, _mxfdDefault_ ).
-        1. Let _mxfd_ be ? GetNumberOption(_options_, `"maximumFractionDigits"`, _mnfd_, 20, _mxfdActualDefault_).
-        1. Let _mnsd_ be ? Get(_options_, `"minimumSignificantDigits"`).
-        1. Let _mxsd_ be ? Get(_options_, `"maximumSignificantDigits"`).
+        1. Let _mxfd_ be ? GetNumberOption(_options_, *"maximumFractionDigits"*, _mnfd_, 20, _mxfdActualDefault_).
+        1. Let _mnsd_ be ? Get(_options_, *"minimumSignificantDigits"*).
+        1. Let _mxsd_ be ? Get(_options_, *"maximumSignificantDigits"*).
         1. Set _intlObj_.[[MinimumIntegerDigits]] to _mnid_.
         1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfd_.
         1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfd_.
@@ -47,36 +47,36 @@
         1. Else,
           1. Let _options_ be ? ToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %NumberFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _numberFormat_.[[Locale]] to _r_.[[locale]].
         1. Set _numberFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _style_ be ? GetOption(_options_, `"style"`, `"string"`, &laquo; `"decimal"`, `"percent"`, `"currency"` &raquo;, `"decimal"`).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, *"string"*, &laquo; *"decimal"*, *"percent"*, *"currency"* &raquo;, *"decimal"*).
         1. Set _numberFormat_.[[Style]] to _style_.
-        1. Let _currency_ be ? GetOption(_options_, `"currency"`, `"string"`, *undefined*, *undefined*).
+        1. Let _currency_ be ? GetOption(_options_, *"currency"*, *"string"*, *undefined*, *undefined*).
         1. If _currency_ is not *undefined*, then
           1. If the result of IsWellFormedCurrencyCode(_currency_) is *false*, throw a *RangeError* exception.
-        1. If _style_ is `"currency"` and _currency_ is *undefined*, throw a *TypeError* exception.
-        1. If _style_ is `"currency"`, then
+        1. If _style_ is *"currency"* and _currency_ is *undefined*, throw a *TypeError* exception.
+        1. If _style_ is *"currency"*, then
           1. Let _currency_ be the result of converting _currency_ to upper case as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
           1. Set _numberFormat_.[[Currency]] to _currency_.
           1. Let _cDigits_ be CurrencyDigits(_currency_).
-        1. Let _currencyDisplay_ be ? GetOption(_options_, `"currencyDisplay"`, `"string"`, &laquo; `"code"`, `"symbol"`, `"name"` &raquo;, `"symbol"`).
-        1. If _style_ is `"currency"`, set _numberFormat_.[[CurrencyDisplay]] to _currencyDisplay_.
-        1. If _style_ is `"currency"`, then
+        1. Let _currencyDisplay_ be ? GetOption(_options_, *"currencyDisplay"*, *"string"*, &laquo; *"code"*, *"symbol"*, *"name"* &raquo;, *"symbol"*).
+        1. If _style_ is *"currency"*, set _numberFormat_.[[CurrencyDisplay]] to _currencyDisplay_.
+        1. If _style_ is *"currency"*, then
           1. Let _mnfdDefault_ be _cDigits_.
           1. Let _mxfdDefault_ be _cDigits_.
         1. Else,
           1. Let _mnfdDefault_ be 0.
-          1. If _style_ is `"percent"`, then
+          1. If _style_ is *"percent"*, then
             1. Let _mxfdDefault_ be 0.
           1. Else,
             1. Let _mxfdDefault_ be 3.
         1. Perform ? SetNumberFormatDigitOptions(_numberFormat_, _options_, _mnfdDefault_, _mxfdDefault_).
-        1. Let _useGrouping_ be ? GetOption(_options_, `"useGrouping"`, `"boolean"`, *undefined*, *true*).
+        1. Let _useGrouping_ be ? GetOption(_options_, *"useGrouping"*, *"boolean"*, *undefined*, *true*).
         1. Set _numberFormat_.[[UseGrouping]] to _useGrouping_.
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _patterns_ be _dataLocaleData_.[[patterns]].
@@ -152,23 +152,23 @@
         1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. For each element _patternPart_ of _patternParts_, in List order, do
           1. Let _p_ be _patternPart_.[[Type]].
-          1. If _p_ is `"literal"`, then
-            1. Add new part record { [[Type]]: `"literal"`, [[Value]]: _patternPart_.[[Value]] } as a new element of _result_.
-          1. If _p_ is equal to `"number"`, then
+          1. If _p_ is *"literal"*, then
+            1. Add new part record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } as a new element of _result_.
+          1. If _p_ is equal to *"number"*, then
             1. If _x_ is *NaN*, then
               1. Let _n_ be an implementation- and locale-dependent (ILD) String value indicating the *NaN* value.
-              1. Append a new Record { [[Type]]: `"nan"`, [[Value]]: _n_ } as the last element of _result_.
+              1. Append a new Record { [[Type]]: *"nan"*, [[Value]]: _n_ } as the last element of _result_.
             1. Else if _x_ is not a finite Number or BigInt,
               1. Let _n_ be an ILD String value indicating infinity.
-              1. Append a new Record { [[Type]]: `"infinity"`, [[Value]]: _n_ } as the last element of _result_.
+              1. Append a new Record { [[Type]]: *"infinity"*, [[Value]]: _n_ } as the last element of _result_.
             1. Else,
-              1. If _numberFormat_.[[Style]] is `"percent"`, let _x_ be 100 × _x_.
+              1. If _numberFormat_.[[Style]] is *"percent"*, let _x_ be 100 × _x_.
               1. Let _n_ be FormatNumericToString(_numberFormat_, _x_).
-              1. If the _numberFormat_.[[NumberingSystem]] matches one of the values in the `"Numbering System"` column of <emu-xref href="#table-numbering-system-digits"></emu-xref> below, then
-                1. Let _digits_ be a List whose 10 String valued elements are the UTF-16 string representations of the 10 _digits_ specified in the `"Digits"` column of the matching row in <emu-xref href="#table-numbering-system-digits"></emu-xref>.
+              1. If the _numberFormat_.[[NumberingSystem]] matches one of the values in the *"Numbering System"* column of <emu-xref href="#table-numbering-system-digits"></emu-xref> below, then
+                1. Let _digits_ be a List whose 10 String valued elements are the UTF-16 string representations of the 10 _digits_ specified in the *"Digits"* column of the matching row in <emu-xref href="#table-numbering-system-digits"></emu-xref>.
                 1. Replace each _digit_ in _n_ with the value of _digits_[_digit_].
               1. Else use an implementation dependent algorithm to map _n_ to the appropriate representation of _n_ in the given numbering system.
-              1. Let _decimalSepIndex_ be Call(%StringProto_indexOf%, _n_, &laquo; `"."`, 0 &raquo;).
+              1. Let _decimalSepIndex_ be Call(%StringProto_indexOf%, _n_, &laquo; *"."*, 0 &raquo;).
               1. If _decimalSepIndex_ > 0, then
                 1. Let _integer_ be the substring of _n_ from position 0, inclusive, to position _decimalSepIndex_, exclusive.
                 1. Let _fraction_ be the substring of _n_ from position _decimalSepIndex_, exclusive, to the end of _n_.
@@ -181,37 +181,37 @@
                 1. Assert: The number of elements in _groups_ List is greater than 0.
                 1. Repeat, while _groups_ List is not empty
                   1. Remove the first element from _groups_ and let _integerGroup_ be the value of that element.
-                  1. Append a new Record { [[Type]]: `"integer"`, [[Value]]: _integerGroup_ } as the last element of _result_.
+                  1. Append a new Record { [[Type]]: *"integer"*, [[Value]]: _integerGroup_ } as the last element of _result_.
                   1. If _groups_ List is not empty, then
-                    1. Append a new Record { [[Type]]: `"group"`, [[Value]]: _groupSepSymbol_ } as the last element of _result_.
+                    1. Append a new Record { [[Type]]: *"group"*, [[Value]]: _groupSepSymbol_ } as the last element of _result_.
               1. Else,
-                1. Append a new Record { [[Type]]: `"integer"`, [[Value]]: _integer_ } as the last element of _result_.
+                1. Append a new Record { [[Type]]: *"integer"*, [[Value]]: _integer_ } as the last element of _result_.
               1. If _fraction_ is not *undefined*, then
                 1. Let _decimalSepSymbol_ be the ILND String representing the decimal separator.
-                1. Append a new Record { [[Type]]: `"decimal"`, [[Value]]: _decimalSepSymbol_ } as the last element of _result_.
-                1. Append a new Record { [[Type]]: `"fraction"`, [[Value]]: _fraction_ } as the last element of _result_.
-          1. Else if _p_ is equal to `"plusSign"`, then
+                1. Append a new Record { [[Type]]: *"decimal"*, [[Value]]: _decimalSepSymbol_ } as the last element of _result_.
+                1. Append a new Record { [[Type]]: *"fraction"*, [[Value]]: _fraction_ } as the last element of _result_.
+          1. Else if _p_ is equal to *"plusSign"*, then
             1. Let _plusSignSymbol_ be the ILND String representing the plus sign.
-            1. Append a new Record { [[Type]]: `"plusSign"`, [[Value]]: _plusSignSymbol_ } as the last element of _result_.
-          1. Else if _p_ is equal to `"minusSign"`, then
+            1. Append a new Record { [[Type]]: *"plusSign"*, [[Value]]: _plusSignSymbol_ } as the last element of _result_.
+          1. Else if _p_ is equal to *"minusSign"*, then
             1. Let _minusSignSymbol_ be the ILND String representing the minus sign.
-            1. Append a new Record { [[Type]]: `"minusSign"`, [[Value]]: _minusSignSymbol_ } as the last element of _result_.
-          1. Else if _p_ is equal to `"percentSign"` and _numberFormat_.[[Style]] is `"percent"`, then
+            1. Append a new Record { [[Type]]: *"minusSign"*, [[Value]]: _minusSignSymbol_ } as the last element of _result_.
+          1. Else if _p_ is equal to *"percentSign"* and _numberFormat_.[[Style]] is *"percent"*, then
             1. Let _percentSignSymbol_ be the ILND String representing the percent sign.
-            1. Append a new Record { [[Type]]: `"percentSign"`, [[Value]]: _percentSignSymbol_ } as the last element of _result_.
-          1. Else if _p_ is equal to `"currency"` and _numberFormat_.[[Style]] is `"currency"`, then
+            1. Append a new Record { [[Type]]: *"percentSign"*, [[Value]]: _percentSignSymbol_ } as the last element of _result_.
+          1. Else if _p_ is equal to *"currency"* and _numberFormat_.[[Style]] is *"currency"*, then
             1. Let _currency_ be _numberFormat_.[[Currency]].
-            1. Assert: _numberFormat_.[[CurrencyDisplay]] is `"code"`, `"symbol"` or `"name"`.
-            1. If _numberFormat_.[[CurrencyDisplay]] is `"code"`, then
+            1. Assert: _numberFormat_.[[CurrencyDisplay]] is *"code"*, *"symbol"* or *"name"*.
+            1. If _numberFormat_.[[CurrencyDisplay]] is *"code"*, then
               1. Let _cd_ be _currency_.
-            1. Else if _numberFormat_.[[CurrencyDisplay]] is `"symbol"`, then
+            1. Else if _numberFormat_.[[CurrencyDisplay]] is *"symbol"*, then
               1. Let _cd_ be an ILD String value representing _currency_ in short form. If the implementation does not have such a representation of _currency_, use _currency_ itself.
-            1. Else if _numberFormat_.[[CurrencyDisplay]] is `"name"`, then
+            1. Else if _numberFormat_.[[CurrencyDisplay]] is *"name"*, then
               1. Let _cd_ be an ILD String value representing _currency_ in long form. If the implementation does not have such a representation of _currency_, use _currency_ itself.
-            1. Append a new Record { [[Type]]: `"currency"`, [[Value]]: _cd_ } as the last element of _result_.
+            1. Append a new Record { [[Type]]: *"currency"*, [[Value]]: _cd_ } as the last element of _result_.
           1. Else,
             1. Let _unknown_ be an ILND String based on _x_ and _p_.
-            1. Append a new Record { [[Type]]: `"unknown"`, [[Value]]: _unknown_ } as the last element of _result_.
+            1. Append a new Record { [[Type]]: *"unknown"*, [[Value]]: _unknown_ } as the last element of _result_.
         1. Return _result_.
       </emu-alg>
 
@@ -353,8 +353,8 @@
         1. Let _n_ be 0.
         1. For each _part_ in _parts_, do
           1. Let _O_ be ObjectCreate(%ObjectPrototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, `"type"`, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, `"value"`, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
           1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(_n_), _O_).
           1. Increment _n_ by 1.
         1. Return _result_.
@@ -371,25 +371,25 @@
       <emu-alg>
         1. Let _p_ be _maxPrecision_.
         1. If _x_ = 0, then
-          1. Let _m_ be the String consisting of _p_ occurrences of the character `"0"`.
+          1. Let _m_ be the String consisting of _p_ occurrences of the character *"0"*.
           1. Let _e_ be 0.
         1. Else,
           1. Let _e_ and _n_ be integers such that 10<sup>_p_–1</sup> ≤ _n_ < 10<sup>_p_</sup> and for which the exact mathematical value of _n_ × 10<sup>_e_–_p_+1</sup> – _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ × 10<sup>_e_–_p_+1</sup> is larger.
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
         1. If _e_ ≥ _p_, then
-          1. Return the string-concatenation of _m_ and _e_-_p_+1 occurrences of the character `"0"`.
+          1. Return the string-concatenation of _m_ and _e_-_p_+1 occurrences of the character *"0"*.
         1. If _e_ = _p_-1, then
           1. Return _m_.
         1. If _e_ ≥ 0, then
-          1. Let _m_ be the string-concatenation of the first _e_+1 characters of _m_, the character `"."`, and the remaining _p_–(_e_+1) characters of _m_.
+          1. Let _m_ be the string-concatenation of the first _e_+1 characters of _m_, the character *"."*, and the remaining _p_–(_e_+1) characters of _m_.
         1. If _e_ < 0, then
-          1. Let _m_ be the string-concatenation of the String value `"0."`, –(_e_+1) occurrences of the character `"0"`, and _m_.
-        1. If _m_ contains the character `"."`, and _maxPrecision_ > _minPrecision_, then
+          1. Let _m_ be the string-concatenation of the String value *"0."*, –(_e_+1) occurrences of the character *"0"*, and _m_.
+        1. If _m_ contains the character *"."*, and _maxPrecision_ > _minPrecision_, then
           1. Let _cut_ be _maxPrecision_ – _minPrecision_.
-          1. Repeat, while _cut_ > 0 and the last character of _m_ is `"0"`
+          1. Repeat, while _cut_ > 0 and the last character of _m_ is *"0"*
             1. Remove the last character from _m_.
             1. Decrease _cut_ by 1.
-          1. If the last character of _m_ is `"."`, then
+          1. If the last character of _m_ is *"."*, then
             1. Remove the last character from _m_.
         1. Return _m_.
       </emu-alg>
@@ -405,25 +405,25 @@
       <emu-alg>
         1. Let _f_ be _maxFraction_.
         1. Let _n_ be an integer for which the exact mathematical value of _n_ ÷ 10<sup>_f_</sup> – _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
-        1. If _n_ = 0, let _m_ be the String `"0"`. Otherwise, let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
+        1. If _n_ = 0, let _m_ be the String *"0"*. Otherwise, let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
         1. If _f_ ≠ 0, then
           1. Let _k_ be the number of characters in _m_.
           1. If _k_ ≤ _f_, then
-            1. Let _z_ be the String value consisting of _f_+1–_k_ occurrences of the character `"0"`.
+            1. Let _z_ be the String value consisting of _f_+1–_k_ occurrences of the character *"0"*.
             1. Let _m_ be the string-concatenation of _z_ and _m_.
             1. Let _k_ be _f_+1.
           1. Let _a_ be the first _k_–_f_ characters of _m_, and let _b_ be the remaining _f_ characters of _m_.
-          1. Let _m_ be the string-concatenation of _a_, `"."`, and _b_.
+          1. Let _m_ be the string-concatenation of _a_, *"."*, and _b_.
           1. Let _int_ be the number of characters in _a_.
         1. Else, let _int_ be the number of characters in _m_.
         1. Let _cut_ be _maxFraction_ – _minFraction_.
-        1. Repeat, while _cut_ > 0 and the last character of _m_ is `"0"`
+        1. Repeat, while _cut_ > 0 and the last character of _m_ is *"0"*
           1. Remove the last character from _m_.
           1. Decrease _cut_ by 1.
-        1. If the last character of _m_ is `"."`, then
+        1. If the last character of _m_ is *"."*, then
           1. Remove the last character from _m_.
         1. If _int_ < _minInteger_, then
-          1. Let _z_ be the String consisting of _minInteger_–_int_ occurrences of the character `"0"`.
+          1. Let _z_ be the String consisting of _minInteger_–_int_ occurrences of the character *"0"*.
           1. Let _m_ be the string-concatenation of _z_ and _m_.
         1. Return _m_.
       </emu-alg>
@@ -470,7 +470,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%NumberFormatPrototype%"`, &laquo; [[InitializedNumberFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[Currency]], [[CurrencyDisplay]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[UseGrouping]], [[PositivePattern]], [[NegativePattern]], [[BoundFormat]] &raquo;).
+        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%NumberFormatPrototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[Currency]], [[CurrencyDisplay]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[UseGrouping]], [[PositivePattern]], [[NegativePattern]], [[BoundFormat]] &raquo;).
         1. Perform ? InitializeNumberFormat(_numberFormat_, _locales_, _options_).
       </emu-alg>
       <emu-normative-optional>
@@ -532,11 +532,11 @@
       </p>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; `"nu"` &raquo;.
+        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; *"nu"* &raquo;.
       </p>
 
       <emu-note>
-        Unicode Technical Standard 35 describes two locale extension keys that are relevant to number formatting, `"nu"` for numbering system and `"cu"` for currency. Intl.NumberFormat, however, requires that the currency of a currency format is specified through the currency property in the options objects.
+        Unicode Technical Standard 35 describes two locale extension keys that are relevant to number formatting, *"nu"* for numbering system and *"cu"* for currency. Intl.NumberFormat, however, requires that the currency of a currency format is specified through the currency property in the options objects.
       </emu-note>
 
       <p>
@@ -544,8 +544,8 @@
       </p>
 
       <ul>
-        <li>The list that is the value of the `"nu"` field of any locale field of [[LocaleData]] must not include the values `"native"`, `"traditio"`, or `"finance"`.</li>
-        <li>[[LocaleData]].[[&lt;_locale_&gt;]] must have a patterns field for all locale values _locale_. The value of this field must be a record, which must have fields with the names of the three number format styles: `"decimal"`, `"percent"`, and `"currency"`. Each of these fields in turn must be a record with the fields positivePattern and negativePattern. The value of these fields must be string values that must contain the substring `"{number}"` and may contain the substrings `"{plusSign}"`, and `"{minusSign}"`; the values within the percent field must also contain the substring `"{percentSign}"`; the values within the currency field must also contain the substring `"{currency}"`. The pattern strings must not contain any characters in the General Category "Number, decimal digit" as specified by the Unicode Standard.</li>
+        <li>The list that is the value of the *"nu"* field of any locale field of [[LocaleData]] must not include the values *"native"*, *"traditio"*, or *"finance"*.</li>
+        <li>[[LocaleData]].[[&lt;_locale_&gt;]] must have a patterns field for all locale values _locale_. The value of this field must be a record, which must have fields with the names of the three number format styles: *"decimal"*, *"percent"*, and *"currency"*. Each of these fields in turn must be a record with the fields positivePattern and negativePattern. The value of these fields must be string values that must contain the substring *"{number}"* and may contain the substrings *"{plusSign}"*, and *"{minusSign}"*; the values within the percent field must also contain the substring *"{percentSign}"*; the values within the currency field must also contain the substring *"{currency}"*. The pattern strings must not contain any characters in the General Category "Number, decimal digit" as specified by the Unicode Standard.</li>
       </ul>
 
       <emu-note>
@@ -573,7 +573,7 @@
       <h1>Intl.NumberFormat.prototype [ @@toStringTag ]</h1>
 
       <p>
-        The initial value of the @@toStringTag property is the String value `"Object"`.
+        The initial value of the @@toStringTag property is the String value *"Object"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
@@ -650,47 +650,47 @@
           </thead>
           <tr>
             <td>[[Locale]]</td>
-            <td>`"locale"`</td>
+            <td>*"locale"*</td>
           </tr>
           <tr>
             <td>[[NumberingSystem]]</td>
-            <td>`"numberingSystem"`</td>
+            <td>*"numberingSystem"*</td>
           </tr>
           <tr>
             <td>[[Style]]</td>
-            <td>`"style"`</td>
+            <td>*"style"*</td>
           </tr>
           <tr>
             <td>[[Currency]]</td>
-            <td>`"currency"`</td>
+            <td>*"currency"*</td>
           </tr>
           <tr>
             <td>[[CurrencyDisplay]]</td>
-            <td>`"currencyDisplay"`</td>
+            <td>*"currencyDisplay"*</td>
           </tr>
           <tr>
             <td>[[MinimumIntegerDigits]]</td>
-            <td>`"minimumIntegerDigits"`</td>
+            <td>*"minimumIntegerDigits"*</td>
           </tr>
           <tr>
             <td>[[MinimumFractionDigits]]</td>
-            <td>`"minimumFractionDigits"`</td>
+            <td>*"minimumFractionDigits"*</td>
           </tr>
           <tr>
             <td>[[MaximumFractionDigits]]</td>
-            <td>`"maximumFractionDigits"`</td>
+            <td>*"maximumFractionDigits"*</td>
           </tr>
           <tr>
             <td>[[MinimumSignificantDigits]]</td>
-            <td>`"minimumSignificantDigits"`</td>
+            <td>*"minimumSignificantDigits"*</td>
           </tr>
           <tr>
             <td>[[MaximumSignificantDigits]]</td>
-            <td>`"maximumSignificantDigits"`</td>
+            <td>*"maximumSignificantDigits"*</td>
           </tr>
           <tr>
             <td>[[UseGrouping]]</td>
-            <td>`"useGrouping"`</td>
+            <td>*"useGrouping"*</td>
           </tr>
         </table>
       </emu-table>
@@ -715,9 +715,9 @@
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
       <li>[[NumberingSystem]] is a String value with the "type" given in Unicode Technical Standard 35 for the numbering system used for formatting.</li>
-      <li>[[Style]] is one of the String values `"decimal"`, `"currency"`, or `"percent"`, identifying the number format style used.</li>
-      <li>[[Currency]] is a String value with the currency code identifying the currency to be used if formatting with the `"currency"` style. It is only used when [[Style]] has the value `"currency"`.</li>
-      <li>[[CurrencyDisplay]] is one of the String values `"code"`, `"symbol"`, or `"name"`, specifying whether to display the currency as an ISO 4217 alphabetic currency code, a localized currency symbol, or a localized currency name if formatting with the `"currency"` style. It is only used when [[Style]] has the value `"currency"`.</li>
+      <li>[[Style]] is one of the String values *"decimal"*, *"currency"*, or *"percent"*, identifying the number format style used.</li>
+      <li>[[Currency]] is a String value with the currency code identifying the currency to be used if formatting with the *"currency"* style. It is only used when [[Style]] has the value *"currency"*.</li>
+      <li>[[CurrencyDisplay]] is one of the String values *"code"*, *"symbol"*, or *"name"*, specifying whether to display the currency as an ISO 4217 alphabetic currency code, a localized currency symbol, or a localized currency name if formatting with the *"currency"* style. It is only used when [[Style]] has the value *"currency"*.</li>
       <li>[[MinimumIntegerDigits]] is a non-negative integer Number value indicating the minimum integer digits to be used. Numbers will be padded with leading zeroes if necessary.</li>
       <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative integer Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
       <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be shown. Either none or both of these properties are present; if they are, they override minimum and maximum integer and fraction digits – the formatter uses however many integer and fraction digits are required to display the specified number of significant digits.</li>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -18,9 +18,9 @@
         1. Else
           1. Let _options_ be ? ToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _t_ be ? GetOption(_options_, `"type"`, `"string"`, &laquo; `"cardinal"`, `"ordinal"` &raquo;, `"cardinal"`).
+        1. Let _t_ be ? GetOption(_options_, *"type"*, *"string"*, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, *0*, *3*).
         1. Let _localeData_ be %PluralRules%.[[LocaleData]].
@@ -41,7 +41,7 @@
          1. Assert: Type(_s_) is String.
          1. Let _n_ be ! ToNumber(_s_).
          1. Assert: _n_ is finite.
-         1. Let _dp_ be ! Call(%StringProto_indexOf%, _s_, &laquo; `"."` &raquo;).
+         1. Let _dp_ be ! Call(%StringProto_indexOf%, _s_, &laquo; *"."* &raquo;).
          1. If _dp_ = -1, then
            1. Set _iv_ to _n_.
            1. Let _f_ be 0.
@@ -53,7 +53,7 @@
            1. Let _v_ be the length of _fv_.
          1. Let _i_ be abs(! ToNumber(_iv_)).
          1. If _f_ ≠ 0, then
-           1. Let _ft_ be the value of _fv_ stripped of trailing `"0"`.
+           1. Let _ft_ be the value of _fv_ stripped of trailing *"0"*.
            1. Let _w_ be the length of _ft_.
            1. Let _t_ be ! ToNumber(_ft_).
          1. Else,
@@ -112,7 +112,7 @@
       <h1>PluralRuleSelect ( _locale_, _type_, _n_, _operands_ )</h1>
 
       <p>
-        When the PluralRuleSelect abstract operation is called with four arguments, it performs an implementation-dependent algorithm to map _n_ to the appropriate plural representation of the Plural Rules Operands Record _operands_ by selecting the rules denoted by _type_ for the corresponding _locale_, or the String value `"other"`.
+        When the PluralRuleSelect abstract operation is called with four arguments, it performs an implementation-dependent algorithm to map _n_ to the appropriate plural representation of the Plural Rules Operands Record _operands_ by selecting the rules denoted by _type_ for the corresponding _locale_, or the String value *"other"*.
       </p>
 
     </emu-clause>
@@ -128,7 +128,7 @@
         1. Assert: _pluralRules_ has an [[InitializedPluralRules]] internal slot.
         1. Assert: Type(_n_) is Number.
         1. If _n_ is not a finite Number, then
-          1. Return `"other"`.
+          1. Return *"other"*.
         1. Let _locale_ be _pluralRules_.[[Locale]].
         1. Let _type_ be _pluralRules_.[[Type]].
         1. Let _s_ be ! FormatNumericToString(_pluralRules_, _n_).
@@ -156,7 +156,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%PluralRulesPrototype%"`, &laquo; [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]] &raquo;).
+        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%PluralRulesPrototype%"*, &laquo; [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]] &raquo;).
         1. Return ? InitializePluralRules(_pluralRules_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -243,7 +243,7 @@
       <h1>Intl.PluralRules.prototype [ @@toStringTag ]</h1>
 
       <p>
-        The initial value of the @@toStringTag property is the String value `"Object"`.
+        The initial value of the @@toStringTag property is the String value *"Object"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
@@ -281,8 +281,8 @@
           1. Let _v_ be the value of _pr_'s internal slot whose name is the Internal Slot value of the current row.
           1. If _v_ is not *undefined*, then
             1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
-        1. Let _pluralCategories_ be a List of Strings representing the possible results of <emu-xref href="#sec-pluralruleselect">PluralRuleSelect</emu-xref> for the selected locale _pr_.[[Locale]]. This List consists of unique String values, from the the list `"zero"`, `"one"`, `"two"`, `"few"`, `"many"` and `"other"`, that are relevant for the locale whose localization is specified in LDML Language Plural Rules.
-        1. Perform ! CreateDataProperty(_options_, `"pluralCategories"`, CreateArrayFromList(_pluralCategories_)).
+        1. Let _pluralCategories_ be a List of Strings representing the possible results of <emu-xref href="#sec-pluralruleselect">PluralRuleSelect</emu-xref> for the selected locale _pr_.[[Locale]]. This List consists of unique String values, from the the list *"zero"*, *"one"*, *"two"*, *"few"*, *"many"* and *"other"*, that are relevant for the locale whose localization is specified in LDML Language Plural Rules.
+        1. Perform ! CreateDataProperty(_options_, *"pluralCategories"*, CreateArrayFromList(_pluralCategories_)).
         1. Return _options_.
       </emu-alg>
 
@@ -297,31 +297,31 @@
           </thead>
           <tr>
             <td>[[Locale]]</td>
-            <td>`"locale"`</td>
+            <td>*"locale"*</td>
           </tr>
           <tr>
             <td>[[Type]]</td>
-            <td>`"type"`</td>
+            <td>*"type"*</td>
           </tr>
           <tr>
             <td>[[MinimumIntegerDigits]]</td>
-            <td>`"minimumIntegerDigits"`</td>
+            <td>*"minimumIntegerDigits"*</td>
           </tr>
           <tr>
             <td>[[MinimumFractionDigits]]</td>
-            <td>`"minimumFractionDigits"`</td>
+            <td>*"minimumFractionDigits"*</td>
           </tr>
           <tr>
             <td>[[MaximumFractionDigits]]</td>
-            <td>`"maximumFractionDigits"`</td>
+            <td>*"maximumFractionDigits"*</td>
           </tr>
           <tr>
             <td>[[MinimumSignificantDigits]]</td>
-            <td>`"minimumSignificantDigits"`</td>
+            <td>*"minimumSignificantDigits"*</td>
           </tr>
           <tr>
             <td>[[MaximumSignificantDigits]]</td>
-            <td>`"maximumSignificantDigits"`</td>
+            <td>*"maximumSignificantDigits"*</td>
           </tr>
         </table>
       </emu-table>
@@ -345,7 +345,7 @@
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used by the plural rules.</li>
-      <li>[[Type]] is one of the String values `"cardinal"` or `"ordinal"`, identifying the plural rules used.</li>
+      <li>[[Type]] is one of the String values *"cardinal"* or *"ordinal"*, identifying the plural rules used.</li>
       <li>[[MinimumIntegerDigits]] is a non-negative integer Number value indicating the minimum integer digits to be used.</li>
       <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative integer Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
       <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be used. Either none or both of these properties are present; if they are, they override minimum and maximum integer and fraction digits.</li>


### PR DESCRIPTION
This follows the convention set in ECMA-262 to format strings as literals (`*"string*"` instead of ``` `"string"` ```, see PR: https://github.com/tc39/ecma262/pull/1733) and closes https://github.com/tc39/ecma402/issues/54.

There is also one commit that adds a link in [5. Notational Conventions](https://tc39.es/ecma402/#conventions) to ECMA-262.

While reviewing, consider the following conventions from ECMA-262 that I'm not positive apply here:

- [Tilde for spec-interal values](https://github.com/tc39/ecma262/pull/1725): I couldn't find an example of a spec internal value in ECMA-402 that is not also a string specified somewhere else, such as the  IANA Time Zone Database or Unicode. Because the string is not an internal arbitrary value it doesn't seem like we should use `~`.
- [Notation for code points](https://github.com/tc39/ecma262/pull/1724/files): I don't have an opinion on whether we should stylize characters the way ECMA-262 now stylizing code points, I'm curious if others do.
