### PR TITLE
Editorial: Use string notation for properties

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -36,7 +36,7 @@
       In Collator:
       <ul>
         <li>
-          Support for the Unicode extensions keys kn, kf and the parallel options properties numeric, caseFirst (<emu-xref href="#sec-initializecollator"></emu-xref>)
+          Support for the Unicode extensions keys *"kn"*, *"kf"* and the parallel options properties *"numeric"*, *"caseFirst"* (<emu-xref href="#sec-initializecollator"></emu-xref>)
         </li>
         <li>
           The set of supported *"co"* key values (collations) per locale beyond a default collation (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
@@ -125,7 +125,7 @@
       <emu-xref href="#sec-the-intl-collator-constructor"></emu-xref>, <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref>, <emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref> In ECMA-402, 1st Edition, constructors could be used to create Intl objects from arbitrary objects. This is no longer possible in 2nd Edition.
     </li>
     <li>
-      <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1st Edition, the _length_ property of the function object _F_ was set to 0. In 2nd Edition, _length_ is set to 1.
+      <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1st Edition, the *"length"* property of the function object _F_ was set to *0*. In 2nd Edition, *"length"* is set to *1*.
     </li>
   </ul>
 </emu-annex>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -114,7 +114,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *supportedLocalesOf* method is 1.
+        The value of the *"length"* property of the *supportedLocalesOf* method is 1.
       </p>
     </emu-clause>
 
@@ -126,7 +126,7 @@
       </p>
 
       <emu-note>
-        Unicode Technical Standard 35 describes ten locale extension keys that are relevant to collation: *"co"* for collator usage and specializations, *"ka"* for alternate handling, *"kb"* for backward second level weight, *"kc"* for case level, *"kn"* for numeric, *"kh"* for hiragana quaternary, *"kk"* for normalization, *"kf"* for case first, *"kr"* for reordering, *"ks"* for collation strength, and *"vt"* for variable top. Collator, however, requires that the usage is specified through the usage property of the options object, alternate handling through the ignorePunctuation property of the options object, and case level and the strength through the sensitivity property of the options object. The *"co"* key in the language tag is supported only for collator specializations, and the keys *"kb"*, *"kh"*, *"kk"*, *"kr"*, and *"vt"* are not allowed in this version of the Internationalization API. Support for the remaining keys is implementation dependent.
+        Unicode Technical Standard 35 describes ten locale extension keys that are relevant to collation: *"co"* for collator usage and specializations, *"ka"* for alternate handling, *"kb"* for backward second level weight, *"kc"* for case level, *"kn"* for numeric, *"kh"* for hiragana quaternary, *"kk"* for normalization, *"kf"* for case first, *"kr"* for reordering, *"ks"* for collation strength, and *"vt"* for variable top. Collator, however, requires that the usage is specified through the *"usage"* property of the options object, alternate handling through the *"ignorePunctuation"* property of the options object, and case level and the strength through the *"sensitivity"* property of the options object. The *"co"* key in the language tag is supported only for collator specializations, and the keys *"kb"*, *"kh"*, *"kk"*, *"kr"*, and *"vt"* are not allowed in this version of the Internationalization API. Support for the remaining keys is implementation dependent.
       </emu-note>
 
       <p>
@@ -209,7 +209,7 @@
           1. Return CompareStrings(_collator_, _X_, _Y_).
         </emu-alg>
 
-        <p>The `length` property of a Collator compare function is 2.</p>
+        <p>The *"length"* property of a Collator compare function is 2.</p>
       </emu-clause>
 
       <emu-clause id="sec-collator-comparestrings" aoid="CompareStrings">
@@ -322,12 +322,12 @@
           <tr>
             <td>[[Numeric]]</td>
             <td>*"numeric"*</td>
-            <td>kn</td>
+            <td>*"kn"*</td>
           </tr>
           <tr>
             <td>[[CaseFirst]]</td>
             <td>*"caseFirst"*</td>
-            <td>kf</td>
+            <td>*"kf"*</td>
           </tr>
         </table>
       </emu-table>

--- a/spec/conformance.html
+++ b/spec/conformance.html
@@ -11,13 +11,13 @@
   </p>
   <p>
     <ul>
-      <li>The _options_ property localeMatcher in all constructors and supportedLocalesOf methods.</li>
-      <li>The _options_ properties usage and sensitivity in the Collator constructor.</li>
-      <li>The _options_ properties style and currencyDisplay in the NumberFormat constructor.</li>
-      <li>The _options_ properties minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, and maximumSignificantDigits in the NumberFormat constructor, provided that the additional values are interpreted as integer values higher than the specified limits.</li>
+      <li>The _options_ property *"localeMatcher"* in all constructors and `supportedLocalesOf` methods.</li>
+      <li>The _options_ properties *"usage"* and *"sensitivity"* in the Collator constructor.</li>
+      <li>The _options_ properties *"style"* and *"currencyDisplay"* in the NumberFormat constructor.</li>
+      <li>The _options_ properties *"minimumIntegerDigits"*, *"minimumFractionDigits"*, *"maximumFractionDigits"*, *"minimumSignificantDigits"*, and *"maximumSignificantDigits"* in the NumberFormat constructor, provided that the additional values are interpreted as integer values higher than the specified limits.</li>
       <li>The _options_ properties listed in <emu-xref href="#table-datetimeformat-components"></emu-xref> in the DateTimeFormat constructor.</li>
-      <li>The _options_ property formatMatcher in the DateTimeFormat constructor.</li>
-      <li>The _options_ property type in the PluralRules constructor.</li>
+      <li>The _options_ property *"formatMatcher"* in the DateTimeFormat constructor.</li>
+      <li>The _options_ property *"type"* in the PluralRules constructor.</li>
     </ul>
   </p>
 </emu-clause>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -44,7 +44,7 @@
         <tr>
           <td><dfn>%Date_now%</dfn></td>
           <td>`Date.now`</td>
-          <td>The initial value of the `now` data property of the intrinsic %Date% (ES2020, <emu-xref href="#sec-date.now"></emu-xref>)</td>
+          <td>The initial value of the *"now"* data property of the intrinsic %Date% (ES2020, <emu-xref href="#sec-date.now"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%Intl%</td>
@@ -59,7 +59,7 @@
         <tr>
           <td>%CollatorPrototype%</td>
           <td>`Intl.Collator.prototype`</td>
-          <td>The initial value of the `prototype` data property of the intrinsic %Collator% (<emu-xref href="#sec-intl.collator.prototype"></emu-xref>).</td>
+          <td>The initial value of the *"prototype"* data property of the intrinsic %Collator% (<emu-xref href="#sec-intl.collator.prototype"></emu-xref>).</td>
         </tr>
         <tr>
           <td>%NumberFormat%</td>
@@ -69,7 +69,7 @@
         <tr>
           <td>%NumberFormatPrototype%</td>
           <td>`Intl.NumberFormat.prototype`</td>
-          <td>The initial value of the `prototype` data property of the intrinsic %NumberFormat% (<emu-xref href="#sec-intl.numberformat.prototype"></emu-xref>).</td>
+          <td>The initial value of the *"prototype"* data property of the intrinsic %NumberFormat% (<emu-xref href="#sec-intl.numberformat.prototype"></emu-xref>).</td>
         </tr>
         <tr>
           <td>%DateTimeFormat%</td>
@@ -79,7 +79,7 @@
         <tr>
           <td>%DateTimeFormatPrototype%</td>
           <td>`Intl.DateTimeFormat.prototype`</td>
-          <td>The initial value of the `prototype` data property of the intrinsic %DateTimeFormat% (<emu-xref href="#sec-intl.datetimeformat.prototype"></emu-xref>).</td>
+          <td>The initial value of the *"prototype"* data property of the intrinsic %DateTimeFormat% (<emu-xref href="#sec-intl.datetimeformat.prototype"></emu-xref>).</td>
         </tr>
         <tr>
           <td>%PluralRules%</td>
@@ -89,12 +89,12 @@
         <tr>
           <td>%PluralRulesPrototype%</td>
           <td>`Intl.PluralRules.prototype`</td>
-          <td>The initial value of the `prototype` data property of the intrinsic %PluralRules% (<emu-xref href="#sec-intl.pluralrules.prototype"></emu-xref>).</td>
+          <td>The initial value of the *"prototype"* data property of the intrinsic %PluralRules% (<emu-xref href="#sec-intl.pluralrules.prototype"></emu-xref>).</td>
         </tr>
         <tr>
           <td><dfn>%StringProto_indexOf%</dfn></td>
           <td>`String.prototype.indexOf`</td>
-          <td>The initial value of the `indexOf` data property of the intrinsic %StringPrototype% (ES2020, <emu-xref href="#sec-string.prototype.indexof"></emu-xref>)</td>
+          <td>The initial value of the *"indexOf"* data property of the intrinsic %StringPrototype% (ES2020, <emu-xref href="#sec-string.prototype.indexof"></emu-xref>)</td>
         </tr>
       </table>
     </emu-table>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -244,7 +244,7 @@
       </emu-alg>
 
       <p>
-        The `length` property of a DateTime format function is 1.
+        The *"length"* property of a DateTime format function is 1.
       </p>
     </emu-clause>
 
@@ -287,7 +287,7 @@
               1. Let _fv_ be FormatNumeric(_nf_, _v_).
             1. Else if _f_ is *"2-digit"*, then
               1. Let _fv_ be FormatNumeric(_nf2_, _v_).
-              1. If the `length` property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
+              1. If the *"length"* property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
             1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _f_ in the desired form; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _dateTimeFormat_ has a [[Day]] internal slot. If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[inDST]] field of _tm_. If _p_ is *"era"*, then the String value may also depend on whether _dateTimeFormat_ has a [[Era]] internal slot and if the implementation does not have a localized representation of _f_, then use _f_ itself.
             1. Add new part record { [[Type]]: _p_, [[Value]]: _fv_ } as a new element of the list _result_.
           1. Else if _p_ is equal to *"ampm"*, then
@@ -528,7 +528,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *supportedLocalesOf* method is 1.
+        The value of the *"length"* property of the *supportedLocalesOf* method is 1.
       </p>
     </emu-clause>
 
@@ -544,7 +544,7 @@
       </p>
 
       <emu-note>
-        Unicode Technical Standard 35 describes three locale extension keys that are relevant to date and time formatting, *"ca"* for calendar, *"tz"* for time zone, *"hc"* for hour cycle, and implicitly *"nu"* for the numbering system of the number format used for numbers within the date format. DateTimeFormat, however, requires that the time zone is specified through the timeZone property in the options objects.
+        Unicode Technical Standard 35 describes three locale extension keys that are relevant to date and time formatting, *"ca"* for calendar, *"tz"* for time zone, *"hc"* for hour cycle, and implicitly *"nu"* for the numbering system of the number format used for numbers within the date format. DateTimeFormat, however, requires that the time zone is specified through the *"timeZone"* property in the options objects.
       </emu-note>
 
       <p>
@@ -754,11 +754,11 @@
       </emu-table>
 
       <p>
-        For web compatibility reasons, if the property hourCycle is set, the hour12 property should be set to *true* when hourCycle is *"h11"* or *"h12"*, or to *false* when hourCycle is *"h23"* or *"h24"*.
+        For web compatibility reasons, if the property *"hourCycle"* is set, the *"hour12"* property should be set to *true* when *"hourCycle"* is *"h11"* or *"h12"*, or to *false* when *"hourCycle"* is *"h23"* or *"h24"*.
       </p>
 
       <emu-note>
-        In this version of the ECMAScript 2020 Internationalization API, the timeZone property will be the name of the default time zone if no timeZone property was provided in the options object provided to the Intl.DateTimeFormat constructor. The first edition left the timeZone property *undefined* in this case.
+        In this version of the ECMAScript 2020 Internationalization API, the *"timeZone"* property will be the name of the default time zone if no *"timeZone"* property was provided in the options object provided to the Intl.DateTimeFormat constructor. The first edition left the *"timeZone"* property *undefined* in this case.
       </emu-note>
 
       <emu-note>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1,7 +1,7 @@
 <emu-clause id="intl-object">
   <h1>The Intl Object</h1>
   <p>
-    The Intl object is the <dfn>%Intl%</dfn> intrinsic object and the initial value of the `Intl` property of the global object. The Intl object is a single ordinary object.
+    The Intl object is the <dfn>%Intl%</dfn> intrinsic object and the initial value of the *"Intl"* property of the global object. The Intl object is a single ordinary object.
   </p>
 
   <p>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -32,7 +32,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *localeCompare* method is 1.
+        The value of the *"length"* property of the *localeCompare* method is 1.
       </p>
 
       <emu-note>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -115,7 +115,7 @@
       </emu-alg>
 
       <p>
-        The `length` property of a Number format function is 1.
+        The *"length"* property of a Number format function is 1.
       </p>
     </emu-clause>
 
@@ -520,7 +520,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *supportedLocalesOf* method is 1.
+        The value of the *"length"* property of the *supportedLocalesOf* method is 1.
       </p>
     </emu-clause>
 

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -194,7 +194,7 @@
       </emu-alg>
 
       <p>
-        The value of the `length` property of the *supportedLocalesOf* method is 1.
+        The value of the *"length"* property of the `supportedLocalesOf` method is 1.
       </p>
     </emu-clause>
 


### PR DESCRIPTION
To be consistence internally and with all the changes in ECMA-262.

