### PR TITLE
Typo 2019 => 2020

### DIFF
--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -139,14 +139,14 @@
     <h1>Properties of the BigInt Prototype Object</h1>
 
     <p>
-      The following definition(s) refer to the abstract operation thisBigIntValue as defined in ES2019, <emu-xref href="#sec-properties-of-the-bigint-prototype-object"></emu-xref>.
+      The following definition(s) refer to the abstract operation thisBigIntValue as defined in ES2020, <emu-xref href="#sec-properties-of-the-bigint-prototype-object"></emu-xref>.
     </p>
 
     <emu-clause id="sup-bigint.prototype.tolocalestring">
       <h1>BigInt.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
 
       <p>
-        This definition supersedes the definition provided in ES2019, <emu-xref href="#sec-bigint.prototype.tolocalestring"></emu-xref>.
+        This definition supersedes the definition provided in ES2020, <emu-xref href="#sec-bigint.prototype.tolocalestring"></emu-xref>.
       </p>
 
       <p>


### PR DESCRIPTION
For consistency, the references go to ECMAScript 2020 (the 262 candidate edition in parallel)