### PR TITLE
Revert changes from calendar and numberingSystem options

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -73,26 +73,12 @@
         The abstract operation InitializeDateTimeFormat accepts the arguments _dateTimeFormat_ (which must be an object), _locales_, and _options_. It initializes _dateTimeFormat_ as a DateTimeFormat object. This abstract operation functions as follows:
       </p>
 
-      <p>
-        The following algorithm refers to the `type` nonterminal from <a href="http://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
-      </p>
-
       <emu-alg>
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Let _options_ be ? ToDateTimeOptions(_options_, *"any"*, *"date"*).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, *"string"*, *undefined*, *undefined*).
-        1. If _calendar_ is not *undefined*, then
-          1. If _calendar_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
-          1. Set _calendar_ to the result of mapping _calendar_ to lower case as as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
-        1. Set _opt_.[[ca]] to _calendar_.
-        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
-        1. If _numberingSystem_ is not *undefined*, then
-          1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
-          1. Set _numberingSystem_ to the result of mapping _numberingSystem_ to lower case as as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
-        1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
         1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
         1. If _hour12_ is not *undefined*, then

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -9,7 +9,7 @@
     <h1>Case Sensitivity and Case Mapping</h1>
 
     <p>
-      The String values used to identify locales, currencies, and time zones are interpreted in a case-insensitive manner, treating the Unicode Basic Latin characters *"A"* to *"Z"* (U+0041 to U+005A) as equivalent to the corresponding Basic Latin characters *"a"* to *"z"* (U+0061 to U+007A). No other case folding equivalences are applied. When mapping to upper case, a mapping shall be used that maps characters in the range *"a"* to *"z"* (U+0061 to U+007A) to the corresponding characters in the range *"A"* to *"Z"* (U+0041 to U+005A) and maps no other characters to the latter range. When mapping to lower case, a mapping shall be used that maps characters in the range *"A"* to *"Z"* (U+0041 to U+005A) to the corresponding characters in the range *"a"* to *"z"* (U+0061 to U+007A) and maps no other characters to the latter range.
+      The String values used to identify locales, currencies, and time zones are interpreted in a case-insensitive manner, treating the Unicode Basic Latin characters *"A"* to *"Z"* (U+0041 to U+005A) as equivalent to the corresponding Basic Latin characters *"a"* to *"z"* (U+0061 to U+007A). No other case folding equivalences are applied. When mapping to upper case, a mapping shall be used that maps characters in the range *"a"* to *"z"* (U+0061 to U+007A) to the corresponding characters in the range *"A"* to *"Z"* (U+0041 to U+005A) and maps no other characters to the latter range.
     </p>
 
     <p>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -51,10 +51,6 @@
         The abstract operation InitializeNumberFormat accepts the arguments _numberFormat_ (which must be an object), _locales_, and _options_. It initializes _numberFormat_ as a NumberFormat object. The following steps are taken:
       </p>
 
-      <p>
-        The following algorithm refers to the `type` nonterminal from <a href="http://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
-      </p>
-
       <emu-alg>
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
@@ -64,11 +60,6 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _numberingSystem_ be ? GetOption(_options_, `"numberingSystem"`, `"string"`, *undefined*, *undefined*).
-        1. If _numberingSystem_ is not *undefined*, then
-          1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
-          1. Set _numberingSystem_ to the result of mapping _numberingSystem_ to lower case as as specified in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
-        1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %NumberFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _numberFormat_.[[Locale]] to _r_.[[locale]].


### PR DESCRIPTION
This is a temporary revert commit for #175 until a canonicalization for Unicode extensions are
added through ResolveLocale.

Ref https://github.com/tc39/proposal-intl-locale/issues/96

This commit should be reverted along the proposed solution. Changes are simplified in this single commit to avoid reverting all the 7 original commits from #175.

cc @anba @jswalden @littledan @caiolima.

---

Considering the changes from #175 are already on the master branch and we need to have the "release candidate cut" set before the next TC39 meeting, this PR will help us setting the ideal path, we can pick one of these:

1. Don't merge this PR, the release candidate for ECMA-402 2020 will ship without the changes proposed in tc39/proposal-intl-locale#96. The next ECMA-402 2021 will ideally ship with the canonicalization fixes.
2. Merge this PR, the ECMA-402 2020 RC will ship without the proposed fixes. Right after the Release Candidate Cut, this PR can be reverted. Fixes will follow along. ECMA-402 2021 would ship with everything.

Unfortunately I don't see a way to push everything (including canonicalization fixes) for the ECMA-402 2020, technically we need to communicate and confirm consensus for the changes in the next TC39 meeting and I'd rather not rush things.

---

My preference is option 1, but I'd go with number 2 if anyone opposes to it. This PR is to keep both options equally available.
