### PR TITLE
Normative: Better defaults for hourCycle

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -137,16 +137,16 @@
             1. Set _hc_ to _hcDefault_.
           1. If _hour12_ is not *undefined*, then
             1. If _hour12_ is *true*, then
-              1. If _hcDefault_ is *"h11"* or *"h23"*, then
+              1. If _hcDefault_ is *"h11"*, then
                 1. Set _hc_ to *"h11"*.
               1. Else,
                 1. Set _hc_ to *"h12"*.
             1. Else,
               1. Assert: _hour12_ is *false*.
-              1. If _hcDefault_ is *"h11"* or *"h23"*, then
-                1. Set _hc_ to *"h23"*.
-              1. Else,
+              1. If _hcDefault_ is *"h24"*, then
                 1. Set _hc_ to *"h24"*.
+              1. Else,
+                1. Set _hc_ to *"h23"*.
           1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
           1. If _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then
             1. Let _pattern_ be _bestFormat_.[[pattern12]].


### PR DESCRIPTION
Addresses #402 

Fixes a bugs in the spec where;
* hour12: false would resolve hourCycle to h24 in some locales. This is unexpected as those locales prefer h23
* hour12: true could resolve to hourCycle to h11 is some locales. This is unexpected as those locales prefer h12

Current logic maps h11 to h23 and h12 to h24 which is unexpected. eg
* if hcDefault is h12 but hour12 is false set hourCycle to h24
* if hcDefault is h23 but hour12 is true set hourCycle to h11

New logic
* h12 is always preferred for hour12 is true unless hcDefault is h11
* h23 is always preferred for hour12 is false unless hcDefault is h24

This logic satisfies all locales allowed hour formats in the cldr unicode dataset
Note in particular that in the cldr dataset
* all regions prefer h12 and h23 over h11 and h24.
* No region defines h24 has an allowed format
* Only JP is defines h11 as an allowed (but also accepts h12), In practice h11 is always shown with a dayPeriod.

I believe this brings the spec in to line with the current implementation in spidermonkey and the previous implementation in v8 (see https://bugs.chromium.org/p/chromium/issues/detail?id=1045791 )
