### PR TITLE
Add length property of RelativeTimeFormat

### DIFF
--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -235,7 +235,11 @@
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
     </emu-clause>
-
+    
+    <p>
+      The value of the *"length"* property of the *supportedLocalesOf* method is 1.
+    </p>
+    
     <emu-clause id="sec-Intl.RelativeTimeFormat-internal-slots">
       <h1>Internal slots</h1>
 


### PR DESCRIPTION
Add text about the length property of supportedLocalesOf in RelativeTimeFormat to make it consistent with other parts.

Ref
https://tc39.es/ecma402/#sec-intl.collator.supportedlocalesof
https://tc39.es/ecma402/#sec-intl.numberformat.supportedlocalesof
https://tc39.es/ecma402/#sec-intl.datetimeformat.supportedlocalesof
https://tc39.es/ecma402/#sec-intl.pluralrules.supportedlocalesof
https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.supportedLocalesOf
