### PR TITLE
Normative: Allow Collator to get collation from option

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -14,6 +14,10 @@
         The abstract operation InitializeCollator accepts the arguments _collator_ (which must be an object), _locales_, and _options_. It initializes _collator_ as a *Collator* object. The following steps are taken:
       </p>
 
+      <p>
+        The following algorithm refers to the `type` nonterminal from <a href="http://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
+      </p>
+      
       <emu-alg>
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -33,7 +33,7 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _collation_ be ? GetOption(_options_, `"collation"`, `"string"`, *undefined*, *undefined*).
+        1. Let _collation_ be ? GetOption(_options_, *"collation"*, *"string"*, *undefined*, *undefined*).
         1. If _collation_ is not *undefined*, then
           1. If _collation_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[co]] to _collation_.

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -15,7 +15,7 @@
       </p>
 
       <p>
-        The following algorithm refers to the `type` nonterminal from <a href="http://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
+        The following algorithm refers to the `type` nonterminal from <a href="https://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
       </p>
       
       <emu-alg>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -35,6 +35,10 @@
         1. Set _opt_.[[kn]] to _numeric_.
         1. Let _caseFirst_ be ? GetOption(_options_, *"caseFirst"*, *"string"*, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
         1. Set _opt_.[[kf]] to _caseFirst_.
+        1. Let _collation_ be ? GetOption(_options_, `"collation"`, `"string"`, *undefined*, *undefined*).
+        1. If _collation_ is not *undefined*, then
+          1. If _collation_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
+        1. Set _opt_.[[co]] to _collation_.
         1. Let _relevantExtensionKeys_ be %Collator%.[[RelevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(%Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
         1. Set _collator_.[[Locale]] to _r_.[[locale]].

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -29,16 +29,16 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Let _collation_ be ? GetOption(_options_, `"collation"`, `"string"`, *undefined*, *undefined*).
+        1. If _collation_ is not *undefined*, then
+          1. If _collation_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
+        1. Set _opt_.[[co]] to _collation_.
         1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, *"boolean"*, *undefined*, *undefined*).
         1. If _numeric_ is not *undefined*, then
           1. Let _numeric_ be ! ToString(_numeric_).
         1. Set _opt_.[[kn]] to _numeric_.
         1. Let _caseFirst_ be ? GetOption(_options_, *"caseFirst"*, *"string"*, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
         1. Set _opt_.[[kf]] to _caseFirst_.
-        1. Let _collation_ be ? GetOption(_options_, `"collation"`, `"string"`, *undefined*, *undefined*).
-        1. If _collation_ is not *undefined*, then
-          1. If _collation_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
-        1. Set _opt_.[[co]] to _collation_.
         1. Let _relevantExtensionKeys_ be %Collator%.[[RelevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(%Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
         1. Set _collator_.[[Locale]] to _r_.[[locale]].


### PR DESCRIPTION
Collator already have "co" in  [[RelevantExtensionKeys]] internal slot and therefore the  usage by using "-u-co-$collationkey" is already supported in ECMA402.

This PR will also make our extension / option handling in ECMA402 consistent.

I check other object and I believe this is the only inconsistent handling between u extension and option now.

Close #380