### PR TITLE
editorial: add note about parsing

### DIFF
--- a/spec/overview.html
+++ b/spec/overview.html
@@ -43,6 +43,8 @@
     <p>
       The Intl object is used to package all functionality defined in the ECMAScript 2021 Internationalization API Specification to avoid name collisions.
     </p>
+
+    <emu-note>If you take a look at the specification, you would realize that while the API includes a variety of formatters, it does not provide any parsing facilities. This is something intentional that has been discussed extensively and concluded after weighing in all the benefits and drawbacks of including said functionality. You could learn more about the discussion on the <a href="https://github.com/tc39/ecma402/issues/342">issue tracker</a>.</emu-note>
   </emu-clause>
 
   <emu-clause id="sec-implementation-dependencies">

--- a/spec/overview.html
+++ b/spec/overview.html
@@ -44,7 +44,7 @@
       The Intl object is used to package all functionality defined in the ECMAScript 2021 Internationalization API Specification to avoid name collisions.
     </p>
 
-    <emu-note>If you take a look at the specification, you would realize that while the API includes a variety of formatters, it does not provide any parsing facilities. This is something intentional that has been discussed extensively and concluded after weighing in all the benefits and drawbacks of including said functionality. You could learn more about the discussion on the <a href="https://github.com/tc39/ecma402/issues/342">issue tracker</a>.</emu-note>
+    <emu-note>While the API includes a variety of formatters, it does not provide any parsing facilities. This is intentional, has been discussed extensively, and concluded after weighing in all the benefits and drawbacks of including said functionality. See the discussion on the <a href="https://github.com/tc39/ecma402/issues/342">issue tracker</a>.</emu-note>
   </emu-clause>
 
   <emu-clause id="sec-implementation-dependencies">


### PR DESCRIPTION
Add a brief note to the specification about the reason for non-existence
of parsing functionality.

Fixes: https://github.com/tc39/ecma402/issues/424

/cc @sffc @littledan 