### PR TITLE
Editorial: Add type assertion to GetOption

### DIFF
--- a/spec/locale.html
+++ b/spec/locale.html
@@ -16,6 +16,7 @@
 
       <emu-alg>
         1. Assert: Type(_tag_) is String.
+        1. Assert: Type(_options_) is Object.
         1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
         1. Let _language_ be ? GetOption(_options_, *"language"*, *"string"*, *undefined*, *undefined*).
         1. If _language_ is not *undefined*, then

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -311,6 +311,7 @@
       </p>
 
       <emu-alg>
+        1. Assert: Type(_options_) is Object.
         1. Let _value_ be ? Get(_options_, _property_).
         1. If _value_ is not *undefined*, then
           1. Assert: _type_ is *"boolean"* or *"string"*.
@@ -349,6 +350,7 @@
       </p>
 
       <emu-alg>
+        1. Assert: Type(_options_) is Object.
         1. Let _value_ be ? Get(_options_, _property_).
         1. Return ? DefaultNumberOption(_value_, _minimum_, _maximum_, _fallback_).
       </emu-alg>


### PR DESCRIPTION
In Temporal, we are using an operation similar to GetOption (and intend
to add it to 262 in the future) and it came up in a discussion that it
would be better to have this assertion in GetOption to show that all
call sites should perform ToObject or whatever on the options object.

Assertion also added to GetNumberOption for symmetry, and to
ApplyOptionsToTag for clarity.