### PR TITLE
Normative: handle awkward rounding behavior

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -170,5 +170,8 @@
     <li>
       <emu-xref href="#sec-Intl-toStringTag"></emu-xref> In ECMA-402, 7th Edition, the @@toStringTag property of `Intl` was not defined. In 8th Edition, @@toStringTag is set to *"Intl"*.
     </li>
+    <li>
+      <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref> In ECMA-402, 8th Edition, the NumberFormat constructor used to throw an error when maximumFractionDigits was set to a value lower than the default fractional digits for that currency. This behavior was corrected in the 9th edition, and it no longer throws an error.
+    </li>
   </ul>
 </emu-annex>

--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -171,7 +171,7 @@
       <emu-xref href="#sec-Intl-toStringTag"></emu-xref> In ECMA-402, 7th Edition, the @@toStringTag property of `Intl` was not defined. In 8th Edition, @@toStringTag is set to *"Intl"*.
     </li>
     <li>
-      <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref> In ECMA-402, 8th Edition, the NumberFormat constructor used to throw an error when maximumFractionDigits was set to a value lower than the default fractional digits for that currency. This behavior was corrected in the 9th edition, and it no longer throws an error.
+      <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref> In ECMA-402, 8th Edition, the NumberFormat constructor used to throw an error when style="currency" and maximumFractionDigits was set to a value lower than the default fractional digits for that currency. This behavior was corrected in the 9th edition, and it no longer throws an error.
     </li>
   </ul>
 </emu-annex>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -31,8 +31,10 @@
         1. Else if _mnfd_ is not *undefined* or _mxfd_ is not *undefined*, then
           1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
           1. Let _mnfdActualDefault_ be _mnfdDefault_.
-          1. If Type(_mxfd_) is Number and _mxfd_ is not *NaN*, then
-            1. Set _mnfdActualDefault_ to min( _mxfd_, _mnfdDefault_ ).
+          1. If _mxfd_ is not *undefined*, then
+            1. Let _mxfd_ be ? ToNumber(_mxfd_).
+            1. If _mxfd_ is not *NaN*, then
+              1. Set _mnfdActualDefault_ to min( max( _mxfd_, 0 ), _mnfdDefault_ ).
           1. Let _mnfd_ be ? DefaultNumberOption(_mnfd_, 0, 20, _mnfdActualDefault_).
           1. Let _mxfdActualDefault_ be max( _mnfd_, _mxfdDefault_ ).
           1. Let _mxfd_ be ? DefaultNumberOption(_mxfd_, _mnfd_, 20, _mxfdActualDefault_).

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -30,19 +30,18 @@
           1. Set _intlObj_.[[MaximumSignificantDigits]] to _mxsd_.
         1. Else if _mnfd_ is not *undefined* or _mxfd_ is not *undefined*, then
           1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
-          1. Let _mnfdActualDefault_ be _mnfdDefault_.
-          1. If _mxfd_ is not *undefined*, then
+          1. If _mxfd_ is *undefined*, then
+            1. Let _mnfdActualDefault_ be _mnfdDefault_.
+          1. Else,
             1. Set _mxfd_ to ? ToNumber(_mxfd_).
-            1. If _mxfd_ is *NaN*, then
-              1. Throw a *RangeError* exception.
+            1. If _mxfd_ is *NaN*, then throw a *RangeError* exception.
             1. Set _mnfdActualDefault_ to min( max( _mxfd_, 0 ), _mnfdDefault_ ).
           1. Let _mnfd_ be ? DefaultNumberOption(_mnfd_, 0, 20, _mnfdActualDefault_).
           1. Let _mxfdActualDefault_ be max( _mnfd_, _mxfdDefault_ ).
           1. If _mxfd_ is *undefined*, then
             1. Set _mxfd_ to _mxfdActualDefault_.
           1. Else,
-            1. If _mxfd_ is less than _mnfd_ or greater than 20, then
-              1. Throw a *RangeError* exception.
+            1. If _mxfd_ is less than _mnfd_ or greater than 20, then throw a *RangeError* exception.
             1. Set _mxfd_ to floor( _mxfd_ ).
           1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfd_.
           1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfd_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -30,7 +30,10 @@
           1. Set _intlObj_.[[MaximumSignificantDigits]] to _mxsd_.
         1. Else if _mnfd_ is not *undefined* or _mxfd_ is not *undefined*, then
           1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
-          1. Let _mnfd_ be ? DefaultNumberOption(_mnfd_, 0, 20, _mnfdDefault_).
+          1. Let _mnfdActualDefault_ be _mnfdDefault_.
+          1. If Type(_mxfd_) is Number and _mxfd_ is not *NaN*, then
+            1. Set _mnfdActualDefault_ to min( _mxfd_, _mnfdDefault_ ).
+          1. Let _mnfd_ be ? DefaultNumberOption(_mnfd_, 0, 20, _mnfdActualDefault_).
           1. Let _mxfdActualDefault_ be max( _mnfd_, _mxfdDefault_ ).
           1. Let _mxfd_ be ? DefaultNumberOption(_mxfd_, _mnfd_, 20, _mxfdActualDefault_).
           1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfd_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -30,10 +30,12 @@
           1. Set _intlObj_.[[MaximumSignificantDigits]] to _mxsd_.
         1. Else if _mnfd_ is not *undefined* or _mxfd_ is not *undefined*, then
           1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
-          1. Let _mnfdActualDefault_ be ? min( _mnfdDefault_, DefaultNumberOption(_mxfd_, 0, 20, 20) ).
-          1. Let _mnfd_ be ? DefaultNumberOption(_mnfd_, 0, 20, _mnfdActualDefault_).
-          1. Let _mxfdActualDefault_ be max( _mnfd_, _mxfdDefault_ ).
-          1. Let _mxfd_ be ? DefaultNumberOption(_mxfd_, _mnfd_, 20, _mxfdActualDefault_).
+          1. Let _specifiedMnfd_ be ? DefaultNumberOption(_mnfd_, 0, 20, *undefined*).
+          1. Let _specifiedMxfd_ be ? DefaultNumberOption(_mxfd_, 0, 20, *undefined*).
+          1. If _specifiedMxfd_ is not *undefined*, set _mnfdDefault_ to min(_mnfdDefault_, _specifiedMxfd_).
+          1. Set _mnfd_ to ! DefaultNumberOption(_specifiedMnfd_, 0, 20, _mnfdDefault_).
+          1. Set _mxfd_ to ! DefaultNumberOption(_specifiedMxfd_, 0, 20, max(_mxfdDefault_, _mnfd_)).
+          1. If _mnfd_ is greater than _mxfd_, throw a *RangeError* exception.
           1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfd_.
           1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfd_.
         1. Else if _notation_ is *"compact"*, then

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -32,12 +32,18 @@
           1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
           1. Let _mnfdActualDefault_ be _mnfdDefault_.
           1. If _mxfd_ is not *undefined*, then
-            1. Let _mxfd_ be ? ToNumber(_mxfd_).
-            1. If _mxfd_ is not *NaN*, then
-              1. Set _mnfdActualDefault_ to min( max( _mxfd_, 0 ), _mnfdDefault_ ).
+            1. Set _mxfd_ to ? ToNumber(_mxfd_).
+            1. If _mxfd_ is *NaN*, then
+              1. Throw a *RangeError* exception.
+            1. Set _mnfdActualDefault_ to min( max( _mxfd_, 0 ), _mnfdDefault_ ).
           1. Let _mnfd_ be ? DefaultNumberOption(_mnfd_, 0, 20, _mnfdActualDefault_).
           1. Let _mxfdActualDefault_ be max( _mnfd_, _mxfdDefault_ ).
-          1. Let _mxfd_ be ? DefaultNumberOption(_mxfd_, _mnfd_, 20, _mxfdActualDefault_).
+          1. If _mxfd_ is *undefined*, then
+            1. Set _mxfd_ to _mxfdActualDefault_.
+          1. Else,
+            1. If _mxfd_ is less than _mnfd_ or greater than 20, then
+              1. Throw a *RangeError* exception.
+            1. Set _mxfd_ to floor( _mxfd_ ).
           1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfd_.
           1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfd_.
         1. Else if _notation_ is *"compact"*, then

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -30,19 +30,10 @@
           1. Set _intlObj_.[[MaximumSignificantDigits]] to _mxsd_.
         1. Else if _mnfd_ is not *undefined* or _mxfd_ is not *undefined*, then
           1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
-          1. If _mxfd_ is *undefined*, then
-            1. Let _mnfdActualDefault_ be _mnfdDefault_.
-          1. Else,
-            1. Set _mxfd_ to ? ToNumber(_mxfd_).
-            1. If _mxfd_ is *NaN*, then throw a *RangeError* exception.
-            1. Set _mnfdActualDefault_ to min( max( _mxfd_, 0 ), _mnfdDefault_ ).
+          1. Let _mnfdActualDefault_ be ? min( _mnfdDefault_, DefaultNumberOption(_mxfd_, 0, 20, 20) ).
           1. Let _mnfd_ be ? DefaultNumberOption(_mnfd_, 0, 20, _mnfdActualDefault_).
           1. Let _mxfdActualDefault_ be max( _mnfd_, _mxfdDefault_ ).
-          1. If _mxfd_ is *undefined*, then
-            1. Set _mxfd_ to _mxfdActualDefault_.
-          1. Else,
-            1. If _mxfd_ is less than _mnfd_ or greater than 20, then throw a *RangeError* exception.
-            1. Set _mxfd_ to floor( _mxfd_ ).
+          1. Let _mxfd_ be ? DefaultNumberOption(_mxfd_, _mnfd_, 20, _mxfdActualDefault_).
           1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfd_.
           1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfd_.
         1. Else if _notation_ is *"compact"*, then


### PR DESCRIPTION
Handle awkward rounding behavior when dealing with currencies and the
value of "maximumFractionDigits" is less than `cDigits`.

Fixes: https://github.com/tc39/ecma402/issues/239
Test 262 PR: https://github.com/tc39/test262/pull/2707
V8 CL: https://chromium-review.googlesource.com/c/v8/v8/+/2288710

/cc @sffc @littledan 