### PR TITLE
Editorial: Change "be this value" to "be the this value"

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -180,7 +180,7 @@
       </p>
 
       <emu-alg>
-        1. Let _collator_ be *this* value.
+        1. Let _collator_ be the *this* value.
         1. Perform ? RequireInternalSlot(_collator_, [[InitializedCollator]]).
         1. If _collator_.[[BoundCompare]] is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-collator-compare-functions"></emu-xref>.
@@ -269,7 +269,7 @@
       </p>
 
       <emu-alg>
-        1. Let _collator_ be *this* value.
+        1. Let _collator_ be the *this* value.
         1. Perform ? RequireInternalSlot(_collator_, [[InitializedCollator]]).
         1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).
         1. For each row of <emu-xref href="#table-collator-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -632,7 +632,7 @@
       </p>
 
       <emu-alg>
-        1. Let _dtf_ be *this* value.
+        1. Let _dtf_ be the *this* value.
         1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
         1. Let _dtf_ be ? UnwrapDateTimeFormat(_dtf_).
         1. If _dtf_.[[BoundFormat]] is *undefined*, then
@@ -656,7 +656,7 @@
       </p>
 
       <emu-alg>
-        1. Let _dtf_ be *this* value.
+        1. Let _dtf_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
         1. If _date_ is *undefined*, then
           1. Let _x_ be Call(%Date_now%, *undefined*).
@@ -674,7 +674,7 @@
       </p>
 
       <emu-alg>
-        1. Let _dtf_ be *this* value.
+        1. Let _dtf_ be the *this* value.
         1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
         1. Let _dtf_ be ? UnwrapDateTimeFormat(_dtf_).
         1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1057,7 +1057,7 @@
       </p>
 
       <emu-alg>
-        1. Let _nf_ be *this* value.
+        1. Let _nf_ be the *this* value.
         1. If Type(_nf_) is not Object, throw a *TypeError* exception.
         1. Let _nf_ be ? UnwrapNumberFormat(_nf_).
         1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).


### PR DESCRIPTION
I noticed we're not consistent about whether we write

> Let foo be *this* value

vs

> Let foo be the *this* value

262 consistently uses the latter form, so this PR just unifies to that language.