### PR TITLE
Editorial: Correct FormatNumber to FormatNumeric

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -311,7 +311,7 @@
             1. Append a new Record { [[Type]]: *"dayPeriod"*, [[Value]]: _fv_ } as the last element of the list _result_.
           1. Else if _p_ is equal to *"relatedYear"*, then
             1. Let _v_ be _tm_.[[RelatedYear]].
-            1. Let _fv_ be FormatNumber(_nf_, _v_).
+            1. Let _fv_ be FormatNumeric(_nf_, _v_).
             1. Append a new Record { [[Type]]: *"relatedYear"*, [[Value]]: _fv_ } as the last element of the list _result_.
           1. Else if _p_ is equal to *"yearName"*, then
             1. Let _v_ be _tm_.[[YearName]].


### PR DESCRIPTION
FormatNumber was renamed to FormatNumeric but didn't change this line while merging.

@anba  @gibson042  @littledan @rwaldron @leobalter 