### PR TITLE
Editorial: Correct MinFromTime and SecFromTime

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -431,11 +431,11 @@
           </tr>
           <tr>
             <td>[[Minute]]</td>
-            <td>`MinuteFromTime(tz)` specified in ES2021's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
+            <td>`MinFromTime(tz)` specified in ES2021's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
           </tr>
           <tr>
             <td>[[Second]]</td>
-            <td>`SecondFromTime(tz)` specified in ES2021's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
+            <td>`SecFromTime(tz)` specified in ES2021's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
           </tr>
           <tr>
             <td>[[InDST]]</td>


### PR DESCRIPTION
There are no MinuteFromTime nor SecondFromTime in https://www.ecma-international.org/ecma-262/11.0/index.html#sec-hours-minutes-second-and-milliseconds
Correct them to MinFromTime and SecFromTime