### PR TITLE
Editorial: Tweak UnicodeExtensionComponents to clarify spec variables

### DIFF
--- a/spec/locale.html
+++ b/spec/locale.html
@@ -62,8 +62,8 @@
           1. Let _attributes_ be _components_.[[Attributes]].
           1. Let _keywords_ be _components_.[[Keywords]].
         1. Else,
-          1. Let _attributes_ be the empty List.
-          1. Let _keywords_ be the empty List.
+          1. Let _attributes_ be a new empty List.
+          1. Let _keywords_ be a new empty List.
         1. Let _result_ be a new Record.
         1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
           1. Let _value_ be *undefined*.
@@ -80,7 +80,7 @@
             1. If _entry_ is not ~empty~, then
               1. Set _entry_.[[Value]] to _value_.
             1. Else,
-              1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
+              1. Append the Record { [[Key]]: _key_, [[Value]]: _value_ } to _keywords_.
           1. Set _result_.[[<_key_>]] to _value_.
         1. Let _locale_ be the String value that is _tag_ with all Unicode locale extension sequences removed.
         1. Let _newExtension_ be a Unicode BCP 47 U Extension based on _attributes_ and _keywords_.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -129,39 +129,35 @@
     <emu-clause id="sec-unicode-extension-components" aoid=UnicodeExtensionComponents>
       <h1>UnicodeExtensionComponents( _extension_ )</h1>
       <p>
-        The UnicodeExtensionComponents abstract operation returns the attributes and keywords from _extension_, which must be a Unicode locale extension sequence. If an attribute or a keyword occurs multiple times in _extension_, only the first occurence is returned. The following steps are taken:
+        The UnicodeExtensionComponents abstract operation returns the attributes and keywords from _extension_, which must be a String value whose contents are a Unicode locale extension sequence. If an attribute or a keyword occurs multiple times in _extension_, only the first occurence is returned. The following steps are taken:
       </p>
 
       <emu-alg>
-        1. Let _attributes_ be the empty List.
-        1. Let _keywords_ be the empty List.
-        1. Let _isKeyword_ be *false*.
-        1. Let _size_ be the number of elements in _extension_.
+        1. Let _attributes_ be a new empty List.
+        1. Let _keywords_ be a new empty List.
+        1. Let _keyword_ be *undefined*.
+        1. Let _size_ be the length of _extension_.
         1. Let _k_ be 3.
         1. Repeat, while _k_ &lt; _size_
           1. Let _e_ be ! Call(%StringProto_indexOf%, _extension_, « *"-"*, _k_ »).
           1. If _e_ = -1, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
           1. Let _subtag_ be the String value equal to the substring of _extension_ consisting of the code units at indices _k_ (inclusive) through _k_ + _len_ (exclusive).
-          1. If _isKeyword_ is *false*, then
-            1. If _len_ &ne; 2 and _subtag_ is not an element of _attributes_, then
+          1. If _keyword_ is *undefined* and _len_ &ne; 2, then
+            1. If _subtag_ is not an element of _attributes_, then
               1. Append _subtag_ to _attributes_.
+          1. Else if _len_ = 2, then
+            1. If _keyword_ is not *undefined* and _keywords_ does not contain an element whose [[Key]] is the same as _keyword_.[[Key]], then
+              1. Append _keyword_ to _keywords_.
+            1. Set _keyword_ to the Record { [[Key]]: _subtag_, [[Value]]: *""* }.
           1. Else,
-            1. If _len_ = 2, then
-              1. If _keywords_ does not contain an element whose [[Key]] is the same as _key_, then
-                1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
+            1. If _keyword_.[[Value]] is the empty String, then
+              1. Set _keyword_.[[Value]] to _subtag_.
             1. Else,
-              1. If _value_ is not the empty String, then
-                1. Let _value_ be the string-concatenation of _value_ and *"-"*.
-              1. Let _value_ be the string-concatenation of _value_ and _subtag_.
-          1. If _len_ = 2, then
-            1. Let _isKeyword_ be *true*.
-            1. Let _key_ be _subtag_.
-            1. Let _value_ be the empty String.
+              1. Set _keyword_.[[Value]] to the string-concatenation of _keyword_.[[Value]], *"-"*, and _subtag_.
           1. Let _k_ be _k_ + _len_ + 1.
-        1. If _isKeyword_ is *true*, then
-          1. If _keywords_ does not contain an element whose [[Key]] is the same as _key_, then
-            1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
-        1. Return the Record{[[Attributes]]: _attributes_, [[Keywords]]: _keywords_}.
+        1. If _keyword_ is not *undefined* and _keywords_ does not contain an element whose [[Key]] is the same as _keyword_.[[Key]], then
+          1. Append _keyword_ to _keywords_.
+        1. Return the Record { [[Attributes]]: _attributes_, [[Keywords]]: _keywords_ }.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
I found it hard to follow the current algorithm, which uses three variables to track the current keyword, two of which are introduced inside a loop for use in later iterations _of_ the loop.