### PR TITLE
Editorial: Fix linter errors in spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "ECMAScript Internationalization API Specification",
   "scripts": {
     "build-es2020": "git remote remove origin && git remote add origin \"git@github.com:$TRAVIS_REPO_SLUG.git\" && git fetch --quiet origin && git checkout --quiet es2020 && mkdir \"out/2020\" && cp -R img \"out/2020\" && ecmarkup --verbose spec/index.html out/2020/index.html --css out/2020/ecmarkup.css --js out/2020/ecmarkup.js",
-    "build-master": "mkdir out && cp -R img out && ecmarkup --verbose spec/index.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
+    "build-master": "mkdir out && cp -R img out && ecmarkup --lint-spec --verbose spec/index.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js",
     "prebuild": "npm run clean",
     "build": "npm run build-master",
     "prebuild-for-pdf": "npm run clean",
@@ -13,7 +13,7 @@
     "prebuild-travis": "npm run clean",
     "build-travis": "npm run build-master && npm run build-es2020",
     "clean": "rm -rf out",
-    "test": "exit 0",
+    "test": "ecmarkup --lint-spec spec/index.html /dev/null",
     "prewatch": "npm run clean",
     "watch": "npm run build-master -- --watch"
   },
@@ -22,7 +22,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma402/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma402/",
   "dependencies": {
-    "ecmarkup": "3.19.1"
+    "ecmarkup": "^4.1.0"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^3.0.0"

--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -153,7 +153,7 @@
       <emu-xref href="#sec-the-intl-collator-constructor"></emu-xref>, <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref>, <emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref> In ECMA-402, 1st Edition, constructors could be used to create Intl objects from arbitrary objects. This is no longer possible in 2nd Edition.
     </li>
     <li>
-      <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1st Edition, the *"length"* property of the function object _F_ was set to *0*. In 2nd Edition, *"length"* is set to *1*.
+      <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1st Edition, the *"length"* property of the function object _F_ was set to *+0*. In 2nd Edition, *"length"* is set to *1*.
     </li>
     <li>
       <emu-xref href="#sec-intl.collator.prototype-@@tostringtag"></emu-xref> In ECMA-402, 7th Edition, the @@toStringTag property of `Intl.Collator.prototype` was set to *"Object"*. In 8th Edition, @@toStringTag is set to *"Intl.Collator"*.

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -58,7 +58,6 @@
         1. Set _collator_.[[IgnorePunctuation]] to _ignorePunctuation_.
         1. Return _collator_.
       </emu-alg>
-
     </emu-clause>
 
     <emu-clause id="sec-intl.collator">
@@ -138,7 +137,6 @@
         <li>The values *"standard"* and *"search"* must not be used as elements in any [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] list.</li>
         <li>[[SearchLocaleData]][[&lt;_locale_&gt;]] must have a sensitivity field with a String value equal to *"base"*, *"accent"*, *"case"*, or *"variant"*.</li>
       </ul>
-
     </emu-clause>
   </emu-clause>
 
@@ -257,12 +255,11 @@
         <emu-note>
           Applications should not assume that the behaviour of the CompareStrings abstract operation for Collator instances with the same resolved options will remain the same for different versions of the same implementation.
         </emu-note>
-
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-intl.collator.prototype.resolvedoptions">
-      <h1>Intl.Collator.prototype.resolvedOptions ()</h1>
+      <h1>Intl.Collator.prototype.resolvedOptions ( )</h1>
 
       <p>
         This function provides access to the locale and collation options computed during initialization of the object.
@@ -369,6 +366,5 @@
     <p>
       Finally, Intl.Collator instances have a [[BoundCompare]] internal slot that caches the function returned by the compare accessor (<emu-xref href="#sec-intl.collator.prototype.compare"></emu-xref>).
     </p>
-
   </emu-clause>
 </emu-clause>

--- a/spec/conformance.html
+++ b/spec/conformance.html
@@ -7,7 +7,7 @@
     A conforming implementation of the ECMAScript 2021 Internationalization API Specification is permitted to provide additional objects, properties, and functions beyond those described in this specification. In particular, a conforming implementation of the ECMAScript 2021 Internationalization API Specification is permitted to provide properties not described in this specification, and values for those properties, for objects that are described in this specification. A conforming implementation is not permitted to add optional arguments to the functions defined in this specification.
   </p>
   <p>
-    A conforming implementation is permitted to accept additional values, and then have implementation-defined behaviour instead of throwing a *RangeError*, for the following properties of _options_  arguments:
+    A conforming implementation is permitted to accept additional values, and then have implementation-defined behaviour instead of throwing a *RangeError*, for the following properties of _options_ arguments:
   </p>
   <p>
     <ul>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -210,12 +210,12 @@
         1. Assert: Type(_formats_) is List.
         1. For each element _format_ of _formats_ in List order, do
           1. Let _score_ be 0.
-          1. For each _property_ shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, do
+          1. For each property name _property_ shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, do
             1. Let _optionsProp_ be _options_.[[&lt;_property_&gt;]].
             1. Let _formatProp_ be _format_.[[&lt;_property_&gt;]].
             1. If _optionsProp_ is *undefined* and _formatProp_ is not *undefined*, then decrease _score_ by _additionPenalty_.
             1. Else if _optionsProp_ is not *undefined* and _formatProp_ is *undefined*, then decrease _score_ by _removalPenalty_.
-            1. Else if _optionsProp_ ≠ _formatProp_,
+            1. Else if _optionsProp_ ≠ _formatProp_, then
               1. Let _values_ be &laquo; *"2-digit"*, *"numeric"*, *"narrow"*, *"short"*, *"long"* &raquo;.
               1. Let _optionsPropIndex_ be the index of _optionsProp_ within _values_.
               1. Let _formatPropIndex_ be the index of _formatProp_ within _values_.
@@ -329,11 +329,10 @@
       <emu-note>
         It is recommended that implementations use the time zone information of the IANA Time Zone Database.
       </emu-note>
-
     </emu-clause>
 
     <emu-clause id="sec-formatdatetime" aoid="FormatDateTime">
-      <h1>FormatDateTime( _dateTimeFormat_, _x_ )</h1>
+      <h1>FormatDateTime ( _dateTimeFormat_, _x_ )</h1>
 
       <p>
         The FormatDateTime abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), and performs the following steps:
@@ -342,11 +341,10 @@
       <emu-alg>
         1. Let _parts_ be ? PartitionDateTimePattern(_dateTimeFormat_, _x_).
         1. Let _result_ be the empty String.
-        1. For each _part_ in _parts_, do
+        1. For each Record _part_ in _parts_, do
           1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
         1. Return _result_.
       </emu-alg>
-
     </emu-clause>
 
     <emu-clause id="sec-formatdatetimetoparts" aoid="FormatDateTimeToParts">
@@ -360,7 +358,7 @@
         1. Let _parts_ be ? PartitionDateTimePattern(_dateTimeFormat_, _x_).
         1. Let _result_ be ArrayCreate(0).
         1. Let _n_ be 0.
-        1. For each _part_ in _parts_, do
+        1. For each Record _part_ in _parts_, do
           1. Let _O_ be ObjectCreate(%Object.prototype%).
           1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
           1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
@@ -368,7 +366,6 @@
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>
-
     </emu-clause>
 
     <emu-clause id="sec-tolocaltime" aoid="ToLocalTime">
@@ -380,7 +377,7 @@
 
       <emu-alg>
         1. Assert: Type(_t_) is Number.
-        1. If _calendar_ is *"gregory"*,
+        1. If _calendar_ is *"gregory"*, then
           1. Let _timeZoneOffset_ be the value calculated according to <emu-xref href="#sec-local-time-zone-adjustment">LocalTZA(_t_, *true*)</emu-xref> where the local time zone is replaced with timezone _timeZone_.
           1. Let _tz_ be the time value _t_ + _timeZoneOffset_.
           1. Return a record with fields calculated from _tz_ according to <emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref>.
@@ -450,7 +447,7 @@
     </emu-clause>
 
     <emu-clause id="sec-unwrapdatetimeformat" aoid="UnwrapDateTimeFormat">
-      <h1>UnwrapDateTimeFormat( _dtf_ )</h1>
+      <h1>UnwrapDateTimeFormat ( _dtf_ )</h1>
       <p>
         The UnwrapDateTimeFormat abstract operation gets the underlying DateTimeFormat operation
         for various methods which implement ECMA-402 v1 semantics for supporting initializing
@@ -460,11 +457,13 @@
         1. Assert: Type(_dtf_) is Object.
       </emu-alg>
       <emu-normative-optional>
+      <!-- Note: 2. is intentional -->
       <emu-alg>
         2. If _dtf_ does not have an [[InitializedDateTimeFormat]] internal slot and ? InstanceofOperator(_dtf_, %DateTimeFormat%) is *true*, then
           1. Let _dtf_ be ? Get(_dtf_, %Intl%.[[FallbackSymbol]]).
       </emu-alg>
       </emu-normative-optional>
+      <!-- Note: 3. is intentional -->
       <emu-alg>
         3. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
         1. Return _dtf_.
@@ -493,6 +492,7 @@
         1. Perform ? InitializeDateTimeFormat(_dateTimeFormat_, _locales_, _options_).
       </emu-alg>
       <emu-normative-optional>
+      <!-- Note: 4. is intentional -->
       <emu-alg>
         4. Let _this_ be the *this* value.
         1. If NewTarget is *undefined* and Type(_this_) is Object and ? InstanceofOperator(_this_, %DateTimeFormat%) is *true*, then
@@ -500,6 +500,7 @@
           1. Return _this_.
       </emu-alg>
       </emu-normative-optional>
+      <!-- Note: 6. is intentional -->
       <emu-alg>
         6. Return _dateTimeFormat_.
       </emu-alg>
@@ -587,9 +588,9 @@
         </li>
       </ul>
 
-      <p>
-        EXAMPLE     An implementation might include the following record as part of its English locale data: {[[hour]]: *"numeric"*, [[minute]]: *"2-digit"*, [[second]]: *"2-digit"*, [[pattern]]: *"{hour}:{minute}:{second}"*, [[pattern12]]: *"{hour}:{minute}:{second} {ampm}"*}.
-      </p>
+      <emu-note>
+        For example, an implementation might include the following record as part of its English locale data: {[[hour]]: *"numeric"*, [[minute]]: *"2-digit"*, [[second]]: *"2-digit"*, [[pattern]]: *"{hour}:{minute}:{second}"*, [[pattern12]]: *"{hour}:{minute}:{second} {ampm}"*}.
+      </emu-note>
 
       <emu-note>
         It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>).
@@ -667,7 +668,7 @@
     </emu-clause>
 
     <emu-clause id="sec-intl.datetimeformat.prototype.resolvedoptions">
-      <h1>Intl.DateTimeFormat.prototype.resolvedOptions ()</h1>
+      <h1>Intl.DateTimeFormat.prototype.resolvedOptions ( )</h1>
 
       <p>
         This function provides access to the locale and formatting options computed during initialization of the object.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -35,42 +35,42 @@
     <h1>Constructor Properties of the Intl Object</h1>
 
     <emu-clause id="sec-intl.locale-intro">
-      <h1>Intl.Locale (...)</h1>
+      <h1>Intl.Locale ( . . . )</h1>
       <p>
         See <emu-xref href="#locale-objects"></emu-xref>.
       </p>
     </emu-clause>
 
     <emu-clause id="sec-intl.collator-intro">
-      <h1>Intl.Collator (...)</h1>
+      <h1>Intl.Collator ( . . . )</h1>
       <p>
         See <emu-xref href="#collator-objects"></emu-xref>.
       </p>
     </emu-clause>
 
     <emu-clause id="sec-intl.numberformat-intro">
-      <h1>Intl.NumberFormat (...)</h1>
+      <h1>Intl.NumberFormat ( . . . )</h1>
       <p>
         See <emu-xref href="#numberformat-objects"></emu-xref>.
       </p>
     </emu-clause>
 
     <emu-clause id="sec-intl.datetimeformat-intro">
-      <h1>Intl.DateTimeFormat (...)</h1>
+      <h1>Intl.DateTimeFormat ( . . . )</h1>
       <p>
         See <emu-xref href="#datetimeformat-objects"></emu-xref>.
       </p>
     </emu-clause>
 
     <emu-clause id="sec-intl.relativetimeformat-intro">
-      <h1>Intl.RelativeTimeFormat (...)</h1>
+      <h1>Intl.RelativeTimeFormat ( . . . )</h1>
       <p>
         See <emu-xref href="#relativetimeformat-objects"></emu-xref>.
       </p>
     </emu-clause>
 
     <emu-clause id="sec-intl.pluralrules-intro">
-      <h1>Intl.PluralRules (...)</h1>
+      <h1>Intl.PluralRules ( . . . )</h1>
       <p>
         See <emu-xref href="#pluralrules-objects"></emu-xref>.
       </p>
@@ -79,7 +79,6 @@
     <emu-note id="legacy-constructor">
       In ECMA 402 v1, Intl constructors supported a mode of operation where calling them with an existing object as a receiver would transform the receiver into the relevant Intl instance with all internal slots. In ECMA 402 v2, this capability was removed, to avoid adding internal slots on existing objects. In ECMA 402 v3, the capability was re-added as "normative optional" in a mode which chains the underlying Intl instance on any object, when the constructor is called. See <a href="https://github.com/tc39/ecma402/issues/57">Issue 57</a> for details.
     </emu-note>
-
   </emu-clause>
 
   <emu-clause id="sec-function-properties-of-the-intl-object">
@@ -97,7 +96,5 @@
         1. Return CreateArrayFromList(_ll_).
       </emu-alg>
     </emu-clause>
-
   </emu-clause>
-
 </emu-clause>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -42,7 +42,6 @@
       <emu-note>
         The `localeCompare` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.
       </emu-note>
-
     </emu-clause>
 
     <emu-clause id="sup-string.prototype.tolocalelowercase">
@@ -85,7 +84,6 @@
       <emu-note>
         The `toLocaleLowerCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.
       </emu-note>
-
     </emu-clause>
 
     <emu-clause id="sup-string.prototype.tolocaleuppercase">
@@ -102,10 +100,8 @@
       <emu-note>
         The `toLocaleUpperCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.
       </emu-note>
-
     </emu-clause>
   </emu-clause>
-
 
   <emu-clause id="sup-properties-of-the-number-prototype-object">
     <h1>Properties of the Number Prototype Object</h1>
@@ -130,10 +126,8 @@
         1. Let _numberFormat_ be ? Construct(%NumberFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return ? FormatNumeric(_numberFormat_, _x_).
       </emu-alg>
-
     </emu-clause>
   </emu-clause>
-
 
   <emu-clause id="sup-properties-of-the-bigint-prototype-object">
     <h1>Properties of the BigInt Prototype Object</h1>
@@ -158,7 +152,6 @@
         1. Let _numberFormat_ be ? Construct(%NumberFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return ? FormatNumeric(_numberFormat_, _x_).
       </emu-alg>
-
     </emu-clause>
   </emu-clause>
 
@@ -187,7 +180,6 @@
         1. Let _dateFormat_ be ? Construct(%DateTimeFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return ? FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
-
     </emu-clause>
 
     <emu-clause id="sup-date.prototype.tolocaledatestring">
@@ -208,7 +200,6 @@
         1. Let _dateFormat_ be ? Construct(%DateTimeFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return ? FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
-
     </emu-clause>
 
     <emu-clause id="sup-date.prototype.tolocaletimestring">
@@ -229,7 +220,6 @@
         1. Let _timeFormat_ be ? Construct(%DateTimeFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return ? FormatDateTime(_timeFormat_, _x_).
       </emu-alg>
-
     </emu-clause>
   </emu-clause>
 
@@ -253,7 +243,7 @@
         1. Let _separator_ be the String value for the list-separator String appropriate for the host environment's current locale (this is derived in an implementation-defined way).
         1. Let _R_ be the empty String.
         1. Let _k_ be 0.
-        1. Repeat, while _k_ &lt; _len_
+        1. Repeat, while _k_ &lt; _len_,
           1. If _k_ &gt; 0, then
             1. Set _R_ to the string-concatenation of _R_ and _separator_.
           1. Let _nextElement_ be ? Get(_array_, ! ToString(_k_)).
@@ -275,7 +265,6 @@
       <emu-note>
         The `toLocaleString` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.
       </emu-note>
-
     </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -9,7 +9,7 @@
     </p>
 
     <emu-clause id="sec-apply-options-to-tag" aoid=ApplyOptionsToTag>
-      <h1>ApplyOptionsToTag( _tag_, _options_ )</h1>
+      <h1>ApplyOptionsToTag ( _tag_, _options_ )</h1>
       <p>
         The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
       </p>
@@ -48,7 +48,7 @@
     </emu-clause>
 
     <emu-clause id="sec-apply-unicode-extension-to-tag" aoid=ApplyUnicodeExtensionToTag>
-      <h1>ApplyUnicodeExtensionToTag( _tag_, _options_, _relevantExtensionKeys_ )</h1>
+      <h1>ApplyUnicodeExtensionToTag ( _tag_, _options_, _relevantExtensionKeys_ )</h1>
       <p>
         The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
       </p>
@@ -65,12 +65,12 @@
           1. Let _attributes_ be the empty List.
           1. Let _keywords_ be the empty List.
         1. Let _result_ be a new Record.
-        1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
+        1. For each element _key_ of _relevantExtensionKeys_ in List order, do
           1. Let _value_ be *undefined*.
           1. If _keywords_ contains an element whose [[Key]] is the same as _key_, then
             1. Let _entry_ be the element of _keywords_ whose [[Key]] is the same as _key_.
             1. Let _value_ be _entry_.[[Value]].
-          1. Else
+          1. Else,
             1. Let _entry_ be ~empty~.
           1. Assert: _options_ has a field [[<_key_>]].
           1. Let _optionsValue_ be _options_.[[<_key_>]].
@@ -92,11 +92,10 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.Locale">
-      <h1>Intl.Locale( _tag_ [, _options_] )</h1>
+      <h1>Intl.Locale ( _tag_ [ , _options_ ] )</h1>
 
       <p>
         The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
-
         When the *Intl.Locale* function is called with an argument _tag_ and an optional argument _options_, the following steps are taken:
       </p>
 
@@ -116,7 +115,7 @@
           1. Let _tag_ be ? ToString(_tag_).
         1. If _options_ is *undefined*, then
           1. Let _options_ be ! ObjectCreate(*null*).
-        1. Else
+        1. Else,
           1. Let _options_ be ? ToObject(_options_).
         1. Set _tag_ to ? ApplyOptionsToTag(_tag_, _options_).
         1. Let _opt_ be a new Record.
@@ -212,7 +211,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.Locale.prototype.maximize">
-      <h1>Intl.Locale.prototype.maximize ()</h1>
+      <h1>Intl.Locale.prototype.maximize ( )</h1>
 
       <emu-alg>
       1. Let _loc_ be the *this* value.
@@ -223,7 +222,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.Locale.prototype.minimize">
-      <h1>Intl.Locale.prototype.minimize ()</h1>
+      <h1>Intl.Locale.prototype.minimize ( )</h1>
 
       <emu-alg>
       1. Let _loc_ be the *this* value.
@@ -234,7 +233,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.Locale.prototype.toString">
-      <h1>Intl.Locale.prototype.toString ()</h1>
+      <h1>Intl.Locale.prototype.toString ( )</h1>
 
       <emu-alg>
       1. Let _loc_ be the *this* value.
@@ -251,6 +250,7 @@
         1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
         1. Let _locale_ be _loc_.[[Locale]].
         1. Return the substring of _locale_ corresponding to the `unicode_language_id` production.
+      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-Intl.Locale.prototype.calendar">

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -12,9 +12,9 @@
       The String values used to identify locales, currencies, and time zones are interpreted in a case-insensitive manner, treating the Unicode Basic Latin characters *"A"* to *"Z"* (U+0041 to U+005A) as equivalent to the corresponding Basic Latin characters *"a"* to *"z"* (U+0061 to U+007A). No other case folding equivalences are applied. When mapping to upper case, a mapping shall be used that maps characters in the range *"a"* to *"z"* (U+0061 to U+007A) to the corresponding characters in the range *"A"* to *"Z"* (U+0041 to U+005A) and maps no other characters to the latter range.
     </p>
 
-    <p>
-      EXAMPLES *"ß"* (U+00DF) must not match or be mapped to *"SS"* (U+0053, U+0053). *"ı"* (U+0131) must not match or be mapped to *"I"* (U+0049).
-    </p>
+    <emu-note>
+      For example, *"ß"* (U+00DF) must not match or be mapped to *"SS"* (U+0053, U+0053). *"ı"* (U+0131) must not match or be mapped to *"I"* (U+0049).
+    </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-language-tags">
@@ -63,8 +63,10 @@
       </p>
 
       <emu-alg>
-        1. Let _localeId_ be the string _locale_ after performing the algorithm to transform it to canonical syntax per <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>.  (The result is a Unicode BCP 47 locale identifier, in canonical syntax but not necessarily in canonical form.)
-        1. Let _localeId_ be the string _localeId_ after performing the algorithm to <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">transform it to canonical form</a>.  (The result is a Unicode BCP 47 locale identifier, in both canonical syntax and canonical form.)
+        1. Let _localeId_ be the string _locale_ after performing the algorithm to transform it to canonical syntax per <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>.
+          (The result is a Unicode BCP 47 locale identifier, in canonical syntax but not necessarily in canonical form.)
+        1. Let _localeId_ be the string _localeId_ after performing the algorithm to <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">transform it to canonical form</a>.
+          (The result is a Unicode BCP 47 locale identifier, in both canonical syntax and canonical form.)
         1. If _localeId_ contains a substring _extension_ that is a Unicode locale extension sequence, then
           1. Let _components_ be ! UnicodeExtensionComponents(_extension_).
           1. Let _attributes_ be _components_.[[Attributes]].
@@ -86,7 +88,6 @@
 
       <emu-note>
         The third step of this algorithm ensures that a Unicode locale extension sequence in the returned language tag contains:
-
         <ul>
           <li>only the first instance of any attribute duplicated in the input, and</li>
           <li>only the first keyword for a given key in the input.</li>
@@ -95,13 +96,12 @@
     </emu-clause>
 
     <emu-clause id="sec-defaultlocale" aoid="DefaultLocale">
-      <h1>DefaultLocale ()</h1>
+      <h1>DefaultLocale ( )</h1>
 
       <p>
         The DefaultLocale abstract operation returns a String value representing the structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizeunicodelocaleid"></emu-xref>) Unicode BCP 47 locale identifier for the host environment's current locale.
       </p>
     </emu-clause>
-
   </emu-clause>
 
   <emu-clause id="sec-currency-codes">
@@ -129,7 +129,6 @@
         1. Return *true*.
       </emu-alg>
     </emu-clause>
-
   </emu-clause>
 
   <emu-clause id="sec-time-zone-names">
@@ -162,7 +161,7 @@
       </p>
 
       <emu-alg>
-        1. Let _ianaTimeZone_ be the Zone or Link name of the IANA Time Zone Database such that _timeZone_, converted to  upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>, is equal to _ianaTimeZone_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
+        1. Let _ianaTimeZone_ be the Zone or Link name of the IANA Time Zone Database such that _timeZone_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>, is equal to _ianaTimeZone_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
         1. If _ianaTimeZone_ is a Link name, let _ianaTimeZone_ be the corresponding Zone name as specified in the *"backward"* file of the IANA Time Zone Database.
         1. If _ianaTimeZone_ is *"Etc/UTC"* or *"Etc/GMT"*, return *"UTC"*.
         1. Return _ianaTimeZone_.
@@ -174,13 +173,12 @@
     </emu-clause>
 
     <emu-clause id="sec-defaulttimezone" aoid="DefaultTimeZone">
-      <h1>DefaultTimeZone ()</h1>
+      <h1>DefaultTimeZone ( )</h1>
 
       <p>
         The DefaultTimeZone abstract operation returns a String value representing the valid (<emu-xref href="#sec-isvalidtimezonename"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizetimezonename"></emu-xref>) time zone name for the host environment's current time zone.
       </p>
     </emu-clause>
-
   </emu-clause>
 
   <emu-clause id="sec-measurement-unit-identifiers">
@@ -191,7 +189,8 @@
     </p>
 
     <p>
-      Only a limited set of core unit identifiers are allowed.  An illegal core unit identifier results in a RangeError.
+      Only a limited set of core unit identifiers are allowed.
+      An illegal core unit identifier results in a RangeError.
     </p>
 
     <emu-clause id="sec-iswellformedunitidentifier" aoid="IsWellFormedUnitIdentifier">
@@ -283,5 +282,4 @@
       </emu-table>
     </emu-clause>
   </emu-clause>
-
 </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -18,9 +18,11 @@
       <li>[[SortLocaleData]] and [[SearchLocaleData]] (for Intl.Collator) and [[LocaleData]] (for Intl.NumberFormat, Intl.DateTimeFormat, Intl.PluralRules, and Intl.RelativeTimeFormat) are records that have fields for each locale contained in [[AvailableLocales]]. The value of each of these fields must be a record that has fields for each key contained in [[RelevantExtensionKeys]]. The value of each of these fields must be a non-empty list of those values defined in Unicode Technical Standard 35 for the given key that are supported by the implementation for the given locale, with the first element providing the default value.</li>
     </ul>
 
-    <p>
-      EXAMPLE     An implementation of DateTimeFormat might include the language tag *"th"* in its [[AvailableLocales]] internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>) include the key *"ca"* in its [[RelevantExtensionKeys]] internal slot. For Thai, the *"buddhist"* calendar is usually the default, but an implementation might also support the calendars *"gregory"*, *"chinese"*, and *"islamicc"* for the locale *"th"*. The [[LocaleData]] internal slot would therefore at least include {[[th]]: {[[ca]]: &laquo; *"buddhist"*, *"gregory"*, *"chinese"*, *"islamicc"* &raquo;}}.
-    </p>
+    <emu-note>
+      For example, an implementation of DateTimeFormat might include the language tag *"th"* in its [[AvailableLocales]] internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>) include the key *"ca"* in its [[RelevantExtensionKeys]] internal slot.
+      For Thai, the *"buddhist"* calendar is usually the default, but an implementation might also support the calendars *"gregory"*, *"chinese"*, and *"islamicc"* for the locale *"th"*.
+      The [[LocaleData]] internal slot would therefore at least include {[[th]]: {[[ca]]: &laquo; *"buddhist"*, *"gregory"*, *"chinese"*, *"islamicc"* &raquo;}}.
+    </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-abstract-operations">
@@ -47,7 +49,7 @@
           1. Let _O_ be ? ToObject(_locales_).
         1. Let _len_ be ? ToLength(? Get(_O_, *"length"*)).
         1. Let _k_ be 0.
-        1. Repeat, while _k_ < _len_
+        1. Repeat, while _k_ < _len_,
           1. Let _Pk_ be ToString(_k_).
           1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
           1. If _kPresent_ is *true*, then
@@ -127,7 +129,7 @@
     </emu-clause>
 
     <emu-clause id="sec-unicode-extension-components" aoid=UnicodeExtensionComponents>
-      <h1>UnicodeExtensionComponents( _extension_ )</h1>
+      <h1>UnicodeExtensionComponents ( _extension_ )</h1>
       <p>
         The UnicodeExtensionComponents abstract operation returns the attributes and keywords from _extension_, which must be a Unicode locale extension sequence. If an attribute or a keyword occurs multiple times in _extension_, only the first occurence is returned. The following steps are taken:
       </p>
@@ -138,7 +140,7 @@
         1. Let _isKeyword_ be *false*.
         1. Let _size_ be the number of elements in _extension_.
         1. Let _k_ be 3.
-        1. Repeat, while _k_ &lt; _size_
+        1. Repeat, while _k_ &lt; _size_,
           1. Let _e_ be ! Call(%String.prototype.indexOf%, _extension_, « *"-"*, _k_ »).
           1. If _e_ = -1, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
           1. Let _subtag_ be the String value equal to the substring of _extension_ consisting of the code units at indices _k_ (inclusive) through _k_ + _len_ (exclusive).
@@ -166,7 +168,7 @@
     </emu-clause>
 
     <emu-clause id="sec-insert-unicode-extension-and-canonicalize" aoid=InsertUnicodeExtensionAndCanonicalize>
-      <h1>InsertUnicodeExtensionAndCanonicalize( _locale_, _extension_ )</h1>
+      <h1>InsertUnicodeExtensionAndCanonicalize ( _locale_, _extension_ )</h1>
       <p>
         The InsertUnicodeExtensionAndCanonicalize abstract operation inserts _extension_, which must be a Unicode locale extension sequence, into _locale_, which must be a String value with a structurally valid and canonicalized Unicode BCP 47 locale identifier. The following steps are taken:
       </p>
@@ -371,7 +373,7 @@
         1. Let _endIndex_ be 0.
         1. Let _nextIndex_ be 0.
         1. Let _length_ be the number of code units in _pattern_.
-        1. Repeat, while _beginIndex_ is an integer index into _pattern_
+        1. Repeat, while _beginIndex_ is an integer index into _pattern_,
           1. Set _endIndex_ to ! Call(%String.prototype.indexOf%, _pattern_, &laquo; *"}"*, _beginIndex_ &raquo;).
           1. Assert: _endIndex_ is greater than _beginIndex_.
           1. If _beginIndex_ is greater than _nextIndex_, then
@@ -387,6 +389,5 @@
         1. Return _result_.
       </emu-alg>
     </emu-clause>
-
   </emu-clause>
 </emu-clause>

--- a/spec/normative-references.html
+++ b/spec/normative-references.html
@@ -46,5 +46,4 @@
       </ul>
     </li>
   </ul>
-
 </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -184,7 +184,7 @@
           1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_).
           1. Let _n_ be _formatNumberResult_.[[FormattedString]].
           1. Let _x_ be _formatNumberResult_.[[RoundedNumber]].
-        1. Let _pattern_ be GetNumberFormatPattern(_numberFormat_, _x_)
+        1. Let _pattern_ be GetNumberFormatPattern(_numberFormat_, _x_).
         1. Let _result_ be a new empty List.
         1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. For each element _patternPart_ of _patternParts_, in List order, do
@@ -246,7 +246,7 @@
         1. Else if _x_ is a non-finite Number, then
           1. Append a new Record { [[Type]]: *"infinity"*, [[Value]]: _n_ } as the last element of _result_.
         1. Else,
-          1. Let _notationSubPattern_ be GetNotationSubPattern(_numberFormat_, _exponent_)
+          1. Let _notationSubPattern_ be GetNotationSubPattern(_numberFormat_, _exponent_).
           1. Let _patternParts_ be PartitionPattern(_notationSubPattern_).
           1. For each element _patternPart_ of _patternParts_, in List order, do
             1. Let _p_ be _patternPart_.[[Type]].
@@ -268,7 +268,7 @@
                 1. Let _groupSepSymbol_ be the implementation-, locale-, and numbering system-dependent (ILND) String representing the grouping separator.
                 1. Let _groups_ be a List whose elements are, in left to right order, the substrings defined by ILND set of locations within the _integer_.
                 1. Assert: The number of elements in _groups_ List is greater than 0.
-                1. Repeat, while _groups_ List is not empty
+                1. Repeat, while _groups_ List is not empty,
                   1. Remove the first element from _groups_ and let _integerGroup_ be the value of that element.
                   1. Append a new Record { [[Type]]: *"integer"*, [[Value]]: _integerGroup_ } as the last element of _result_.
                   1. If _groups_ List is not empty, then
@@ -587,7 +587,7 @@
     </emu-clause>
 
     <emu-clause id="sec-formatnumber" aoid="FormatNumeric">
-      <h1>FormatNumeric( _numberFormat_, _x_ )</h1>
+      <h1>FormatNumeric ( _numberFormat_, _x_ )</h1>
 
       <p>
         The FormatNumeric abstract operation is called with arguments _numberFormat_ (which must be an object initialized as a NumberFormat) and _x_ (which must be a Number or BigInt value), and performs the following steps:
@@ -596,14 +596,14 @@
       <emu-alg>
         1. Let _parts_ be ? PartitionNumberPattern(_numberFormat_, _x_).
         1. Let _result_ be the empty String.
-        1. For each _part_ in _parts_, do
+        1. For each Record _part_ in _parts_, do
           1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
         1. Return _result_.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-formatnumbertoparts" aoid="FormatNumericToParts">
-      <h1>FormatNumericToParts( _numberFormat_, _x_ )</h1>
+      <h1>FormatNumericToParts ( _numberFormat_, _x_ )</h1>
 
       <p>
         The FormatNumericToParts abstract operation is called with arguments _numberFormat_ (which must be an object initialized as a NumberFormat) and _x_ (which must be a Number or BigInt value), and performs the following steps:
@@ -613,7 +613,7 @@
         1. Let _parts_ be ? PartitionNumberPattern(_numberFormat_, _x_).
         1. Let _result_ be ArrayCreate(0).
         1. Let _n_ be 0.
-        1. For each _part_ in _parts_, do
+        1. For each Record _part_ in _parts_, do
           1. Let _O_ be ObjectCreate(%Object.prototype%).
           1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
           1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
@@ -624,7 +624,7 @@
     </emu-clause>
 
     <emu-clause id="sec-torawprecision" aoid="ToRawPrecision">
-      <h1>ToRawPrecision( _x_, _minPrecision_, _maxPrecision_ )</h1>
+      <h1>ToRawPrecision ( _x_, _minPrecision_, _maxPrecision_ )</h1>
 
       <p>
         When the ToRawPrecision abstract operation is called with arguments _x_ (which must be a finite non-negative Number or BigInt), _minPrecision_, and _maxPrecision_ (both must be integers between 1 and 21), the following steps are taken:
@@ -653,7 +653,7 @@
           1. Let _int_ be 1.
         1. If _m_ contains the character *"."*, and _maxPrecision_ > _minPrecision_, then
           1. Let _cut_ be _maxPrecision_ – _minPrecision_.
-          1. Repeat, while _cut_ > 0 and the last character of _m_ is *"0"*
+          1. Repeat, while _cut_ > 0 and the last character of _m_ is *"0"*,
             1. Remove the last character from _m_.
             1. Decrease _cut_ by 1.
           1. If the last character of _m_ is *"."*, then
@@ -663,7 +663,7 @@
     </emu-clause>
 
     <emu-clause id="sec-torawfixed" aoid="ToRawFixed">
-      <h1>ToRawFixed( _x_, _minInteger_, _minFraction_, _maxFraction_ )</h1>
+      <h1>ToRawFixed ( _x_, _minInteger_, _minFraction_, _maxFraction_ )</h1>
 
       <p>
         When the ToRawFixed abstract operation is called with arguments _x_ (which must be a finite non-negative Number or BigInt), _minInteger_ (which must be an integer between 1 and 21), _minFraction_, and _maxFraction_ (which must be integers between 0 and 20), the following steps are taken:
@@ -685,7 +685,7 @@
           1. Let _int_ be the number of characters in _a_.
         1. Else, let _int_ be the number of characters in _m_.
         1. Let _cut_ be _maxFraction_ – _minFraction_.
-        1. Repeat, while _cut_ > 0 and the last character of _m_ is *"0"*
+        1. Repeat, while _cut_ > 0 and the last character of _m_ is *"0"*,
           1. Remove the last character from _m_.
           1. Decrease _cut_ by 1.
         1. If the last character of _m_ is *"."*, then
@@ -695,7 +695,7 @@
     </emu-clause>
 
     <emu-clause id="sec-unwrapnumberformat" aoid="UnwrapNumberFormat">
-      <h1>UnwrapNumberFormat( _nf_ )</h1>
+      <h1>UnwrapNumberFormat ( _nf_ )</h1>
       <p>
         The UnwrapNumberFormat abstract operation gets the underlying NumberFormat operation
         for various methods which implement ECMA-402 v1 semantics for supporting initializing
@@ -705,11 +705,13 @@
         1. Assert: Type(_nf_) is Object.
       </emu-alg>
       <emu-normative-optional>
+      <!-- Note: 2. is intentional -->
       <emu-alg>
         2. If _nf_ does not have an [[InitializedNumberFormat]] internal slot and ? InstanceofOperator(_nf_, %NumberFormat%) is *true*, then
           1. Let _nf_ be ? Get(_nf_, %Intl%.[[FallbackSymbol]]).
       </emu-alg>
       </emu-normative-optional>
+      <!-- Note: 3. is intentional -->
       <emu-alg>
         3. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
         1. Return _nf_.
@@ -838,7 +840,8 @@
     <emu-clause id="sec-computeexponent" aoid="ComputeExponent">
       <h1>ComputeExponent ( _numberFormat_, _x_ )</h1>
       <p>
-        The abstract operation ComputeExponent computes an exponent (power of ten) by which to scale _x_ according to the number formatting settings.  It handles cases such as 999 rounding up to 1000, requiring a different exponent.
+        The abstract operation ComputeExponent computes an exponent (power of ten) by which to scale _x_ according to the number formatting settings.
+        It handles cases such as 999 rounding up to 1000, requiring a different exponent.
       </p>
       <emu-alg>
         1. If _x_ = 0, then
@@ -900,6 +903,7 @@
         1. Perform ? InitializeNumberFormat(_numberFormat_, _locales_, _options_).
       </emu-alg>
       <emu-normative-optional>
+      <!-- Note: 4. is intentional -->
       <emu-alg>
         4. Let _this_ be the *this* value.
         1. If NewTarget is *undefined* and Type(_this_) is Object and ? InstanceofOperator(_this_, %NumberFormat%) is *true*, then
@@ -907,6 +911,7 @@
           1. Return _this_.
       </emu-alg>
       </emu-normative-optional>
+      <!-- Note: 6. is intentional -->
       <emu-alg>
         6. Return _numberFormat_.
       </emu-alg>
@@ -972,9 +977,20 @@
       <ul>
         <li>The list that is the value of the *"nu"* field of any locale field of [[LocaleData]] must not include the values *"native"*, *"traditio"*, or *"finance"*.</li>
         <li>[[LocaleData]].[[&lt;_locale_&gt;]] must have a [[patterns]] field for all locale values _locale_. The value of this field must be a Record, which must have fields with the names of the four number format styles: *"decimal"*, *"percent"*, *"currency"*, and *"unit"*.</li>
-        <li>The two fields *"currency"* and *"unit"* noted above must be Records with at least one field, *"fallback"*. The *"currency"* may have additional fields with keys corresponding to currency codes according to <emu-xref href="#sec-currency-codes"></emu-xref>.  Each field of *"currency"* must be a Record with fields corresponding to the possible currencyDisplay values: *"code"*, *"symbol"*, *"narrowSymbol"*, and *"name"*.  Each of those fields must contain a Record with fields corresponding to the possible currencySign values: *"standard"* or *"accounting"*. The *"unit"* field (of [[LocaleData]].[[&lt;_locale_&gt;]]) may have additional fields beyond the required field *"fallback"* with keys corresponding to core measurement unit identifiers corresponding to <emu-xref href="#sec-measurement-unit-identifiers"></emu-xref>.  Each field of *"unit"* must be a Record with fields corresponding to the possible unitDisplay values: *"narrow"*, *"short"*, and *"long"*.</li>
+        <li>
+          The two fields *"currency"* and *"unit"* noted above must be Records with at least one field, *"fallback"*.
+          The *"currency"* may have additional fields with keys corresponding to currency codes according to <emu-xref href="#sec-currency-codes"></emu-xref>.
+          Each field of *"currency"* must be a Record with fields corresponding to the possible currencyDisplay values: *"code"*, *"symbol"*, *"narrowSymbol"*, and *"name"*.
+          Each of those fields must contain a Record with fields corresponding to the possible currencySign values: *"standard"* or *"accounting"*. The *"unit"* field (of [[LocaleData]].[[&lt;_locale_&gt;]]) may have additional fields beyond the required field *"fallback"* with keys corresponding to core measurement unit identifiers corresponding to <emu-xref href="#sec-measurement-unit-identifiers"></emu-xref>.
+          Each field of *"unit"* must be a Record with fields corresponding to the possible unitDisplay values: *"narrow"*, *"short"*, and *"long"*.
+        </li>
         <li>All of the leaf fields so far described for the patterns tree (*"decimal"*, *"percent"*, great-grandchildren of *"currency"*, and grandchildren of *"unit"*) must be Records with the keys *"positivePattern"*, *"zeroPattern"*, and *"negativePattern"*.</li>
-        <li>The value of the aforementioned fields (the sign-dependent pattern fields) must be string values that must contain the substring *"{number}"*.  *"positivePattern"* must contain the substring *"{plusSign}"* but not *"{minusSign}"*; *"negativePattern"* must contain the substring *"{minusSign}"* but not *"{plusSign}"*; and *"zeroPattern"* must not contain either *"{plusSign}"* or *"{minusSign}"*.  Additionally, the values within the *"percent"* field must also contain the substring *"{percentSign}"*; the values within the *"currency"* field must also contain one or more of the following substrings: *"{currencyCode}"*, *"{currencyPrefix}"*, or *"{currencySuffix}"*; and the values within the *"unit"* field must also contain one or more of the following substrings: *"{unitPrefix}"* or *"{unitSuffix}"*. The pattern strings must not contain any characters in the General Category "Number, decimal digit" as specified by the Unicode Standard.</li>
+        <li>
+          The value of the aforementioned fields (the sign-dependent pattern fields) must be string values that must contain the substring *"{number}"*.
+          *"positivePattern"* must contain the substring *"{plusSign}"* but not *"{minusSign}"*; *"negativePattern"* must contain the substring *"{minusSign}"* but not *"{plusSign}"*; and *"zeroPattern"* must not contain either *"{plusSign}"* or *"{minusSign}"*.
+          Additionally, the values within the *"percent"* field must also contain the substring *"{percentSign}"*; the values within the *"currency"* field must also contain one or more of the following substrings: *"{currencyCode}"*, *"{currencyPrefix}"*, or *"{currencySuffix}"*; and the values within the *"unit"* field must also contain one or more of the following substrings: *"{unitPrefix}"* or *"{unitSuffix}"*.
+          The pattern strings must not contain any characters in the General Category "Number, decimal digit" as specified by the Unicode Standard.
+        </li>
         <li>[[LocaleData]].[[&lt;_locale_&gt;]] must also have a [[notationSubPatterns]] field for all locale values _locale_. The value of this field must be a Record, which must have two fields: [[scientific]] and [[compact]]. The [[scientific]] field must be a string value containing the substrings *"{number}"*, *"{scientificSeparator}"*, and *"{scientificExponent}"*. The [[compact]] field must be a Record with two fields: *"short"* and *"long"*. Each of these fields must be a Record with integer keys corresponding to all discrete magnitudes the implementation supports for compact notation. Each of these fields must be a string value which may contain the substring *"{number}"*. Strings descended from *"short"* must contain the substring *"{compactSymbol}"*, and strings descended from *"long"* must contain the substring *"{compactName}"*.</li>
       </ul>
 
@@ -1050,7 +1066,7 @@
     </emu-clause>
 
     <emu-clause id="sec-intl.numberformat.prototype.resolvedoptions">
-      <h1>Intl.NumberFormat.prototype.resolvedOptions ()</h1>
+      <h1>Intl.NumberFormat.prototype.resolvedOptions ( )</h1>
 
       <p>
         This function provides access to the locale and formatting options computed during initialization of the object.
@@ -1181,9 +1197,12 @@
       <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be shown. If present, the formatter uses however many fraction digits are required to display the specified number of significant digits. These properties are only used when [[RoundingType]] is ~significantDigits~.</li>
       <li>[[UseGrouping]] is a Boolean value indicating whether a grouping separator should be used.</li>
       <li>[[RoundingType]] is one of the values ~fractionDigits~, ~significantDigits~, or ~compactRounding~, indicating which rounding strategy to use. If ~fractionDigits~, the number is rounded according to [[MinimumFractionDigits]] and [[MaximumFractionDigits]], as described above. If ~significantDigits~, the number is rounded according to [[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] as described above. If ~compactRounding~, the number is rounded to 1 maximum fraction digit if there is 1 digit before the decimal separator, and otherwise round to 0 fraction digits.</li>
-      <li>[[Notation]]  is one of the String values *"standard"*, *"scientific"*, *"engineering"*, or *"compact"*, specifying whether the number should be displayed without scaling, scaled to the units place with the power of ten in scientific notation, scaled to the nearest thousand with the power of ten in scientific notation, or scaled to the nearest locale-dependent compact decimal notation power of ten with the corresponding compact decimal notation affix.</li>
+      <li>[[Notation]] is one of the String values *"standard"*, *"scientific"*, *"engineering"*, or *"compact"*, specifying whether the number should be displayed without scaling, scaled to the units place with the power of ten in scientific notation, scaled to the nearest thousand with the power of ten in scientific notation, or scaled to the nearest locale-dependent compact decimal notation power of ten with the corresponding compact decimal notation affix.</li>
       <li>[[CompactDisplay]] is one of the String values *"short"* or *"long"*, specifying whether to display compact notation affixes in short form ("5K") or long form ("5 thousand") if formatting with the *"compact"* notation. It is only used when [[Notation]] has the value *"compact"*.</li>
-      <li>[[SignDisplay]] is one of the String values *"auto"*, *"always"*, *"never"*, or *"exceptZero"*, specifying whether to show the sign on negative numbers only, positive and negative numbers including zero, neither positive nor negative numbers, or positive and negative numbers but not zero.  In scientific notation, this slot affects the sign display of the mantissa but not the exponent.</li>
+      <li>
+        [[SignDisplay]] is one of the String values *"auto"*, *"always"*, *"never"*, or *"exceptZero"*, specifying whether to show the sign on negative numbers only, positive and negative numbers including zero, neither positive nor negative numbers, or positive and negative numbers but not zero.
+        In scientific notation, this slot affects the sign display of the mantissa but not the exponent.
+      </li>
     </ul>
 
     <p>

--- a/spec/overview.html
+++ b/spec/overview.html
@@ -28,7 +28,6 @@
 
     <p>
       Applications can use the API in two ways:
-
       <ol>
         <li>
           Directly, by using the constructors Intl.Collator, Intl.NumberFormat, Intl.DateTimeFormat, or Intl.PluralRules to construct an object, specifying a list of preferred languages and options to configure the behaviour of the resulting object. The object then provides a main function (compare, select, or format), which can be called repeatedly. It also provides a resolvedOptions function, which the application can use to find out the exact configuration of the object.
@@ -59,7 +58,6 @@
 
     <p>
       Due to the nature of internationalization, the API specification has to leave several details implementation dependent:
-
       <ul>
         <li>
           <em>The set of locales that an implementation supports with adequate localizations:</em> Linguists estimate the number of human languages to around 6000, and the more widely spoken ones have variations based on regions or other parameters. Even large locale data collections, such as the Common Locale Data Repository, cover only a subset of this large set. Implementations targeting resource-constrained devices may have to further reduce the subset.
@@ -89,5 +87,4 @@
       </p>
     </emu-clause>
   </emu-clause>
-
 </emu-clause>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -15,20 +15,19 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
           1. Let _options_ be ObjectCreate(*null*).
-        1. Else
+        1. Else,
           1. Let _options_ be ? ToObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _t_ be ? GetOption(_options_, *"type"*, *"string"*, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
-        1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, *0*, *3*, *"standard"*).
+        1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, *+0*, *3*, *"standard"*).
         1. Let _localeData_ be %PluralRules%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %PluralRules%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _pluralRules_.[[Locale]] to the value of _r_.[[locale]].
         1. Return _pluralRules_.
       </emu-alg>
-
     </emu-clause>
 
     <emu-clause id="sec-getoperands" aoid="GetOperands">
@@ -104,17 +103,14 @@
            </tr>
          </table>
        </emu-table>
-
     </emu-clause>
 
     <emu-clause id="sec-pluralruleselect" aoid="PluralRuleSelect">
-
       <h1>PluralRuleSelect ( _locale_, _type_, _n_, _operands_ )</h1>
 
       <p>
         When the PluralRuleSelect abstract operation is called with four arguments, it performs an implementation-dependent algorithm to map _n_ to the appropriate plural representation of the Plural Rules Operands Record _operands_ by selecting the rules denoted by _type_ for the corresponding _locale_, or the String value *"other"*.
       </p>
-
     </emu-clause>
 
     <emu-clause id="sec-resolveplural" aoid="ResolvePlural">
@@ -136,9 +132,7 @@
         1. Let _operands_ be ? GetOperands(_s_).
         1. Return ? PluralRuleSelect(_locale_, _type_, _n_, _operands_).
       </emu-alg>
-
     </emu-clause>
-
   </emu-clause>
 
   <emu-clause id="sec-intl-pluralrules-constructor">
@@ -182,7 +176,7 @@
     </emu-clause>
 
     <emu-clause id="sec-intl.pluralrules.supportedlocalesof">
-      <h1>Intl.PluralRules.supportedLocalesOf ( _locales_ [, _options_ ] )</h1>
+      <h1>Intl.PluralRules.supportedLocalesOf ( _locales_ [ , _options_ ] )</h1>
 
       <p>
         When the `supportedLocalesOf` method is called with arguments _locales_ and _options_, the following steps are taken:
@@ -221,7 +215,6 @@
       <emu-note>
         It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>).
       </emu-note>
-
     </emu-clause>
   </emu-clause>
 
@@ -252,7 +245,7 @@
     </emu-clause>
 
     <emu-clause id="sec-intl.pluralrules.prototype.select">
-      <h1>Intl.PluralRules.prototype.select( _value_ )</h1>
+      <h1>Intl.PluralRules.prototype.select ( _value_ )</h1>
 
       <p>
         When the `select` method is called with an argument _value_, the following steps are taken:
@@ -267,7 +260,7 @@
     </emu-clause>
 
     <emu-clause id="sec-intl.pluralrules.prototype.resolvedoptions">
-      <h1>Intl.PluralRules.prototype.resolvedOptions ()</h1>
+      <h1>Intl.PluralRules.prototype.resolvedOptions ( )</h1>
 
       <p>
         This function provides access to the locale and options computed during initialization of the object.
@@ -352,6 +345,5 @@
       <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be used. Either none or both of these properties are present; if they are, they override minimum and maximum integer and fraction digits.</li>
       <li>[[RoundingType]] is one of the values ~fractionDigits~ or ~significantDigits~, indicating which rounding strategy to use, as discussed in <emu-xref href="#sec-properties-of-intl-numberformat-instances"></emu-xref>.</li>
     </ul>
-
   </emu-clause>
 </emu-clause>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -4,7 +4,6 @@
   <emu-clause id="sec-intl-relativetimeformat--abstracts">
     <h1>Abstract Operations for RelativeTimeFormat Objects</h1>
 
-
     <emu-clause id="sec-InitializeRelativeTimeFormat" aoid="InitializeRelativeTimeFormat">
       <h1>InitializeRelativeTimeFormat ( _relativeTimeFormat_, _locales_, _options_ )</h1>
 
@@ -13,7 +12,6 @@
       </p>
       <p>
         The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
-
         The following steps are taken:
       </p>
 
@@ -136,7 +134,7 @@
             1. Append Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
           1. Else,
             1. Assert: _patternPart_.[[Type]] is *"0"*.
-            1. For each _part_ in _parts_, do
+            1. For each Record _part_ in _parts_, do
               1. Append Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: _unit_ } to _result_.
         1. Return _result_.
       </emu-alg>
@@ -152,7 +150,7 @@
       <emu-alg>
         1. Let _parts_ be ? PartitionRelativeTimePattern(_relativeTimeFormat_, _value_, _unit_).
         1. Let _result_ be an empty String.
-        1. For each _part_ in _parts_, do
+        1. For each Record _part_ in _parts_, do
           1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
         1. Return _result_.
       </emu-alg>
@@ -169,11 +167,11 @@
         1. Let _parts_ be ? PartitionRelativeTimePattern(_relativeTimeFormat_, _value_, _unit_).
         1. Let _result_ be ArrayCreate(0).
         1. Let _n_ be 0.
-        1. For each _part_ in _parts_, do
+        1. For each Record _part_ in _parts_, do
           1. Let _O_ be ObjectCreate(%Object.prototype%).
           1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
           1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
-          1. If _part_ has a [[Unit]] field,
+          1. If _part_ has a [[Unit]] field, then
             1. Perform ! CreateDataPropertyOrThrow(_O_, *"unit"*, _part_.[[Unit]]).
           1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(_n_), _O_).
           1. Increment _n_ by 1.
@@ -190,7 +188,7 @@
     </p>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat">
-      <h1>Intl.RelativeTimeFormat ([ _locales_ [ , _options_ ]])</h1>
+      <h1>Intl.RelativeTimeFormat ( [ _locales_ [ , _options_ ] ] )</h1>
 
       <p>
         When the *Intl.RelativeTimeFormat* function is called with optional arguments the following steps are taken:
@@ -223,7 +221,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat.supportedLocalesOf">
-      <h1>Intl.RelativeTimeFormat.supportedLocalesOf ( _locales_ [, _options_ ])</h1>
+      <h1>Intl.RelativeTimeFormat.supportedLocalesOf ( _locales_ [ , _options_ ] )</h1>
 
       <p>
         When the `supportedLocalesOf` method of %RelativeTimeFormat% is called, the following steps are taken:
@@ -304,7 +302,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat.prototype.format">
-      <h1>Intl.RelativeTimeFormat.prototype.format( _value_, _unit_ )</h1>
+      <h1>Intl.RelativeTimeFormat.prototype.format ( _value_, _unit_ )</h1>
 
       <p>
         When the `format` method is called with arguments _value_ and _unit_, the following steps are taken:
@@ -320,7 +318,7 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat.prototype.formatToParts">
-      <h1>Intl.RelativeTimeFormat.prototype.formatToParts( _value_, _unit_ )</h1>
+      <h1>Intl.RelativeTimeFormat.prototype.formatToParts ( _value_, _unit_ )</h1>
 
       <p>
         When the `formatToParts` method is called with arguments _value_ and _unit_, the following steps are taken:
@@ -336,7 +334,7 @@
     </emu-clause>
 
     <emu-clause id="sec-intl.relativetimeformat.prototype.resolvedoptions">
-      <h1>Intl.RelativeTimeFormat.prototype.resolvedOptions ()</h1>
+      <h1>Intl.RelativeTimeFormat.prototype.resolvedOptions ( )</h1>
 
       <p>
         This function provides access to the locale and options computed during initialization of the object.

--- a/spec/scope.html
+++ b/spec/scope.html
@@ -3,5 +3,4 @@
   <p>
     This Standard defines the application programming interface for ECMAScript objects that support programs that need to adapt to the linguistic and cultural conventions used by different human languages and countries.
   </p>
-
 </emu-clause>


### PR DESCRIPTION
Based on a [discussion in Temporal](https://github.com/tc39/proposal-temporal/pull/870), it seems like it might be a good idea to run ecmarkup's linter on the spec, now that in version 4.1.0 has brought several bug fixes in the linter.

This adds the linter to the build process and makes it fail if any warnings are generated.