### PR TITLE
Normative: Use OrdinaryHasInstance in normative optional steps

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -461,7 +461,7 @@
       </emu-alg>
       <emu-normative-optional>
       <emu-alg>
-        2. If _dtf_ does not have an [[InitializedDateTimeFormat]] internal slot and ? InstanceofOperator(_dtf_, %DateTimeFormat%) is *true*, then
+        2. If _dtf_ does not have an [[InitializedDateTimeFormat]] internal slot and ? OrdinaryHasInstance(%DateTimeFormat%, _dtf_) is *true*, then
           1. Let _dtf_ be ? Get(_dtf_, %Intl%.[[FallbackSymbol]]).
       </emu-alg>
       </emu-normative-optional>
@@ -495,7 +495,7 @@
       <emu-normative-optional>
       <emu-alg>
         4. Let _this_ be the *this* value.
-        1. If NewTarget is *undefined* and Type(_this_) is Object and ? InstanceofOperator(_this_, %DateTimeFormat%) is *true*, then
+        1. If NewTarget is *undefined* and Type(_this_) is Object and ? OrdinaryHasInstance(%DateTimeFormat%, _this_) is *true*, then
           1. Perform ? DefinePropertyOrThrow(_this_, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: _dateTimeFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _this_.
       </emu-alg>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -706,7 +706,7 @@
       </emu-alg>
       <emu-normative-optional>
       <emu-alg>
-        2. If _nf_ does not have an [[InitializedNumberFormat]] internal slot and ? InstanceofOperator(_nf_, %NumberFormat%) is *true*, then
+        2. If _nf_ does not have an [[InitializedNumberFormat]] internal slot and ? OrdinaryHasInstance(%NumberFormat%, _nf_) is *true*, then
           1. Let _nf_ be ? Get(_nf_, %Intl%.[[FallbackSymbol]]).
       </emu-alg>
       </emu-normative-optional>
@@ -902,7 +902,7 @@
       <emu-normative-optional>
       <emu-alg>
         4. Let _this_ be the *this* value.
-        1. If NewTarget is *undefined* and Type(_this_) is Object and ? InstanceofOperator(_this_, %NumberFormat%) is *true*, then
+        1. If NewTarget is *undefined* and Type(_this_) is Object and ? OrdinaryHasInstance(%NumberFormat%, _this_) is *true*, then
           1. Perform ? DefinePropertyOrThrow(_this_, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: _numberFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _this_.
       </emu-alg>


### PR DESCRIPTION
This PR reduces the surface area of [legacy constructor semantics](https://github.com/tc39/ecma402/pull/84) by using [`OrdinaryHasInstance`](https://tc39.es/ecma262/#sec-ordinaryhasinstance) instead of [`instanceof` operator](https://tc39.es/ecma262/#sec-instanceofoperator), which skips `Symbol.hasInstance` lookup/call and a few checks we don't need or already implement.

The change is safe because a) `Symbol.hasInstance` is rarely used and b) the code that depends on [legacy constructor semantics](https://github.com/tc39/ecma402/pull/84) precedes cross-browser `Symbol.hasInstance` implementation.

JSC already implements this change, while V8 and SpiderMonkey perform [`InstanceofOperator`](https://tc39.es/ecma262/#sec-instanceofoperator).

<details>

<summary><code>Intl.NumberFormat</code> test case</summary><br>

```js
const nf = new Intl.NumberFormat();

Object.defineProperty(Intl.NumberFormat, Symbol.hasInstance, {
    get() { throw new Error("Intl.NumberFormat[@@hasInstance] lookup"); }
});

nf.resolvedOptions(); // JSC: OK, V8 & SM: exception
nf.format; // JSC: OK, V8 & SM: exception
Intl.NumberFormat(); // JSC: OK, V8 & SM: exception
```

</details>

<details>

<summary><code>Intl.DateTimeFormat</code> test case</summary><br>

```js
const dtf = new Intl.DateTimeFormat();

Object.defineProperty(Intl.DateTimeFormat, Symbol.hasInstance, {
    get() { throw new Error("Intl.DateTimeFormat[@@hasInstance] lookup"); }
});

dtf.resolvedOptions(); // JSC: OK, V8 & SM: exception
dtf.format; // JSC: OK, V8 & SM: exception
Intl.DateTimeFormat(); // JSC: OK, V8 & SM: exception
```

</details>

_cc_ @littledan @anba @caridy

**EDIT**: Updated test cases with `resolvedOptions` and `format`.