### PR TITLE
Normative: DisplayNames styles and type options as impl. defined

### DIFF
--- a/spec/conformance.html
+++ b/spec/conformance.html
@@ -20,6 +20,7 @@
       <li>The _options_ properties *"minimumIntegerDigits"*, *"minimumFractionDigits"*, *"maximumFractionDigits"*, and *"minimumSignificantDigits"* in the PluralRules constructor, provided that the additional values are interpreted as integer values higher than the specified limits.</li>
       <li>The _options_ property *"type"* in the PluralRules constructor.</li>
       <li>The _options_ property *"style"* and *"numeric"* in the RelativeTimeFormat constructor.</li>
+      <li>The _options_ property *"style"* and *"type"* in the DisplayNames constructor.</li>
     </ul>
   </p>
 </emu-clause>


### PR DESCRIPTION
Closes #521

Technically this is normative, but remains within the consensus from DisplayNames, in my understanding.

cc @FrankYFTang 