### PR TITLE
Meta: Add templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,0 +1,13 @@
+---
+name: "\U0001F41B Bug report"
+about: Report a bug with the specification.
+
+---
+
+<!--
+Thank you for reporting a possible bug in ECMA-402.
+
+If this is a bug with a specific implementation of ECMA-402, such as
+a JavaScript engine or a browser, you might need to report it on their bug
+tracker as well.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+--- 
+blank_issues_enabled: true
+contact_links: 
+  - 
+    about: "See the contributing guidelines for feature requests and proposals"
+    name: "\U0001F680 Feature request"
+    url: "https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md"
+  - 
+    about: "This repository is a TC39 project and subscribes to its code of conduct"
+    name: "\U0001F4AC Code of Conduct"
+    url: "https://tc39.es/code-of-conduct/"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+<!--
+If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:
+
+* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
+* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
+
+Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
+-->


### PR DESCRIPTION
I'd like to open this for discussion.

This ECMA-402 repo has a different aspect compared to 262 as we accept issues with feature suggestions in our issues tracker. I'm adapting the current templates from 262 here and we should eventually add templates for new proposals, ideas, etc.

The PR template has a downstream notice to avoid issues on the spec chaining, I should add ECMA-262 in that list.

I'd like to get an idea of how this group sees the proposed additions. We can merge it if useful.