### PR TITLE
spec: GetOption reform for ECMA 2021

### DIFF
--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -50,7 +50,7 @@
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _displayNames_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%DisplayNames.prototype%"*, &laquo; [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], [[Fields]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Let _options_ be ? ToObject(_options_).
+        1. Let _options_ be ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _localeData_ be %DisplayNames%.[[LocaleData]].
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -173,7 +173,7 @@
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _listFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%ListFormat.prototype%"*, &laquo; [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[Templates]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Let _options_ be GetOptionsObject(*null*).
+        1. Let _options_ be GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -173,10 +173,7 @@
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _listFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%ListFormat.prototype%"*, &laquo; [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[Templates]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. If _options_ is *undefined*, then
-          1. Let _options_ be ObjectCreate(*null*).
-        1. Else,
-          1. Let _options_ be ? ToObject(_options_).
+        1. Let _options_ be GetOptionsObject(*null*).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.


### PR DESCRIPTION
Fix ECMA 2021 additions (Intl.DisplayNames and Intl.ListFormat) to work
with the new, stricter GetOption. This no longer coerces non-null
primitives to objects and instead throws a TypeError.

Fixes: https://github.com/tc39/ecma402/issues/537

/cc @sffc @ptomato 