### PR TITLE
Editorial: Fix spec typos and GH Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: ljharb/actions/node/run@125357c
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
         name: 'npm install && npm run build-master'
         with:
           node-version: lts/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,17 +12,16 @@ jobs:
     if: ${{ github.repository == 'tc39/ecma402' }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: ljharb/actions/node/run@125357c
-        name: 'npm install && npm run build-only ./scripts/auto-deploy.sh'
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+      - name: 'npm install && npm run build-only ./scripts/auto-deploy.sh'
+        uses: ljharb/actions/node/run@main
         with:
           node-version: lts/*
           shell-command: |
             npm run build-only
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@4.0.0
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: out
-          CLEAN: true
+          branch: gh-pages
+          folder: out

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -9,4 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ljharb/require-allow-edits@a200d61
+    - uses: ljharb/require-allow-edits@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -169,7 +169,7 @@
       <emu-xref href="#sec-the-intl-collator-constructor"></emu-xref>, <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref>, <emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref> In ECMA-402, 1st Edition, constructors could be used to create Intl objects from arbitrary objects. This is no longer possible in 2nd Edition.
     </li>
     <li>
-      <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1st Edition, the *"length"* property of the function object _F_ was set to *+0*. In 2nd Edition, *"length"* is set to *1*.
+      <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1st Edition, the *"length"* property of the function object _F_ was set to *+0*<sub>𝔽</sub>. In 2nd Edition, *"length"* is set to *1*<sub>𝔽</sub>.
     </li>
     <li>
       <emu-xref href="#sec-intl.collator.prototype-@@tostringtag"></emu-xref> In ECMA-402, 7th Edition, the @@toStringTag property of `Intl.Collator.prototype` was set to *"Object"*. In 8th Edition, @@toStringTag is set to *"Intl.Collator"*.

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -247,7 +247,7 @@
         </p>
 
         <p>
-          The actual return values are implementation-defined to permit implementers to encode additional information in the value. The method is required to return *+0* when comparing Strings that are considered canonically equivalent by the Unicode standard.
+          The actual return values are implementation-defined to permit implementers to encode additional information in the value. The method is required to return *+0*<sub>𝔽</sub> when comparing Strings that are considered canonically equivalent by the Unicode standard.
         </p>
 
         <emu-note>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -66,7 +66,7 @@
         <tr>
           <td>[[FractionalSecondDigits]]</td>
           <td>*"fractionalSecondDigits"*</td>
-          <td>*1*, *2*, *3*</td>
+          <td>*1*<sub>𝔽</sub>, *2*<sub>𝔽</sub>, *3*<sub>𝔽</sub></td>
         </tr>
         <tr>
           <td>[[TimeZoneName]]</td>
@@ -247,7 +247,7 @@
           1. If _timeFormat_ has a [[pattern12]] field, then
             1. Let _pattern12_ be the string _connector_ with the substring *"{0}"* replaced with _timeFormat_.[[pattern12]] and the substring *"{1}"* replaced with _dateFormat_.[[pattern]].
             1. Set _format_.[[pattern12]] to _pattern12_.
-          1. Let _dateTimeRangeFormat_ be _dataLocaleData_.[[DateTimeRangeFormat]].[[&lt;_dateStyle_&gt;]].[[&lt;_timeStyle_&gt;]]
+          1. Let _dateTimeRangeFormat_ be _dataLocaleData_.[[DateTimeRangeFormat]].[[&lt;_dateStyle_&gt;]].[[&lt;_timeStyle_&gt;]].
           1. Add to _format_ all fields from _dateTimeRangeFormat_ including [[rangePatterns]] and [[rangePatterns12]], if present.
           1. Return _format_.
         1. If _timeStyle_ is not *undefined*, then
@@ -283,7 +283,7 @@
             1. Else if _optionsProp_ is not *undefined* and _formatProp_ is *undefined*, decrease _score_ by _removalPenalty_.
             1. Else if _optionsProp_ ≠ _formatProp_, then
               1. If _property_ is *"fractionalSecondDigits"*, then
-                1. Let _values_ be &laquo; *1*, *2*, *3* &raquo;.
+                1. Let _values_ be &laquo; *1*<sub>𝔽</sub>, *2*<sub>𝔽</sub>, *3*<sub>𝔽</sub> &raquo;.
               1. Else,
                 1. Let _values_ be &laquo; *"2-digit"*, *"numeric"*, *"narrow"*, *"short"*, *"long"* &raquo;.
               1. Let _optionsPropIndex_ be the index of _optionsProp_ within _values_.
@@ -409,7 +409,6 @@
       <emu-note>
         It is recommended that implementations use the time zone information of the IANA Time Zone Database.
       </emu-note>
-
     </emu-clause>
 
     <emu-clause id="sec-partitiondatetimepattern" aoid="PartitionDateTimePattern">
@@ -461,7 +460,6 @@
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>
-
     </emu-clause>
 
     <emu-clause id="sec-partitiondatetimerangepattern" aoid="PartitionDateTimeRangePattern">

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -40,7 +40,7 @@
       <h1>IsStructurallyValidLanguageTag ( _locale_ )</h1>
 
       <p>
-        The IsStructurallyValidLanguageTag abstract operation determines whether the _locale_ argument (which must be a String value) is a language tag recognized by this specification.  (It does not consider whether the language tag conveys any meaningful semantics, differentiate between aliased subtags and their preferred replacement subtags, or require canonical casing or subtag ordering.)
+        The IsStructurallyValidLanguageTag abstract operation determines whether the _locale_ argument (which must be a String value) is a language tag recognized by this specification. (It does not consider whether the language tag conveys any meaningful semantics, differentiate between aliased subtags and their preferred replacement subtags, or require canonical casing or subtag ordering.)
       </p>
 
       <p>
@@ -66,7 +66,7 @@
       </ul>
 
       <p>
-        When evaluating each condition, terminal value characters in the grammar are interpreted as the corresponding ASCII code points.  Subtags are duplicates if they are ASCII case-insensitively equivalent.
+        When evaluating each condition, terminal value characters in the grammar are interpreted as the corresponding ASCII code points. Subtags are duplicates if they are ASCII case-insensitively equivalent.
       </p>
 
       <emu-note>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -139,7 +139,7 @@
       </p>
 
       <emu-alg>
-        1. If _x_ &lt; 0 or _x_ is *-0*, let _isNegative_ be *true*; else let _isNegative_ be *false*.
+        1. If _x_ &lt; 0 or _x_ is *-0*<sub>𝔽</sub>, let _isNegative_ be *true*; else let _isNegative_ be *false*.
         1. If _isNegative_, then
           1. Let _x_ be -_x_.
         1. If _intlObject_.[[RoundingType]] is ~significantDigits~, then

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -19,7 +19,7 @@
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _t_ be ? GetOption(_options_, *"type"*, *"string"*, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
-        1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, *+0*, *3*, *"standard"*).
+        1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, *+0*<sub>𝔽</sub>, *3*<sub>𝔽</sub>, *"standard"*).
         1. Let _localeData_ be %PluralRules%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %PluralRules%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _pluralRules_.[[Locale]] to the value of _r_.[[locale]].

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -69,7 +69,7 @@
         1. Assert: _relativeTimeFormat_ has an [[InitializedRelativeTimeFormat]] internal slot.
         1. Assert: Type(_value_) is Number.
         1. Assert: Type(_unit_) is String.
-        1. If _value_ is *NaN*, *+&infin;*, or *-&infin;*, throw a *RangeError* exception.
+        1. If _value_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Let _unit_ be ? SingularRelativeTimeUnit(_unit_).
         1. Let _localeData_ be %RelativeTimeFormat%.[[LocaleData]].
         1. Let _dataLocale_ be _relativeTimeFormat_.[[DataLocale]].
@@ -90,7 +90,7 @@
           1. If _patterns_ has a field [[&lt;_valueString_&gt;]], then
             1. Let _result_ be _patterns_.[[&lt;_valueString_&gt;]].
             1. Return a List containing the Record { [[Type]]: *"literal"*, [[Value]]: _result_ }.
-        1. If _value_ is *-0* or if _value_ is less than 0, then
+        1. If _value_ is *-0*<sub>𝔽</sub> or if _value_ is less than 0, then
           1. Let _tl_ be *"past"*.
         1. Else,
           1. Let _tl_ be *"future"*.


### PR DESCRIPTION
This patch fixes warnings raised from the spec build