### PR TITLE
Editorial- Unify the option value referring UTS35

### DIFF
--- a/spec/locale.html
+++ b/spec/locale.html
@@ -95,7 +95,7 @@
       <h1>Intl.Locale ( _tag_ [ , _options_ ] )</h1>
 
       <p>
-        The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
+        The following algorithm refers to the `type` nonterminal from <a href="https://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
         When the `Intl.Locale` function is called with an argument _tag_ and an optional argument _options_, the following steps are taken:
       </p>
 
@@ -118,11 +118,11 @@
         1. Let _opt_ be a new Record.
         1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, *"string"*, *undefined*, *undefined*).
         1. If _calendar_ is not *undefined*, then
-          1. If _calendar_ does not match the `type` sequence (from <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35 Unicode Locale Identifier, section 3.2</a>), throw a *RangeError* exception.
+          1. If _calendar_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[ca]] to _calendar_.
         1. Let _collation_ be ? GetOption(_options_, *"collation"*, *"string"*, *undefined*, *undefined*).
         1. If _collation_ is not *undefined*, then
-          1. If _collation_ does not match the `type` sequence (from <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35 Unicode Locale Identifier, section 3.2</a>), throw a *RangeError* exception.
+          1. If _collation_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[co]] to _collation_.
         1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
         1. Set _opt_.[[hc]] to _hc_.
@@ -133,7 +133,7 @@
         1. Set _opt_.[[kn]] to _kn_.
         1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
-          1. If _numberingSystem_ does not match the `type` sequence (from <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35 Unicode Locale Identifier, section 3.2</a>), throw a *RangeError* exception.
+          1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _r_ be ! ApplyUnicodeExtensionToTag(_tag_, _opt_, _relevantExtensionKeys_).
         1. Set _locale_.[[Locale]] to _r_.[[locale]].

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -11,7 +11,7 @@
         The abstract operation InitializeRelativeTimeFormat accepts the arguments _relativeTimeFormat_ (which must be an object), _locales_, and _options_. It initializes _relativeTimeFormat_ as a RelativeTimeFormat object.
       </p>
       <p>
-        The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
+        The following algorithm refers to the `type` nonterminal from <a href="https://www.unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35's Unicode Locale Identifier grammar</a>.
         The following steps are taken:
       </p>
 
@@ -23,7 +23,7 @@
         1. Set _opt_.[[LocaleMatcher]] to _matcher_.
         1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
-          1. If _numberingSystem_ does not match the `type` sequence (from <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">UTS 35 Unicode Locale Identifier, section 3.2</a>), throw a *RangeError* exception.
+          1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _localeData_ be %RelativeTimeFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%RelativeTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %RelativeTimeFormat%.[[RelevantExtensionKeys]], _localeData_).


### PR DESCRIPTION
Unify the option value calendar/collation/numberingSystem checking while referring to UTS35

Close #565

@ryzokuken @sffc @zbraniecki @leobalter @gibfahn 