### PR TITLE
Editorial: Remove the mention of the "the first substring"

### DIFF
--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -63,7 +63,7 @@
           1. Let _requestedLocale_ be _requestedLocales_[0].
         1. Else,
           1. Let _requestedLocale_ be DefaultLocale().
-        1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with all Unicode locale extension sequences (<emu-xref href="#sec-unicode-locale-extension-sequences"></emu-xref>) removed.
+        1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with any Unicode locale extension sequences (<emu-xref href="#sec-unicode-locale-extension-sequences"></emu-xref>) removed.
         1. Let _availableLocales_ be a List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
         1. Let _locale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
         1. If _locale_ is *undefined*, let _locale_ be *"und"*.

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -57,7 +57,7 @@
         1. Assert: Type(_tag_) is String.
         1. Assert: _tag_ matches the `unicode_locale_id` production.
         1. If _tag_ contains a substring that is a Unicode locale extension sequence, then
-          1. Let _extension_ be the String value consisting of the substring of Unicode locale extension sequence within _tag_.
+          1. Let _extension_ be the String value consisting of the substring of the Unicode locale extension sequence within _tag_.
           1. Let _components_ be ! UnicodeExtensionComponents(_extension_).
           1. Let _attributes_ be _components_.[[Attributes]].
           1. Let _keywords_ be _components_.[[Keywords]].
@@ -82,7 +82,7 @@
             1. Else,
               1. Append the Record { [[Key]]: _key_, [[Value]]: _value_ } to _keywords_.
           1. Set _result_.[[<_key_>]] to _value_.
-        1. Let _locale_ be the String value that is _tag_ with all Unicode locale extension sequences removed.
+        1. Let _locale_ be the String value that is _tag_ with any Unicode locale extension sequences removed.
         1. Let _newExtension_ be a Unicode BCP 47 U Extension based on _attributes_ and _keywords_.
         1. If _newExtension_ is not the empty String, then
           1. Let _locale_ be ! InsertUnicodeExtensionAndCanonicalize(_locale_, _newExtension_).

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -57,7 +57,7 @@
         1. Assert: Type(_tag_) is String.
         1. Assert: _tag_ matches the `unicode_locale_id` production.
         1. If _tag_ contains a substring that is a Unicode locale extension sequence, then
-          1. Let _extension_ be the String value consisting of the first substring of _tag_ that is a Unicode locale extension sequence.
+          1. Let _extension_ be the String value consisting of substring of Unicode locale extension sequence within _tag_.
           1. Let _components_ be ! UnicodeExtensionComponents(_extension_).
           1. Let _attributes_ be _components_.[[Attributes]].
           1. Let _keywords_ be _components_.[[Keywords]].

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -57,7 +57,7 @@
         1. Assert: Type(_tag_) is String.
         1. Assert: _tag_ matches the `unicode_locale_id` production.
         1. If _tag_ contains a substring that is a Unicode locale extension sequence, then
-          1. Let _extension_ be the String value consisting of substring of Unicode locale extension sequence within _tag_.
+          1. Let _extension_ be the String value consisting of the substring of Unicode locale extension sequence within _tag_.
           1. Let _components_ be ! UnicodeExtensionComponents(_extension_).
           1. Let _attributes_ be _components_.[[Attributes]].
           1. Let _keywords_ be _components_.[[Keywords]].

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -107,7 +107,7 @@
           1. If _availableLocale_ is not *undefined*, then
             1. Set _result_.[[locale]] to _availableLocale_.
             1. If _locale_ and _noExtensionsLocale_ are not the same String value, then
-              1. Let _extension_ be the String value consisting of the first substring of _locale_ that is a Unicode locale extension sequence.
+              1. Let _extension_ be the String value consisting of the substring of Unicode locale extension sequence within _locale_.
               1. Set _result_.[[extension]] to _extension_.
             1. Return _result_.
         1. Let _defLocale_ be DefaultLocale().
@@ -116,7 +116,7 @@
       </emu-alg>
 
       <emu-note>
-        The algorithm is based on the Lookup algorithm described in RFC 4647 section 3.4, but options specified through Unicode locale extension sequences are ignored in the lookup. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the first Unicode locale extension sequence within the request locale language tag.
+        The algorithm is based on the Lookup algorithm described in RFC 4647 section 3.4, but options specified through Unicode locale extension sequences are ignored in the lookup. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of Unicode locale extension sequence within the request locale language tag.
       </emu-note>
     </emu-clause>
 
@@ -124,7 +124,7 @@
       <h1>BestFitMatcher ( _availableLocales_, _requestedLocales_ )</h1>
 
       <p>
-        The BestFitMatcher abstract operation compares _requestedLocales_, which must be a List as returned by CanonicalizeLocaleList, against the locales in _availableLocales_ and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the LookupMatcher abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the first Unicode locale extension sequence within the request locale language tag.
+        The BestFitMatcher abstract operation compares _requestedLocales_, which must be a List as returned by CanonicalizeLocaleList, against the locales in _availableLocales_ and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the LookupMatcher abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of Unicode locale extension sequence within the request locale language tag.
       </p>
     </emu-clause>
 

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -102,12 +102,12 @@
       <emu-alg>
         1. Let _result_ be a new Record.
         1. For each element _locale_ of _requestedLocales_, do
-          1. Let _noExtensionsLocale_ be the String value that is _locale_ with all Unicode locale extension sequences removed.
+          1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
           1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
           1. If _availableLocale_ is not *undefined*, then
             1. Set _result_.[[locale]] to _availableLocale_.
             1. If _locale_ and _noExtensionsLocale_ are not the same String value, then
-              1. Let _extension_ be the String value consisting of the substring of Unicode locale extension sequence within _locale_.
+              1. Let _extension_ be the String value consisting of the substring of the Unicode locale extension sequence within _locale_.
               1. Set _result_.[[extension]] to _extension_.
             1. Return _result_.
         1. Let _defLocale_ be DefaultLocale().
@@ -116,7 +116,7 @@
       </emu-alg>
 
       <emu-note>
-        The algorithm is based on the Lookup algorithm described in RFC 4647 section 3.4, but options specified through Unicode locale extension sequences are ignored in the lookup. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of Unicode locale extension sequence within the request locale language tag.
+        The algorithm is based on the Lookup algorithm described in RFC 4647 section 3.4, but options specified through Unicode locale extension sequences are ignored in the lookup. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
       </emu-note>
     </emu-clause>
 
@@ -124,7 +124,7 @@
       <h1>BestFitMatcher ( _availableLocales_, _requestedLocales_ )</h1>
 
       <p>
-        The BestFitMatcher abstract operation compares _requestedLocales_, which must be a List as returned by CanonicalizeLocaleList, against the locales in _availableLocales_ and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the LookupMatcher abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of Unicode locale extension sequence within the request locale language tag.
+        The BestFitMatcher abstract operation compares _requestedLocales_, which must be a List as returned by CanonicalizeLocaleList, against the locales in _availableLocales_ and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the LookupMatcher abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
       </p>
     </emu-clause>
 
@@ -266,7 +266,7 @@
       <emu-alg>
         1. Let _subset_ be a new empty List.
         1. For each element _locale_ of _requestedLocales_, do
-          1. Let _noExtensionsLocale_ be the String value that is _locale_ with all Unicode locale extension sequences removed.
+          1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
           1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
           1. If _availableLocale_ is not *undefined*, append _locale_ to the end of _subset_.
         1. Return _subset_.


### PR DESCRIPTION
Close #559
Remove the misleading usage of the "first" substring which imply it is possible to have second or rest but under condition which are not possible. 