### PR TITLE
Normative: Add hourCycle to opt before passing to FormatMatcher

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -123,7 +123,25 @@
             1. Throw a *RangeError* exception.
           1. Let _timeZone_ be CanonicalizeTimeZoneName(_timeZone_).
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
+        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _formatOptions_ be a new Record.
+        1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
+        1. Let _hc_ be _dateTimeFormat_.[[HourCycle]].
+        1. If _hc_ is *null*, then
+          1. Set _hc_ to _hcDefault_.
+        1. If _hour12_ is not *undefined*, then
+          1. If _hour12_ is *true*, then
+            1. If _hcDefault_ is *"h11"* or *"h23"*, then
+              1. Set _hc_ to *"h11"*.
+            1. Else,
+              1. Set _hc_ to *"h12"*.
+          1. Else,
+            1. Assert: _hour12_ is *false*.
+            1. If _hcDefault_ is *"h11"* or *"h23"*, then
+              1. Set _hc_ to *"h23"*.
+            1. Else,
+              1. Set _hc_ to *"h24"*.
+        1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Set _formatOptions_.[[hourCycle]] to _dateTimeFormat_.[[HourCycle]]. 
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
           1. Let _prop_ be the name given in the Property column of the row.
@@ -132,7 +150,6 @@
           1. Else,
             1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
           1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
         1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, *"string"*, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.
@@ -161,30 +178,12 @@
           1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
           1. Let _pattern_ be _bestFormat_.[[pattern]].
           1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns]].
+        1. Else if _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then
+          1. Let _pattern_ be _bestFormat_.[[pattern12]].
+          1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns12]].
         1. Else,
-          1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
-          1. Let _hc_ be _dateTimeFormat_.[[HourCycle]].
-          1. If _hc_ is *null*, then
-            1. Set _hc_ to _hcDefault_.
-          1. If _hour12_ is not *undefined*, then
-            1. If _hour12_ is *true*, then
-              1. If _hcDefault_ is *"h11"* or *"h23"*, then
-                1. Set _hc_ to *"h11"*.
-              1. Else,
-                1. Set _hc_ to *"h12"*.
-            1. Else,
-              1. Assert: _hour12_ is *false*.
-              1. If _hcDefault_ is *"h11"* or *"h23"*, then
-                1. Set _hc_ to *"h23"*.
-              1. Else,
-                1. Set _hc_ to *"h24"*.
-          1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
-          1. If _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then
-            1. Let _pattern_ be _bestFormat_.[[pattern12]].
-            1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns12]].
-          1. Else,
-            1. Let _pattern_ be _bestFormat_.[[pattern]].
-            1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns]].
+          1. Let _pattern_ be _bestFormat_.[[pattern]].
+          1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns]].
         1. Set _dateTimeFormat_.[[Pattern]] to _pattern_.
         1. Set _dateTimeFormat_.[[RangePatterns]] to _rangePatterns_.
         1. Return _dateTimeFormat_.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -123,7 +123,6 @@
             1. Throw a *RangeError* exception.
           1. Let _timeZone_ be CanonicalizeTimeZoneName(_timeZone_).
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _formatOptions_ be a new Record.
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
           1. Let _prop_ be the name given in the Property column of the row.
@@ -132,6 +131,7 @@
           1. Else,
             1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
           1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
+        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
         1. Let _hc_ be _dateTimeFormat_.[[HourCycle]].
         1. If _hc_ is *null*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -176,9 +176,7 @@
             1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
         1. If _dateTimeFormat_.[[Hour]] is *undefined*, then
           1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
-          1. Let _pattern_ be _bestFormat_.[[pattern]].
-          1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns]].
-        1. Else if _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then
+        1. If _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then
           1. Let _pattern_ be _bestFormat_.[[pattern12]].
           1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns12]].
         1. Else,

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -123,14 +123,15 @@
             1. Throw a *RangeError* exception.
           1. Let _timeZone_ be CanonicalizeTimeZoneName(_timeZone_).
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
-        1. Let _opt_ be a new Record.
+        1. Let _formatOptions_ be a new Record.
+        1. Set _formatOptions_.[[hourCycle]] to _dateTimeFormat_.[[HourCycle]]. 
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
           1. Let _prop_ be the name given in the Property column of the row.
           1. If _prop_ is *"fractionalSecondDigits"*, then
             1. Let _value_ be ? GetNumberOption(options, *"fractionalSecondDigits"*, 1, 3, *undefined*).
           1. Else,
             1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
-          1. Set _opt_.[[&lt;_prop_&gt;]] to _value_.
+          1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
         1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, *"string"*, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
@@ -140,7 +141,7 @@
         1. If _dateStyle_ is not *undefined* or _timeStyle_ is not *undefined*, then
           1. For each row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, do
             1. Let _prop_ be the name given in the Property column of the row.
-            1. Let _p_ be _opt_.[[&lt;_prop_&gt;]].
+            1. Let _p_ be _formatOptions_.[[&lt;_prop_&gt;]].
             1. If _p_ is not *undefined*, then
               1. Throw a *TypeError* exception.
           1. Let _styles_ be _dataLocaleData_.[[styles]].[[&lt;_calendar_&gt;]].
@@ -148,9 +149,9 @@
         1. Else,
           1. Let _formats_ be _dataLocaleData_.[[formats]].[[&lt;_calendar_&gt;]].
           1. If _matcher_ is *"basic"*, then
-            1. Let _bestFormat_ be BasicFormatMatcher(_opt_, _formats_).
+            1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
           1. Else,
-            1. Let _bestFormat_ be BestFitFormatMatcher(_opt_, _formats_).
+            1. Let _bestFormat_ be BestFitFormatMatcher(_formatOptions_, _formats_).
         1. For each row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
           1. Let _prop_ be the name given in the Property column of the row.
           1. If _bestFormat_ has a field [[&lt;_prop_&gt;]], then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -129,18 +129,18 @@
         1. Let _hc_ be _dateTimeFormat_.[[HourCycle]].
         1. If _hc_ is *null*, then
           1. Set _hc_ to _hcDefault_.
-        1. If _hour12_ is not *undefined*, then
-          1. If _hour12_ is *true*, then
-            1. If _hcDefault_ is *"h11"* or *"h23"*, then
-              1. Set _hc_ to *"h11"*.
-            1. Else,
-              1. Set _hc_ to *"h12"*.
+        1. If _hour12_ is *true*, then
+          1. If _hcDefault_ is *"h11"* or *"h23"*, then
+            1. Set _hc_ to *"h11"*.
           1. Else,
-            1. Assert: _hour12_ is *false*.
-            1. If _hcDefault_ is *"h11"* or *"h23"*, then
-              1. Set _hc_ to *"h23"*.
-            1. Else,
-              1. Set _hc_ to *"h24"*.
+            1. Set _hc_ to *"h12"*.
+        1. Else if _hour12_ is *false*, then
+          1. If _hcDefault_ is *"h11"* or *"h23"*, then
+            1. Set _hc_ to *"h23"*.
+          1. Else,
+            1. Set _hc_ to *"h24"*.
+        1. Else,
+          1. Assert: _hour12_ is *undefined*.
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Set _formatOptions_.[[hourCycle]] to _dateTimeFormat_.[[HourCycle]]. 
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -125,6 +125,13 @@
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _formatOptions_ be a new Record.
+        1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
+          1. Let _prop_ be the name given in the Property column of the row.
+          1. If _prop_ is *"fractionalSecondDigits"*, then
+            1. Let _value_ be ? GetNumberOption(options, *"fractionalSecondDigits"*, 1, 3, *undefined*).
+          1. Else,
+            1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
+          1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
         1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
         1. Let _hc_ be _dateTimeFormat_.[[HourCycle]].
         1. If _hc_ is *null*, then
@@ -143,13 +150,6 @@
           1. Assert: _hour12_ is *undefined*.
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Set _formatOptions_.[[hourCycle]] to _dateTimeFormat_.[[HourCycle]]. 
-        1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
-          1. Let _prop_ be the name given in the Property column of the row.
-          1. If _prop_ is *"fractionalSecondDigits"*, then
-            1. Let _value_ be ? GetNumberOption(options, *"fractionalSecondDigits"*, 1, 3, *undefined*).
-          1. Else,
-            1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
-          1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
         1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, *"string"*, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -149,7 +149,7 @@
         1. Else,
           1. Assert: _hour12_ is *undefined*.
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
-        1. Set _formatOptions_.[[hourCycle]] to _dateTimeFormat_.[[HourCycle]]. 
+        1. Set _formatOptions_.[[hourCycle]] to _hc_. 
         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
         1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, *"string"*, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.


### PR DESCRIPTION
fixes #511 

There's another alternative that I considered which is adding `hourCycle` to Table 4, but that would be a rather big change as `hourCycle` isn't technically a date/time formatting parts, just preferences.
Since it's not in Table 4, `BasicFormatMatcher` basically doesn't do anything with it, but `BestFitFormatMatcher` technically can since it's impl-dependent