### PR TITLE
Normative: Fix spec bugs in numberformat.html caused by Unified NumberFormat

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -174,8 +174,10 @@
         1. Let _exponent_ be 0.
         1. If _x_ is *NaN*, then
           1. Let _n_ be an implementation- and locale-dependent (ILD) String value indicating the *NaN* value.
-        1. Else if _x_ is a non-finite Number, then
-          1. Let _n_ be an ILD String value indicating infinity.
+        1. Else if _x_ is *+&infin;*, then
+          1. Let _n_ be an ILD String value indicating positive infinity.
+        1. Else if _x_ is *-&infin;*, then
+          1. Let _n_ be an ILD String value indicating negative infinity.
         1. Else,
           1. If _numberFormat_.[[Style]] is *"percent"*, let _x_ be 100 × _x_.
           1. Let _exponent_ be ComputeExponent(_numberFormat_, _x_).

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -632,6 +632,7 @@
       </p>
 
       <emu-alg>
+        1. Set x to ℝ(x).
         1. Let _p_ be _maxPrecision_.
         1. If _x_ = 0, then
           1. Let _m_ be the String consisting of _p_ occurrences of the character *"0"*.
@@ -670,6 +671,7 @@
       </p>
 
       <emu-alg>
+        1. Set x to ℝ(x).
         1. Let _f_ be _maxFraction_.
         1. Let _n_ be an integer for which the exact mathematical value of _n_ / 10<sup>_f_</sup> – _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
         1. Let _xFinal_ be _n_ / 10<sup>_f_</sup>.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -638,7 +638,7 @@
           1. Let _e_ be 0.
           1. Let _xFinal_ be 0.
         1. Else,
-          1. Let _e_ and _n_ be integers such that 10<sup>_p_–1</sup> ≤ _n_ < 10<sup>_p_</sup> and for which the exact mathematical value of _n_ × 10<sup>_e_–_p_+1</sup> – _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ × 10<sup>_e_–_p_+1</sup> is larger.
+          1. Let _e_ and _n_ be integers such that 10<sup>_p_ - 1</sup> &le; _n_ &lt; 10<sup>_p_</sup> and for which _n_ &times; 10<sup>_e_ - _p_ + 1</sup> - _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ &times; 10<sup>_e_ - _p_ + 1</sup> is larger.
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
           1. Let _xFinal_ be _n_ × 10<sup>_e_–_p_+1</sup>.
         1. If _e_ ≥ _p_–1, then

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -636,8 +636,7 @@
           1. Let _e_ be 0.
           1. Let _xFinal_ be 0.
         1. Else,
-          1. Let _e_ be the base 10 logarithm of _x_ rounded down to the nearest integer.
-          1. Let _n_ be an integer such that 10<sup>_p_–1</sup> ≤ _n_ < 10<sup>_p_</sup> and for which the exact mathematical value of _n_ × 10<sup>_e_–_p_+1</sup> – _x_ is as close to zero as possible. If there is more than one such _n_, pick the one for which _n_ × 10<sup>_e_–_p_+1</sup> is larger.
+          1. Let _e_ and _n_ be integers such that 10<sup>_p_–1</sup> ≤ _n_ < 10<sup>_p_</sup> and for which the exact mathematical value of _n_ × 10<sup>_e_–_p_+1</sup> – _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ × 10<sup>_e_–_p_+1</sup> is larger.
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
           1. Let _xFinal_ be _n_ × 10<sup>_e_–_p_+1</sup>.
         1. If _e_ ≥ _p_–1, then


### PR DESCRIPTION
I changed part of the ToRawPrecision algorithm in ES2019 as part of [Unified NumberFormat](https://github.com/tc39/proposal-unified-intl-numberformat).  However, in my work on NFv3, I realized that one change I made is unsound.  This is in a crucial function, ToRawPrecision, which is used for all significant digits rounding.

Problem explanation: In ToRawPrecision, the _e_ value is supposed to represent the power of 10 of the resolved number *after* rounding.  However, my change in ES2020 computed _e_ based on the input value *before* rounding.

Example values of _x_, _p_, _n_, and _e_, with _xFinal_ for reference:

Formula: _x_ ≈ _n_ × 10<sup>_e_–_p_+1</sup>

| _x_ | _p_ | _n_ | _e_ | _xFinal_ |
|---|---|---|---|---|
| 1.11 | 3 | 111 | 0 | 1.11 |
| 11.1 | 3 | 111 | 1 | 11.1 |
| 1.11 | 2 | 11 | 0 | 1.1 |
| 11.1 | 2 | 11 | 1 | 11 |
| 9.999 | 3 | 100 | 1 | 10.0 |
| 9.999 | 2 | 10 | 1 | 10 |
| 9.9 | 3 | 990 | 0 | 9.90 |
| 9.9 | 2 | 99 | 0 | 9.9 |

Practically, the ES2020 algorithm works in all cases except those where the number rounds up to the next magnitude.  A spec-compliant ES2020 implementation would need to return "9.99" instead of "10.0" in the fifth row.

***Please check my logic!***

All browsers still implement it correctly, but I would like to restore the old algorithm as soon as possible.  ~I consider this an editorial change because it is restoring correct behavior after a mess-up in ES2020.~ (2021-05-06: This is still normative.)

~Can we sneak this into ES2021?~ (2021-05-06: No, don't push this into ES 2021.)