### PR TITLE
Editorial: Refactor SetNumberFormatDigitOptions

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -22,27 +22,35 @@
         1. Let _mnsd_ be ? Get(_options_, *"minimumSignificantDigits"*).
         1. Let _mxsd_ be ? Get(_options_, *"maximumSignificantDigits"*).
         1. Set _intlObj_.[[MinimumIntegerDigits]] to _mnid_.
-        1. If _mnsd_ is not *undefined* or _mxsd_ is not *undefined*, then
-          1. Set _intlObj_.[[RoundingType]] to ~significantDigits~.
-          1. Let _mnsd_ be ? DefaultNumberOption(_mnsd_, 1, 21, 1).
-          1. Let _mxsd_ be ? DefaultNumberOption(_mxsd_, _mnsd_, 21, 21).
-          1. Set _intlObj_.[[MinimumSignificantDigits]] to _mnsd_.
-          1. Set _intlObj_.[[MaximumSignificantDigits]] to _mxsd_.
-        1. Else if _mnfd_ is not *undefined* or _mxfd_ is not *undefined*, then
-          1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
-          1. Let _mnfd_ be ? DefaultNumberOption(_mnfd_, 0, 20, *undefined*).
-          1. Let _mxfd_ be ? DefaultNumberOption(_mxfd_, 0, 20, *undefined*).
-          1. If _mnfd_ is *undefined*, set _mnfd_ to min(_mnfdDefault_, _mxfd_).
-          1. Else if _mxfd_ is *undefined*, set _mxfd_ to max(_mxfdDefault_, _mnfd_).
-          1. Else if _mnfd_ is greater than _mxfd_, throw a *RangeError* exception.
-          1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfd_.
-          1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfd_.
-        1. Else if _notation_ is *"compact"*, then
+        1. Let _hasSd_ be _mnsd_ is not *undefined* or _mxsd_ is not *undefined*.
+        1. Let _hasFd_ be _mnfd_ is not *undefined* or _mxfd_ is not *undefined*.
+        1. Let _needSd_ be _hasSd_.
+        1. Let _needFd_ be not _hasSd_ and _notation_ is not *"compact"*.
+        1. If _needSd_, then
+          1. If _hasSd_, then
+            1. Set _intlObj_.[[RoundingType]] to ~significantDigits~.
+            1. Let _mnsd_ be ? DefaultNumberOption(_mnsd_, 1, 21, 1).
+            1. Let _mxsd_ be ? DefaultNumberOption(_mxsd_, _mnsd_, 21, 21).
+            1. Set _intlObj_.[[MinimumSignificantDigits]] to _mnsd_.
+            1. Set _intlObj_.[[MaximumSignificantDigits]] to _mxsd_.
+          1. Else,
+            1. Assert *false*.
+        1. If _needFd_, then
+          1. If _hasFd_, then
+            1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
+            1. Let _mnfd_ be ? DefaultNumberOption(_mnfd_, 0, 20, *undefined*).
+            1. Let _mxfd_ be ? DefaultNumberOption(_mxfd_, 0, 20, *undefined*).
+            1. If _mnfd_ is *undefined*, set _mnfd_ to min(_mnfdDefault_, _mxfd_).
+            1. Else if _mxfd_ is *undefined*, set _mxfd_ to max(_mxfdDefault_, _mnfd_).
+            1. Else if _mnfd_ is greater than _mxfd_, throw a *RangeError* exception.
+            1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfd_.
+            1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfd_.
+          1. Else,
+            1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
+            1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfdDefault_.
+            1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfdDefault_.
+        1. If not _needSd_ and not _needFd_, then
           1. Set _intlObj_.[[RoundingType]] to ~compactRounding~.
-        1. Else,
-          1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
-          1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfdDefault_.
-          1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfdDefault_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
This is an editorial change intended to re-structure the SetNumberFormatDigitOptions abstract operation to reduce diffs in the NumberFormat v3 proposal.

@ryzokuken, you've worked extensively on this abstract operation before, so I would like you to review it to make sure that it is, indeed, editorial.