### PR TITLE
Editorial: mention "cf" in Note 1 of #sec-intl.numberformat-internal-slots

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -961,7 +961,7 @@
       </p>
 
       <emu-note>
-        Unicode Technical Standard 35 describes two locale extension keys that are relevant to number formatting: *"cu"* for currency and *"nu"* for numbering system. Intl.NumberFormat, however, requires that the currency of a currency format is specified through the currency property in the options objects.
+        Unicode Technical Standard 35 describes three locale extension keys that are relevant to number formatting: *"cu"* for currency, *"cf"* for currency format style, and *"nu"* for numbering system. Intl.NumberFormat, however, requires that the currency of a currency format is specified through the currency property in the options objects, and the currency format style of a currency format is specified through the currencySign property in the options objects.
       </emu-note>
 
       <p>


### PR DESCRIPTION
Mention "cf" in https://tc39.es/ecma402/#sec-intl.numberformat-internal-slots
see also https://unicode.org/reports/tr35/#Key_Type_Definitions Make it clear that "cf" is not supported via extension. 