### PR TITLE
Editorial: Clarify the "All registered Zone and Link names"

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -75,6 +75,9 @@
         <li>
           The calendric calculations used for calendars other than *"gregory"*, and adjustments for local time zones and daylight saving time (<emu-xref href="#sec-formatdatetime"></emu-xref>)
         </li>
+        <li>
+          The set of all known registered Zone and Link names of the IANA Time Zone Database and the information about their offsets from UTC and their daylight saving time rules (<emu-xref href="#sec-time-zone-names"></emu-xref>)
+        </li>
       </ul>
     </li>
     <li>


### PR DESCRIPTION
Clarify that "All registered Zone and Link names" is implementation dependent in a sense that a ealier shipped browser may not have the latest IANA timezone DB in practice.
 (in ECMA262 language - implementation-approximated ??)

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
