### PR TITLE
Editorial: Use consistent language to reference intrinsic constructors

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -153,7 +153,7 @@
       <h1>Intl.Collator.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.Collator.prototype.constructor` is the intrinsic object %Collator%.
+        The initial value of `Intl.Collator.prototype.constructor` is %Collator%.
       </p>
     </emu-clause>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1001,7 +1001,7 @@
       <h1>Intl.DateTimeFormat.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.DateTimeFormat.prototype.constructor` is the intrinsic object %DateTimeFormat%.
+        The initial value of `Intl.DateTimeFormat.prototype.constructor` is %DateTimeFormat%.
       </p>
     </emu-clause>
 

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -151,7 +151,7 @@
       <h1>Intl.DisplayNames.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.DisplayNames.prototype.constructor` is the intrinsic object %DisplayNames%.
+        The initial value of `Intl.DisplayNames.prototype.constructor` is %DisplayNames%.
       </p>
     </emu-clause>
 

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -270,7 +270,7 @@
       <h1>Intl.ListFormat.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.ListFormat.prototype.constructor` is the intrinsic object %ListFormat%.
+        The initial value of `Intl.ListFormat.prototype.constructor` is %ListFormat%.
       </p>
     </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1005,7 +1005,7 @@
       <h1>Intl.NumberFormat.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.NumberFormat.prototype.constructor` is the intrinsic object %NumberFormat%.
+        The initial value of `Intl.NumberFormat.prototype.constructor` is %NumberFormat%.
       </p>
     </emu-clause>
 

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -226,7 +226,7 @@
       <h1>Intl.PluralRules.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.PluralRules.prototype.constructor` is the intrinsic object %PluralRules%.
+        The initial value of `Intl.PluralRules.prototype.constructor` is %PluralRules%.
       </p>
     </emu-clause>
 


### PR DESCRIPTION
Ref https://github.com/tc39/ecma262/pull/2490