### PR TITLE
Normative: Add new numbering system "tnsa"

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -562,6 +562,10 @@
             <td>U+114D0 to U+114D9</td>
           </tr>
           <tr>
+            <td>tnsa</td>
+            <td>U+16AC0 to U+16AC9</td>
+          </tr>
+          <tr>
             <td>vaii</td>
             <td>U+A620 to U+A629</td>
           </tr>


### PR DESCRIPTION
Add "tnsa" to the table of numbering systems with simple digit mappings. The
Tangsa script ("Tnsa") is a new addition in Unicode 14.

Also see: <https://github.com/unicode-org/cldr/pull/1326>