### PR TITLE
Editorial: Remove unnecessary specification of supportedLocalesOf `length` properties

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -113,10 +113,6 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
-
-      <p>
-        The value of the *"length"* property of the `supportedLocalesOf` method is 1.
-      </p>
     </emu-clause>
 
     <emu-clause id="sec-intl-collator-internal-slots">

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -756,10 +756,6 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
-
-      <p>
-        The value of the *"length"* property of the `supportedLocalesOf` method is 1.
-      </p>
     </emu-clause>
 
     <emu-clause id="sec-intl.datetimeformat-internal-slots">

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -962,10 +962,6 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
-
-      <p>
-        The value of the *"length"* property of the `supportedLocalesOf` method is 1.
-      </p>
     </emu-clause>
 
     <emu-clause id="sec-intl.numberformat-internal-slots">

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -184,10 +184,6 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
-
-      <p>
-        The value of the *"length"* property of the `supportedLocalesOf` method is 1.
-      </p>
     </emu-clause>
 
     <emu-clause id="sec-intl.pluralrules-internal-slots">

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -231,10 +231,6 @@
       </emu-alg>
     </emu-clause>
 
-    <p>
-      The value of the *"length"* property of the `supportedLocalesOf` method is 1.
-    </p>
-
     <emu-clause id="sec-Intl.RelativeTimeFormat-internal-slots">
       <h1>Internal slots</h1>
 


### PR DESCRIPTION
Some but not all `supportedLocalesOf` definitions explicitly specify `length`, but none of them should need to. However, we might consider updating https://tc39.es/ecma402/#conventions to explicitly adopt https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects
> Every built-in <a href="https://tc39.es/ecma262/#function-object">function object</a>, including <a href="https://tc39.es/ecma262/#constructor">constructors</a>, has a **"length"** property whose value is a non-negative <a href="https://tc39.es/ecma262/#integral-number">integral Number</a>. Unless otherwise specified, this value is equal to the number of required parameters shown in the subclause heading for the function description. Optional parameters and rest parameters are not included in the parameter count.