### PR TITLE
Editorial: correct references to negative zero

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -814,7 +814,7 @@
             1. Let _pattern_ be _patterns_.[[negativePattern]].
         1. Else,
           1. Assert: _signDisplay_ is *"exceptZero"*.
-          1. If _x_ is *NaN* or _x_ is finite and ℝ(_x_) is 0, then
+          1. If _x_ is *NaN*, or if _x_ is finite and ℝ(_x_) is 0, then
             1. Let _pattern_ be _patterns_.[[zeroPattern]].
           1. Else if ℝ(_x_) &gt; 0, then
             1. Let _pattern_ be _patterns_.[[positivePattern]].

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -157,7 +157,7 @@
       </p>
 
       <emu-alg>
-        1. If _x_ &lt; 0<sub>𝔽</sub> or _x_ is *-0*<sub>𝔽</sub>, let _isNegative_ be *true*; else let _isNegative_ be *false*.
+        1. If ℝ(_x_) &lt; 0 or _x_ is *-0*<sub>𝔽</sub>, let _isNegative_ be *true*; else let _isNegative_ be *false*.
         1. If _isNegative_, then
           1. Let _x_ be -_x_.
         1. If _intlObject_.[[RoundingType]] is ~significantDigits~, then
@@ -814,9 +814,9 @@
             1. Let _pattern_ be _patterns_.[[negativePattern]].
         1. Else,
           1. Assert: _signDisplay_ is *"exceptZero"*.
-          1. If _x_ is 0<sub>𝔽</sub> or _x_ is -0<sub>𝔽</sub> or _x_ is *NaN*, then
+          1. If _x_ is *NaN* or _x_ is finite and ℝ(_x_) is 0, then
             1. Let _pattern_ be _patterns_.[[zeroPattern]].
-          1. Else if _x_ &gt; 0<sub>𝔽</sub>, then
+          1. Else if ℝ(_x_) &gt; 0, then
             1. Let _pattern_ be _patterns_.[[positivePattern]].
           1. Else,
             1. Let _pattern_ be _patterns_.[[negativePattern]].

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -157,7 +157,7 @@
       </p>
 
       <emu-alg>
-        1. If _x_ &lt; 0 or _x_ is *-0*<sub>𝔽</sub>, let _isNegative_ be *true*; else let _isNegative_ be *false*.
+        1. If _x_ &lt; 0<sub>𝔽</sub> or _x_ is *-0*<sub>𝔽</sub>, let _isNegative_ be *true*; else let _isNegative_ be *false*.
         1. If _isNegative_, then
           1. Let _x_ be -_x_.
         1. If _intlObject_.[[RoundingType]] is ~significantDigits~, then
@@ -814,9 +814,9 @@
             1. Let _pattern_ be _patterns_.[[negativePattern]].
         1. Else,
           1. Assert: _signDisplay_ is *"exceptZero"*.
-          1. If _x_ is 0 or _x_ is -0 or _x_ is *NaN*, then
+          1. If _x_ is 0<sub>𝔽</sub> or _x_ is -0<sub>𝔽</sub> or _x_ is *NaN*, then
             1. Let _pattern_ be _patterns_.[[zeroPattern]].
-          1. Else if _x_ &gt; 0, then
+          1. Else if _x_ &gt; 0<sub>𝔽</sub>, then
             1. Let _pattern_ be _patterns_.[[positivePattern]].
           1. Else,
             1. Let _pattern_ be _patterns_.[[negativePattern]].


### PR DESCRIPTION
"Negative zero" cannot be expressed with an ECMA262 mathematical value,
but it may be expressed with an ECMA262 Number value. Update new
references to "negative zero" to use an appropriate type. Update
corresponding references to "zero" to avoid comparing mathematical
values with Number values.

/cc @bakkot
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
