### PR TITLE
Editorial: Move IsValidDateTimeFieldCode to DisplayNames Objects AOs

### DIFF
--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -36,7 +36,6 @@
         1. Return _code_.
       </emu-alg>
     </emu-clause>
-  </emu-clause>
 
     <emu-clause id="sec-isvaliddatetimefieldcode" type="abstract operation">
       <h1>
@@ -113,6 +112,7 @@
         </table>
       </emu-table>
     </emu-clause>
+  </emu-clause>
 
   <emu-clause id="sec-intl-displaynames-constructor">
     <h1>The Intl.DisplayNames Constructor</h1>


### PR DESCRIPTION
Hello!

I was recently implementing DisplayNames v2 for SerenityOS and noticed that `IsValidDateTimeFieldCode` was put in section 12.2 all by itself. It seems it should have been placed under the `Abstract Operations for DisplayNames Objects` section (it even has the indentation in the .html file to align with that).