### PR TITLE
Editorial: Fix ecmarkup warnings

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -149,7 +149,7 @@
         1. Else,
           1. Assert: _hour12_ is *undefined*.
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
-        1. Set _formatOptions_.[[hourCycle]] to _hc_. 
+        1. Set _formatOptions_.[[hourCycle]] to _hc_.
         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
         1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, *"string"*, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -193,9 +193,9 @@
         1. Let _exponent_ be 0.
         1. If _x_ is *NaN*, then
           1. Let _n_ be an implementation- and locale-dependent (ILD) String value indicating the *NaN* value.
-        1. Else if _x_ is *+&infin;*, then
+        1. Else if _x_ is *+&infin;*<sub>𝔽</sub>, then
           1. Let _n_ be an ILD String value indicating positive infinity.
-        1. Else if _x_ is *-&infin;*, then
+        1. Else if _x_ is *-&infin;*<sub>𝔽</sub>, then
           1. Let _n_ be an ILD String value indicating negative infinity.
         1. Else,
           1. If _numberFormat_.[[Style]] is *"percent"*, let _x_ be 100 × _x_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -203,12 +203,12 @@
         1. Else if _x_ is *-&infin;*<sub>𝔽</sub>, then
           1. Let _n_ be an ILD String value indicating negative infinity.
         1. Else,
-          1. If _numberFormat_.[[Style]] is *"percent"*, let _x_ be 100 × _x_.
+          1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ to 100 × _x_.
           1. Let _exponent_ be ComputeExponent(_numberFormat_, _x_).
-          1. Let _x_ be _x_ × 10<sup>-_exponent_</sup>.
+          1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.
           1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_).
           1. Let _n_ be _formatNumberResult_.[[FormattedString]].
-          1. Let _x_ be _formatNumberResult_.[[RoundedNumber]].
+          1. Set _x_ to _formatNumberResult_.[[RoundedNumber]].
         1. Let _pattern_ be GetNumberFormatPattern(_numberFormat_, _x_).
         1. Let _result_ be a new empty List.
         1. Let _patternParts_ be PartitionPattern(_pattern_).

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -203,6 +203,7 @@
         1. Else if _x_ is *-&infin;*<sub>𝔽</sub>, then
           1. Let _n_ be an ILD String value indicating negative infinity.
         1. Else,
+          1. Set _x_ to ℝ(_x_).
           1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ to 100 × _x_.
           1. Let _exponent_ be ComputeExponent(_numberFormat_, _x_).
           1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -182,12 +182,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-partitionnumberpattern" aoid="PartitionNumberPattern">
-      <h1>PartitionNumberPattern ( _numberFormat_, _x_ )</h1>
-
-      <p>
-        The PartitionNumberPattern abstract operation is called with arguments _numberFormat_ (which must be an object initialized as a NumberFormat) and _x_ (which must be a Number or BigInt value), interprets _x_ as a numeric value, and creates the corresponding parts according to the effective locale and the formatting options of _numberFormat_. The following steps are taken:
-      </p>
+    <emu-clause id="sec-partitionnumberpattern" type="abstract operation">
+      <h1>
+        PartitionNumberPattern (
+          _numberFormat_: an object initialized as a NumberFormat,
+          _x_: a Number or a BigInt,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It creates the parts representing the mathematical value of _x_ according to the effective locale and the formatting options of _numberFormat_.</dd>
+      </dl>
 
       <emu-alg>
         1. Let _exponent_ be 0.


### PR DESCRIPTION
```
warning: trailing spaces are not allowed (spelling) at spec/datetimeformat.html:152:54:
  150 |           1. Assert: _hour12_ is *undefined*.
  151 |         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
> 152 |         1. Set _formatOptions_.[[hourCycle]] to _hc_. 
      |                                                      ^
  153 |         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
  154 |         1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, *"string"*, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
  155 |         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.


warning: literal Number or BigInt values should be followed by <sub>𝔽</sub> or <sub>ℤ</sub> respectively (spelling) at spec/numberformat.html:196:27:
  194 |         1. If _x_ is *NaN*, then
  195 |           1. Let _n_ be an implementation- and locale-dependent (ILD) String value indicating the *NaN* value.
> 196 |         1. Else if _x_ is *+&infin;*, then
      |                           ^
  197 |           1. Let _n_ be an ILD String value indicating positive infinity.
  198 |         1. Else if _x_ is *-&infin;*, then
  199 |           1. Let _n_ be an ILD String value indicating negative infinity.


warning: literal Number or BigInt values should be followed by <sub>𝔽</sub> or <sub>ℤ</sub> respectively (spelling) at spec/numberformat.html:198:27:
  196 |         1. Else if _x_ is *+&infin;*, then
  197 |           1. Let _n_ be an ILD String value indicating positive infinity.
> 198 |         1. Else if _x_ is *-&infin;*, then
      |                           ^
  199 |           1. Let _n_ be an ILD String value indicating negative infinity.
  200 |         1. Else,
  201 |           1. If _numberFormat_.[[Style]] is *"percent"*, let _x_ be 100 × _x_.
```