### PR TITLE
Normative: Disallow '_' for calendar , referring to UTS35

### DIFF
--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -266,6 +266,7 @@
           1. Return _code_.
         1. If _type_ is *"calendar"*, then
           1. If _code_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
+          1. If _code_ uses any of the backwards compatibility syntax described in <a href="https://unicode.org/reports/tr35/#BCP_47_Conformance">Unicode Technical Standard #35 LDML § 3.3 BCP 47 Conformance</a>, throw a *RangeError* exception.
           1. Let _code_ be the result of mapping _code_ to lower case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
           1. Return _code_.
         1. If _type_ is *"dateTimeField"*, then


### PR DESCRIPTION
Make it clear "_" is not acceptable for calendar code

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
