### PR TITLE
Editorial: Refactor an example to eliminate horizontal scrolling

### DIFF
--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -335,8 +335,8 @@
 
       <emu-note>
         Example:
-        <emu-alg>1. MakePartsList(*"AA{0}BB"*, *"hour"*, &laquo; Record { [[Type]]: *"integer"*, [[Value]]: *"15"* } &raquo;).</emu-alg>
-        will produce an output List of Records like
+        <emu-alg>1. Return ! MakePartsList(*"AA{0}BB"*, *"hour"*, &laquo; Record { [[Type]]: *"integer"*, [[Value]]: *"15"* } &raquo;).</emu-alg>
+        will return a List of Records like
         <p style="white-space: pre-wrap">
           &laquo;
             { [[Type]]: *"literal"*, [[Value]]: *"AA"*, [[Unit]]: ~empty~},

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -335,16 +335,15 @@
 
       <emu-note>
         Example:
-        <pre>
-          MakePartsList("AA{0}BB", "hour", &laquo; { [[Type]]: "integer", [[Value]]: "15" } &raquo; )
-
-        Output (List of Records):
+        <emu-alg>1. MakePartsList(*"AA{0}BB"*, *"hour"*, &laquo; Record { [[Type]]: *"integer"*, [[Value]]: *"15"* } &raquo;).</emu-alg>
+        will produce an output List of Records like
+        <p style="white-space: pre-wrap">
           &laquo;
-            { [[Type]]: "literal", [[Value]]: "AA", [[Unit]]: empty},
-            { [[Type]]: "integer", [[Value]]: "15", [[Unit]]: "hour"},
-            { [[Type]]: "literal", [[Value]]: "BB", [[Unit]]: empty}
+            { [[Type]]: *"literal"*, [[Value]]: *"AA"*, [[Unit]]: ~empty~},
+            { [[Type]]: *"integer"*, [[Value]]: *"15"*, [[Unit]]: *"hour"*},
+            { [[Type]]: *"literal"*, [[Value]]: *"BB"*, [[Unit]]: ~empty~}
           &raquo;
-        </pre>
+        </p>
       </emu-note>
 
       <emu-alg>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -337,13 +337,13 @@
         Example:
         <emu-alg>1. Return ! MakePartsList(*"AA{0}BB"*, *"hour"*, &laquo; Record { [[Type]]: *"integer"*, [[Value]]: *"15"* } &raquo;).</emu-alg>
         will return a List of Records like
-        <p style="white-space: pre-wrap">
+        <kbd style="font: inherit; white-space: pre-wrap">
           &laquo;
             { [[Type]]: *"literal"*, [[Value]]: *"AA"*, [[Unit]]: ~empty~},
             { [[Type]]: *"integer"*, [[Value]]: *"15"*, [[Unit]]: *"hour"*},
             { [[Type]]: *"literal"*, [[Value]]: *"BB"*, [[Unit]]: ~empty~}
           &raquo;
-        </p>
+        </kbd>
       </emu-note>
 
       <emu-alg>


### PR DESCRIPTION
Fixes a PDF rendering glitch. This should ideally land before cutting the 2022 edition.

before | after
-- | --
scrollbar in rendered PDF:<br>![before](https://user-images.githubusercontent.com/1199584/158880854-6aa06a0b-9ecc-4fd2-ac49-bece29ebac22.png) | no scrollbar:<br> ![after](https://user-images.githubusercontent.com/1199584/158880869-ab5fbb8f-063c-4dfb-b841-45dd05778f39.png)