### PR TITLE
Editorial: Only set dtf.[[HourCycle]] once.

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -73,7 +73,6 @@
         1. Set _dateTimeFormat_.[[Locale]] to _r_.[[locale]].
         1. Let _calendar_ be _r_.[[ca]].
         1. Set _dateTimeFormat_.[[Calendar]] to _calendar_.
-        1. Set _dateTimeFormat_.[[HourCycle]] to _r_.[[hc]].
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
@@ -95,7 +94,7 @@
           1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
-        1. Let _hc_ be _dateTimeFormat_.[[HourCycle]].
+        1. Let _hc_ be _r_.[[hc]].
         1. If _hc_ is *null*, then
           1. Set _hc_ to _hcDefault_.
         1. If _hour12_ is *true*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -77,22 +77,24 @@
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
-        1. Let _hc_ be _r_.[[hc]].
-        1. If _hc_ is *null*, then
-          1. Set _hc_ to _hcDefault_.
+        1. If _r_.[[hc]] is *null*, then
+          1. Let _hc_ be _hcDefault_.
         1. If _hour12_ is *true*, then
           1. If _hcDefault_ is *"h11"* or *"h23"*, then
-            1. Set _hc_ to *"h11"*.
+            1. Let _hc_ be *"h11"*.
           1. Else,
-            1. Set _hc_ to *"h12"*.
+            1. Let _hc_ be *"h12"*.
         1. Else if _hour12_ is *false*, then
           1. If _hcDefault_ is *"h11"* or *"h23"*, then
-            1. Set _hc_ to *"h23"*.
+            1. Let _hc_ be *"h23"*.
           1. Else,
-            1. Set _hc_ to *"h24"*.
+            1. Let _hc_ be *"h24"*.
         1. Else,
+          1. Let _hc_ be _r_.[[hc]].
           1. Assert: _hour12_ is *undefined*.
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
+        1. Let _formatOptions_ be a new Record.
+        1. Set _formatOptions_.[[hourCycle]] to _hc_.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then
           1. Set _timeZone_ to DefaultTimeZone().
@@ -102,7 +104,6 @@
             1. Throw a *RangeError* exception.
           1. Set _timeZone_ to CanonicalizeTimeZoneName(_timeZone_).
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
-        1. Let _formatOptions_ be a new Record.
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
           1. Let _prop_ be the name given in the Property column of the row.
           1. If _prop_ is *"fractionalSecondDigits"*, then
@@ -110,7 +111,6 @@
           1. Else,
             1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
           1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
-        1. Set _formatOptions_.[[hourCycle]] to _hc_.
         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
         1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, *"string"*, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -75,23 +75,6 @@
         1. Set _dateTimeFormat_.[[Calendar]] to _calendar_.
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
-        1. If _timeZone_ is *undefined*, then
-          1. Let _timeZone_ be DefaultTimeZone().
-        1. Else,
-          1. Let _timeZone_ be ? ToString(_timeZone_).
-          1. If the result of IsValidTimeZoneName(_timeZone_) is *false*, then
-            1. Throw a *RangeError* exception.
-          1. Let _timeZone_ be CanonicalizeTimeZoneName(_timeZone_).
-        1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
-        1. Let _formatOptions_ be a new Record.
-        1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
-          1. Let _prop_ be the name given in the Property column of the row.
-          1. If _prop_ is *"fractionalSecondDigits"*, then
-            1. Let _value_ be ? GetNumberOption(_options_, *"fractionalSecondDigits"*, 1, 3, *undefined*).
-          1. Else,
-            1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
-          1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
         1. Let _hc_ be _r_.[[hc]].
@@ -110,6 +93,23 @@
         1. Else,
           1. Assert: _hour12_ is *undefined*.
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
+        1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
+        1. If _timeZone_ is *undefined*, then
+          1. Let _timeZone_ be DefaultTimeZone().
+        1. Else,
+          1. Let _timeZone_ be ? ToString(_timeZone_).
+          1. If the result of IsValidTimeZoneName(_timeZone_) is *false*, then
+            1. Throw a *RangeError* exception.
+          1. Let _timeZone_ be CanonicalizeTimeZoneName(_timeZone_).
+        1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
+        1. Let _formatOptions_ be a new Record.
+        1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
+          1. Let _prop_ be the name given in the Property column of the row.
+          1. If _prop_ is *"fractionalSecondDigits"*, then
+            1. Let _value_ be ? GetNumberOption(_options_, *"fractionalSecondDigits"*, 1, 3, *undefined*).
+          1. Else,
+            1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, &laquo; the strings given in the Values column of the row &raquo;, *undefined*).
+          1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
         1. Set _formatOptions_.[[hourCycle]] to _hc_.
         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
         1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, *"string"*, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -95,12 +95,12 @@
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then
-          1. Let _timeZone_ be DefaultTimeZone().
+          1. Set _timeZone_ to DefaultTimeZone().
         1. Else,
-          1. Let _timeZone_ be ? ToString(_timeZone_).
+          1. Set _timeZone_ to ? ToString(_timeZone_).
           1. If the result of IsValidTimeZoneName(_timeZone_) is *false*, then
             1. Throw a *RangeError* exception.
-          1. Let _timeZone_ be CanonicalizeTimeZoneName(_timeZone_).
+          1. Set _timeZone_ to CanonicalizeTimeZoneName(_timeZone_).
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
         1. Let _formatOptions_ be a new Record.
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do


### PR DESCRIPTION
The field is set, read, and then immediately overwritten, without any other possible use in between.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
