### PR TITLE
Editorial: Don't refer to 'normalized' in IsWellFormedCurrencyCode before it is set

### DIFF
--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -151,7 +151,7 @@
       </p>
 
       <emu-alg>
-        1. If the length of _normalized_ is not 3, return *false*.
+        1. If the length of _currency_ is not 3, return *false*.
         1. Let _normalized_ be the ASCII-uppercase of _currency_.
         1. If _normalized_ contains any code unit outside of 0x0041 through 0x005A (corresponding to Unicode characters LATIN CAPITAL LETTER A through LATIN CAPITAL LETTER Z), return *false*.
         1. Return *true*.


### PR DESCRIPTION
Minor issue I noticed while looking over recent changes to the spec. In `IsWellFormedCurrencyCode`, the creation of the `normalized` string was moved lower in the AO, after the step to check its length.