### PR TITLE
Editorial: Update NumberFormat to conform with conventions

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -564,9 +564,9 @@
           1. Let _n_ be an ILD String value indicating negative infinity.
         1. Else,
           1. Set _x_ to ℝ(_x_).
-          1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ to 100 × _x_.
+          1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ to 100 &times; _x_.
           1. Let _exponent_ be ComputeExponent(_numberFormat_, _x_).
-          1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.
+          1. Set _x_ to _x_ &times; 10<sup>-_exponent_</sup>.
           1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_).
           1. Let _n_ be _formatNumberResult_.[[FormattedString]].
           1. Set _x_ to _formatNumberResult_.[[RoundedNumber]].
@@ -1030,11 +1030,11 @@
         1. Else,
           1. Let _e_ and _n_ be integers such that 10<sup>_p_ - 1</sup> &le; _n_ &lt; 10<sup>_p_</sup> and for which _n_ &times; 10<sup>_e_ - _p_ + 1</sup> - _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ &times; 10<sup>_e_ - _p_ + 1</sup> is larger.
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
-          1. Let _xFinal_ be _n_ × 10<sup>_e_ - _p_ + 1</sup>.
-        1. If _e_ ≥ (_p_ - 1), then
+          1. Let _xFinal_ be _n_ &times; 10<sup>_e_ - _p_ + 1</sup>.
+        1. If _e_ &ge; (_p_ - 1), then
           1. Let _m_ be the string-concatenation of _m_ and _e_ - _p_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Let _int_ be _e_ + 1.
-        1. Else if _e_ ≥ 0, then
+        1. Else if _e_ &ge; 0, then
           1. Let _m_ be the string-concatenation of the first _e_ + 1 characters of _m_, the character *"."*, and the remaining _p_ - (_e_ + 1) characters of _m_.
           1. Let _int_ be _e_ + 1.
         1. Else,
@@ -1065,9 +1065,9 @@
         1. Let _n_ be an integer for which the exact mathematical value of _n_ / 10<sup>_f_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
         1. Let _xFinal_ be _n_ / 10<sup>_f_</sup>.
         1. If _n_ = 0, let _m_ be *"0"*. Otherwise, let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
-        1. If _f_ ≠ 0, then
+        1. If _f_ &ne; 0, then
           1. Let _k_ be the number of characters in _m_.
-          1. If _k_ ≤ _f_, then
+          1. If _k_ &le; _f_, then
             1. Let _z_ be the String value consisting of _f_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _m_ be the string-concatenation of _z_ and _m_.
             1. Let _k_ be _f_ + 1.
@@ -1200,7 +1200,7 @@
           1. Let _x_ = -_x_.
         1. Let _magnitude_ be the base 10 logarithm of _x_ rounded down to the nearest integer.
         1. Let _exponent_ be ComputeExponentForMagnitude(_numberFormat_, _magnitude_).
-        1. Let _x_ be _x_ × 10<sup>-_exponent_</sup>.
+        1. Let _x_ be _x_ &times; 10<sup>-_exponent_</sup>.
         1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_).
         1. If _formatNumberResult_.[[RoundedNumber]] = 0, then
           1. Return _exponent_.
@@ -1224,7 +1224,7 @@
           1. Return _magnitude_.
         1. Else if _notation_ is *"engineering"*, then
           1. Let _thousands_ be the greatest integer that is not greater than _magnitude_ / 3.
-          1. Return _thousands_ × 3.
+          1. Return _thousands_ &times; 3.
         1. Else,
           1. Assert: _notation_ is *"compact"*.
           1. Let _exponent_ be an implementation- and locale-dependent (ILD) integer by which to scale a number of the given magnitude in compact notation for the current locale.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -534,7 +534,7 @@
         1. Let _int_ be _result_.[[IntegerDigitsCount]].
         1. Let _minInteger_ be _intlObject_.[[MinimumIntegerDigits]].
         1. If _int_ < _minInteger_, then
-          1. Let _forwardZeros_ be the String consisting of _minInteger_–_int_ occurrences of the character *"0"*.
+          1. Let _forwardZeros_ be the String consisting of _minInteger_–_int_ occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Set _string_ to the string-concatenation of _forwardZeros_ and _string_.
         1. If _isNegative_, then
           1. Let _x_ be -_x_.
@@ -1024,7 +1024,7 @@
         1. Set x to ℝ(x).
         1. Let _p_ be _maxPrecision_.
         1. If _x_ = 0, then
-          1. Let _m_ be the String consisting of _p_ occurrences of the character *"0"*.
+          1. Let _m_ be the String consisting of _p_ occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Let _e_ be 0.
           1. Let _xFinal_ be 0.
         1. Else,
@@ -1032,14 +1032,14 @@
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
           1. Let _xFinal_ be _n_ × 10<sup>_e_–_p_+1</sup>.
         1. If _e_ ≥ _p_–1, then
-          1. Let _m_ be the string-concatenation of _m_ and _e_–_p_+1 occurrences of the character *"0"*.
+          1. Let _m_ be the string-concatenation of _m_ and _e_–_p_+1 occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Let _int_ be _e_+1.
         1. Else if _e_ ≥ 0, then
           1. Let _m_ be the string-concatenation of the first _e_+1 characters of _m_, the character *"."*, and the remaining _p_–(_e_+1) characters of _m_.
           1. Let _int_ be _e_+1.
         1. Else,
           1. Assert: _e_ < 0.
-          1. Let _m_ be the string-concatenation of *"0."*, –(_e_+1) occurrences of the character *"0"*, and _m_.
+          1. Let _m_ be the string-concatenation of *"0."*, –(_e_+1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
           1. Let _int_ be 1.
         1. If _m_ contains the character *"."*, and _maxPrecision_ > _minPrecision_, then
           1. Let _cut_ be _maxPrecision_ – _minPrecision_.
@@ -1068,7 +1068,7 @@
         1. If _f_ ≠ 0, then
           1. Let _k_ be the number of characters in _m_.
           1. If _k_ ≤ _f_, then
-            1. Let _z_ be the String value consisting of _f_+1–_k_ occurrences of the character *"0"*.
+            1. Let _z_ be the String value consisting of _f_+1–_k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _m_ be the string-concatenation of _z_ and _m_.
             1. Let _k_ be _f_+1.
           1. Let _a_ be the first _k_–_f_ characters of _m_, and let _b_ be the remaining _f_ characters of _m_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1032,14 +1032,14 @@
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
           1. Let _xFinal_ be _n_ &times; 10<sup>_e_ - _p_ + 1</sup>.
         1. If _e_ &ge; (_p_ - 1), then
-          1. Let _m_ be the string-concatenation of _m_ and _e_ - _p_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
+          1. Set _m_ to the string-concatenation of _m_ and _e_ - _p_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Let _int_ be _e_ + 1.
         1. Else if _e_ &ge; 0, then
-          1. Let _m_ be the string-concatenation of the first _e_ + 1 code units of _m_, the code unit 0x002E (FULL STOP), and the remaining _p_ - (_e_ + 1) code units of _m_.
+          1. Set _m_ to the string-concatenation of the first _e_ + 1 code units of _m_, the code unit 0x002E (FULL STOP), and the remaining _p_ - (_e_ + 1) code units of _m_.
           1. Let _int_ be _e_ + 1.
         1. Else,
           1. Assert: _e_ &lt; 0.
-          1. Let _m_ be the string-concatenation of *"0."*, -(_e_ + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
+          1. Set _m_ to the string-concatenation of *"0."*, -(_e_ + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
           1. Let _int_ be 1.
         1. If _m_ contains the code unit 0x002E (FULL STOP) and _maxPrecision_ &gt; _minPrecision_, then
           1. Let _cut_ be _maxPrecision_ - _minPrecision_.
@@ -1069,10 +1069,10 @@
           1. Let _k_ be the length of _m_.
           1. If _k_ &le; _f_, then
             1. Let _z_ be the String value consisting of _f_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
-            1. Let _m_ be the string-concatenation of _z_ and _m_.
-            1. Let _k_ be _f_ + 1.
+            1. Set _m_ to the string-concatenation of _z_ and _m_.
+            1. Set _k_ to _f_ + 1.
           1. Let _a_ be the first _k_ - _f_ code units of _m_, and let _b_ be the remaining _f_ code units of _m_.
-          1. Let _m_ be the string-concatenation of _a_, *"."*, and _b_.
+          1. Set _m_ to the string-concatenation of _a_, *"."*, and _b_.
           1. Let _int_ be the length of _a_.
         1. Else, let _int_ be the length of _m_.
         1. Let _cut_ be _maxFraction_ - _minFraction_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1033,10 +1033,10 @@
           1. Let _xFinal_ be _n_ × 10<sup>_e_ - _p_ + 1</sup>.
         1. If _e_ ≥ (_p_ - 1), then
           1. Let _m_ be the string-concatenation of _m_ and _e_ - _p_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
-          1. Let _int_ be _e_+1.
+          1. Let _int_ be _e_ + 1.
         1. Else if _e_ ≥ 0, then
-          1. Let _m_ be the string-concatenation of the first _e_+1 characters of _m_, the character *"."*, and the remaining _p_ - (_e_ + 1) characters of _m_.
-          1. Let _int_ be _e_+1.
+          1. Let _m_ be the string-concatenation of the first _e_ + 1 characters of _m_, the character *"."*, and the remaining _p_ - (_e_ + 1) characters of _m_.
+          1. Let _int_ be _e_ + 1.
         1. Else,
           1. Assert: _e_ &lt; 0.
           1. Let _m_ be the string-concatenation of *"0."*, -(_e_ + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
@@ -1070,7 +1070,7 @@
           1. If _k_ ≤ _f_, then
             1. Let _z_ be the String value consisting of _f_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _m_ be the string-concatenation of _z_ and _m_.
-            1. Let _k_ be _f_+1.
+            1. Let _k_ be _f_ + 1.
           1. Let _a_ be the first _k_ - _f_ characters of _m_, and let _b_ be the remaining _f_ characters of _m_.
           1. Let _m_ be the string-concatenation of _a_, *"."*, and _b_.
           1. Let _int_ be the number of characters in _a_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -252,7 +252,7 @@
           The value of the aforementioned fields (the sign-dependent pattern fields) must be string values that must contain the substring *"{number}"*.
           *"positivePattern"* must contain the substring *"{plusSign}"* but not *"{minusSign}"*; *"negativePattern"* must contain the substring *"{minusSign}"* but not *"{plusSign}"*; and *"zeroPattern"* must not contain either *"{plusSign}"* or *"{minusSign}"*.
           Additionally, the values within the *"percent"* field must also contain the substring *"{percentSign}"*; the values within the *"currency"* field must also contain one or more of the following substrings: *"{currencyCode}"*, *"{currencyPrefix}"*, or *"{currencySuffix}"*; and the values within the *"unit"* field must also contain one or more of the following substrings: *"{unitPrefix}"* or *"{unitSuffix}"*.
-          The pattern strings must not contain any characters in the General Category "Number, decimal digit" as specified by the Unicode Standard.
+          The pattern strings, when interpreted as a sequence of UTF-16 encoded code points as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, must not contain any code points in the General Category "Number, decimal digit" as specified by the Unicode Standard.
         </li>
         <li>[[LocaleData]].[[&lt;_locale_&gt;]] must also have a [[notationSubPatterns]] field for all locale values _locale_. The value of this field must be a Record, which must have two fields: [[scientific]] and [[compact]]. The [[scientific]] field must be a string value containing the substrings *"{number}"*, *"{scientificSeparator}"*, and *"{scientificExponent}"*. The [[compact]] field must be a Record with two fields: *"short"* and *"long"*. Each of these fields must be a Record with integer keys corresponding to all discrete magnitudes the implementation supports for compact notation. Each of these fields must be a string value which may contain the substring *"{number}"*. Strings descended from *"short"* must contain the substring *"{compactSymbol}"*, and strings descended from *"long"* must contain the substring *"{compactName}"*.</li>
       </ul>
@@ -968,7 +968,7 @@
       </emu-table>
 
       <emu-note>
-        The computations rely on String values and locations within numeric strings that are dependent upon the implementation and the effective locale of _numberFormat_ ("ILD") or upon the implementation, the effective locale, and the numbering system of _numberFormat_ ("ILND"). The ILD and ILND Strings mentioned, other than those for currency names, must not contain any characters in the General Category "Number, decimal digit" as specified by the Unicode Standard.
+        The computations rely on String values and locations within numeric strings that are dependent upon the implementation and the effective locale of _numberFormat_ ("ILD") or upon the implementation, the effective locale, and the numbering system of _numberFormat_ ("ILND"). The ILD and ILND Strings mentioned, other than those for currency names, must not contain any code points in the General Category "Number, decimal digit" as specified by the Unicode Standard.
       </emu-note>
 
       <emu-note>
@@ -1035,19 +1035,19 @@
           1. Let _m_ be the string-concatenation of _m_ and _e_ - _p_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Let _int_ be _e_ + 1.
         1. Else if _e_ &ge; 0, then
-          1. Let _m_ be the string-concatenation of the first _e_ + 1 characters of _m_, the character *"."*, and the remaining _p_ - (_e_ + 1) characters of _m_.
+          1. Let _m_ be the string-concatenation of the first _e_ + 1 code units of _m_, the code unit 0x002E (FULL STOP), and the remaining _p_ - (_e_ + 1) code units of _m_.
           1. Let _int_ be _e_ + 1.
         1. Else,
           1. Assert: _e_ &lt; 0.
           1. Let _m_ be the string-concatenation of *"0."*, -(_e_ + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
           1. Let _int_ be 1.
-        1. If _m_ contains the character *"."*, and _maxPrecision_ &gt; _minPrecision_, then
+        1. If _m_ contains the code unit 0x002E (FULL STOP) and _maxPrecision_ &gt; _minPrecision_, then
           1. Let _cut_ be _maxPrecision_ - _minPrecision_.
-          1. Repeat, while _cut_ &gt; 0 and the last character of _m_ is *"0"*,
-            1. Remove the last character from _m_.
+          1. Repeat, while _cut_ &gt; 0 and the last code unit of _m_ is 0x0030 (DIGIT ZERO),
+            1. Remove the last code unit from _m_.
             1. Decrease _cut_ by 1.
-          1. If the last character of _m_ is *"."*, then
-            1. Remove the last character from _m_.
+          1. If the last code unit of _m_ is 0x002E (FULL STOP), then
+            1. Remove the last code unit from _m_.
         1. Return the Record { [[FormattedString]]: _m_, [[RoundedNumber]]: _xFinal_, [[IntegerDigitsCount]]: _int_ }.
       </emu-alg>
     </emu-clause>
@@ -1066,21 +1066,21 @@
         1. Let _xFinal_ be _n_ / 10<sup>_f_</sup>.
         1. If _n_ = 0, let _m_ be *"0"*. Otherwise, let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
         1. If _f_ &ne; 0, then
-          1. Let _k_ be the number of characters in _m_.
+          1. Let _k_ be the length of _m_.
           1. If _k_ &le; _f_, then
             1. Let _z_ be the String value consisting of _f_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _m_ be the string-concatenation of _z_ and _m_.
             1. Let _k_ be _f_ + 1.
-          1. Let _a_ be the first _k_ - _f_ characters of _m_, and let _b_ be the remaining _f_ characters of _m_.
+          1. Let _a_ be the first _k_ - _f_ code units of _m_, and let _b_ be the remaining _f_ code units of _m_.
           1. Let _m_ be the string-concatenation of _a_, *"."*, and _b_.
-          1. Let _int_ be the number of characters in _a_.
-        1. Else, let _int_ be the number of characters in _m_.
+          1. Let _int_ be the length of _a_.
+        1. Else, let _int_ be the length of _m_.
         1. Let _cut_ be _maxFraction_ - _minFraction_.
-        1. Repeat, while _cut_ &gt; 0 and the last character of _m_ is *"0"*,
-          1. Remove the last character from _m_.
+        1. Repeat, while _cut_ &gt; 0 and the last code unit of _m_ is 0x0030 (DIGIT ZERO),
+          1. Remove the last code unit from _m_.
           1. Decrease _cut_ by 1.
-        1. If the last character of _m_ is *"."*, then
-          1. Remove the last character from _m_.
+        1. If the last code unit of _m_ is 0x002E (FULL STOP), then
+          1. Remove the last code unit from _m_.
         1. Return the Record { [[FormattedString]]: _m_, [[RoundedNumber]]: _xFinal_, [[IntegerDigitsCount]]: _int_ }.
       </emu-alg>
     </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -533,7 +533,7 @@
         1. Let _string_ be _result_.[[FormattedString]].
         1. Let _int_ be _result_.[[IntegerDigitsCount]].
         1. Let _minInteger_ be _intlObject_.[[MinimumIntegerDigits]].
-        1. If _int_ < _minInteger_, then
+        1. If _int_ &lt; _minInteger_, then
           1. Let _forwardZeros_ be the String consisting of _minInteger_–_int_ occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Set _string_ to the string-concatenation of _forwardZeros_ and _string_.
         1. If _isNegative_, then
@@ -644,7 +644,7 @@
                 1. Replace each _digit_ in _n_ with the value of _digits_[_digit_].
               1. Else use an implementation dependent algorithm to map _n_ to the appropriate representation of _n_ in the given numbering system.
               1. Let _decimalSepIndex_ be ! StringIndexOf(_n_, *"."*, 0).
-              1. If _decimalSepIndex_ > 0, then
+              1. If _decimalSepIndex_ &gt; 0, then
                 1. Let _integer_ be the substring of _n_ from position 0, inclusive, to position _decimalSepIndex_, exclusive.
                 1. Let _fraction_ be the substring of _n_ from position _decimalSepIndex_, exclusive, to the end of _n_.
               1. Else,
@@ -1038,12 +1038,12 @@
           1. Let _m_ be the string-concatenation of the first _e_+1 characters of _m_, the character *"."*, and the remaining _p_–(_e_+1) characters of _m_.
           1. Let _int_ be _e_+1.
         1. Else,
-          1. Assert: _e_ < 0.
+          1. Assert: _e_ &lt; 0.
           1. Let _m_ be the string-concatenation of *"0."*, –(_e_+1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
           1. Let _int_ be 1.
-        1. If _m_ contains the character *"."*, and _maxPrecision_ > _minPrecision_, then
+        1. If _m_ contains the character *"."*, and _maxPrecision_ &gt; _minPrecision_, then
           1. Let _cut_ be _maxPrecision_ – _minPrecision_.
-          1. Repeat, while _cut_ > 0 and the last character of _m_ is *"0"*,
+          1. Repeat, while _cut_ &gt; 0 and the last character of _m_ is *"0"*,
             1. Remove the last character from _m_.
             1. Decrease _cut_ by 1.
           1. If the last character of _m_ is *"."*, then
@@ -1076,7 +1076,7 @@
           1. Let _int_ be the number of characters in _a_.
         1. Else, let _int_ be the number of characters in _m_.
         1. Let _cut_ be _maxFraction_ – _minFraction_.
-        1. Repeat, while _cut_ > 0 and the last character of _m_ is *"0"*,
+        1. Repeat, while _cut_ &gt; 0 and the last character of _m_ is *"0"*,
           1. Remove the last character from _m_.
           1. Decrease _cut_ by 1.
         1. If the last character of _m_ is *"."*, then

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -534,7 +534,7 @@
         1. Let _int_ be _result_.[[IntegerDigitsCount]].
         1. Let _minInteger_ be _intlObject_.[[MinimumIntegerDigits]].
         1. If _int_ &lt; _minInteger_, then
-          1. Let _forwardZeros_ be the String consisting of _minInteger_–_int_ occurrences of the code unit 0x0030 (DIGIT ZERO).
+          1. Let _forwardZeros_ be the String consisting of _minInteger_ - _int_ occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Set _string_ to the string-concatenation of _forwardZeros_ and _string_.
         1. If _isNegative_, then
           1. Let _x_ be -_x_.
@@ -1030,19 +1030,19 @@
         1. Else,
           1. Let _e_ and _n_ be integers such that 10<sup>_p_ - 1</sup> &le; _n_ &lt; 10<sup>_p_</sup> and for which _n_ &times; 10<sup>_e_ - _p_ + 1</sup> - _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ &times; 10<sup>_e_ - _p_ + 1</sup> is larger.
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
-          1. Let _xFinal_ be _n_ × 10<sup>_e_–_p_+1</sup>.
-        1. If _e_ ≥ _p_–1, then
-          1. Let _m_ be the string-concatenation of _m_ and _e_–_p_+1 occurrences of the code unit 0x0030 (DIGIT ZERO).
+          1. Let _xFinal_ be _n_ × 10<sup>_e_ - _p_ + 1</sup>.
+        1. If _e_ ≥ (_p_ - 1), then
+          1. Let _m_ be the string-concatenation of _m_ and _e_ - _p_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Let _int_ be _e_+1.
         1. Else if _e_ ≥ 0, then
-          1. Let _m_ be the string-concatenation of the first _e_+1 characters of _m_, the character *"."*, and the remaining _p_–(_e_+1) characters of _m_.
+          1. Let _m_ be the string-concatenation of the first _e_+1 characters of _m_, the character *"."*, and the remaining _p_ - (_e_ + 1) characters of _m_.
           1. Let _int_ be _e_+1.
         1. Else,
           1. Assert: _e_ &lt; 0.
-          1. Let _m_ be the string-concatenation of *"0."*, –(_e_+1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
+          1. Let _m_ be the string-concatenation of *"0."*, -(_e_ + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
           1. Let _int_ be 1.
         1. If _m_ contains the character *"."*, and _maxPrecision_ &gt; _minPrecision_, then
-          1. Let _cut_ be _maxPrecision_ – _minPrecision_.
+          1. Let _cut_ be _maxPrecision_ - _minPrecision_.
           1. Repeat, while _cut_ &gt; 0 and the last character of _m_ is *"0"*,
             1. Remove the last character from _m_.
             1. Decrease _cut_ by 1.
@@ -1062,20 +1062,20 @@
       <emu-alg>
         1. Set x to ℝ(x).
         1. Let _f_ be _maxFraction_.
-        1. Let _n_ be an integer for which the exact mathematical value of _n_ / 10<sup>_f_</sup> – _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
+        1. Let _n_ be an integer for which the exact mathematical value of _n_ / 10<sup>_f_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
         1. Let _xFinal_ be _n_ / 10<sup>_f_</sup>.
         1. If _n_ = 0, let _m_ be *"0"*. Otherwise, let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
         1. If _f_ ≠ 0, then
           1. Let _k_ be the number of characters in _m_.
           1. If _k_ ≤ _f_, then
-            1. Let _z_ be the String value consisting of _f_+1–_k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
+            1. Let _z_ be the String value consisting of _f_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Let _m_ be the string-concatenation of _z_ and _m_.
             1. Let _k_ be _f_+1.
-          1. Let _a_ be the first _k_–_f_ characters of _m_, and let _b_ be the remaining _f_ characters of _m_.
+          1. Let _a_ be the first _k_ - _f_ characters of _m_, and let _b_ be the remaining _f_ characters of _m_.
           1. Let _m_ be the string-concatenation of _a_, *"."*, and _b_.
           1. Let _int_ be the number of characters in _a_.
         1. Else, let _int_ be the number of characters in _m_.
-        1. Let _cut_ be _maxFraction_ – _minFraction_.
+        1. Let _cut_ be _maxFraction_ - _minFraction_.
         1. Repeat, while _cut_ &gt; 0 and the last character of _m_ is *"0"*,
           1. Remove the last character from _m_.
           1. Decrease _cut_ by 1.
@@ -1205,7 +1205,7 @@
         1. If _formatNumberResult_.[[RoundedNumber]] = 0, then
           1. Return _exponent_.
         1. Let _newMagnitude_ be the base 10 logarithm of _formatNumberResult_.[[RoundedNumber]] rounded down to the nearest integer.
-        1. If _newMagnitude_ is _magnitude_ – _exponent_, then
+        1. If _newMagnitude_ is _magnitude_ - _exponent_, then
           1. Return _exponent_.
         1. Return ComputeExponentForMagnitude(_numberFormat_, _magnitude_ + 1).
       </emu-alg>


### PR DESCRIPTION
* Align construction of a String of repeated code units with ECMA-262
* Align mathematical formulas and character escaping with ECMA-262
* Refer to String elements as "code point" rather than "character"
* Replace improper use of "let" with "set"