### PR TITLE
Editorial: Cleanup CompareStrings

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -219,12 +219,43 @@
           Behaviour as described below depends upon locale-sensitive identification of the sequence of collation elements for a string, in particular "base letters", and different base letters always compare as unequal (causing the strings containing them to also compare as unequal). Results of comparing variations of the same base letter with different case, diacritic marks, or potentially other aspects further depends upon _collator_.[[Sensitivity]] as follows:
         </p>
 
-        <ul>
-          <li>*"base"*: Characters with the same base letter do not compare as unequal, regardless of differences in case and/or diacritic marks. Examples: a ≠ b, a = á, a = A.</li>
-          <li>*"accent"*: Characters with the same base letter compare as unequal only if they differ in accents and/or other diacritic marks, regardless of differences in case. Examples: a ≠ b, a ≠ á, a = A.</li>
-          <li>*"case"*: Characters with the same base letter compare as unequal only if they differ in case, regardless of differences in accents and/or other diacritic marks. Examples: a ≠ b, a = á, a ≠ A.</li>
-          <li>*"variant"*: Characters with the same base letter compare as unequal if they differ in case, diacritic marks, and/or potentially other differences. Examples: a ≠ b, a ≠ á, a ≠ A.</li>
-        </ul>
+        <emu-table id="table-collator-comparestrings-sensitivity">
+          <emu-caption>Effects of Collator Sensitivity</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>_collator_.[[Sensitivity]]</th>
+                <th>Description</th>
+                <th>*"a"* vs. *"á"*</th>
+                <th>*"a"* vs. *"A"*</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>*"base"*</td>
+              <td>Characters with the same base letter do not compare as unequal, regardless of differences in case and/or diacritic marks.</td>
+              <td>equal</td>
+              <td>equal</td>
+            </tr>
+            <tr>
+              <td>*"accent"*</td>
+              <td>Characters with the same base letter compare as unequal only if they differ in accents and/or other diacritic marks, regardless of differences in case.</td>
+              <td>not equal</td>
+              <td>equal</td>
+            </tr>
+            <tr>
+              <td>*"case"*</td>
+              <td>Characters with the same base letter compare as unequal only if they differ in case, regardless of differences in accents and/or other diacritic marks.</td>
+              <td>equal</td>
+              <td>not equal</td>
+            </tr>
+            <tr>
+              <td>*"variant"*</td>
+              <td>Characters with the same base letter compare as unequal if they differ in case, diacritic marks, and/or potentially other differences.</td>
+              <td>not equal</td>
+              <td>not equal</td>
+            </tr>
+          </table>
+        </emu-table>
 
         <emu-note>
           The mapping from input code points to base letters can include arbitrary contractions, expansions, and collisions, including those that apply special treatment to certain characters with diacritic marks. For example, in Swedish, "ö" is a base letter that differs from "o", and "v" and "w" are considered to be the same base letter. In Slovak, "ch" is a single base letter, and in English, "æ" is a sequence of base letters starting with "a" and ending with "e".

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -216,18 +216,18 @@
         </p>
 
         <p>
-          Behaviour depends upon _collator_.[[Sensitivity]] as follows:
+          Behaviour as described below depends upon locale-sensitive identification of the sequence of collation elements for a string, in particular "base letters", and different base letters always compare as unequal (causing the strings containing them to also compare as unequal). Results of comparing variations of the same base letter with different case, diacritic marks, or potentially other aspects further depends upon _collator_.[[Sensitivity]] as follows:
         </p>
 
         <ul>
-          <li>*"base"*: Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A.</li>
-          <li>*"accent"*: Only strings that differ in base letters or accents and other diacritic marks compare as unequal. Examples: a ≠ b, a ≠ á, a = A.</li>
-          <li>*"case"*: Only strings that differ in base letters or case compare as unequal. Examples: a ≠ b, a = á, a ≠ A.</li>
-          <li>*"variant"*: Strings that differ in base letters, accents and other diacritic marks, or case compare as unequal. Other differences may also be taken into consideration. Examples: a ≠ b, a ≠ á, a ≠ A.</li>
+          <li>*"base"*: Characters with the same base letter do not compare as unequal, regardless of differences in case and/or diacritic marks. Examples: a ≠ b, a = á, a = A.</li>
+          <li>*"accent"*: Characters with the same base letter compare as unequal only if they differ in accents and/or other diacritic marks, regardless of differences in case. Examples: a ≠ b, a ≠ á, a = A.</li>
+          <li>*"case"*: Characters with the same base letter compare as unequal only if they differ in case, regardless of differences in accents and/or other diacritic marks. Examples: a ≠ b, a = á, a ≠ A.</li>
+          <li>*"variant"*: Characters with the same base letter compare as unequal if they differ in case, diacritic marks, and/or potentially other differences. Examples: a ≠ b, a ≠ á, a ≠ A.</li>
         </ul>
 
         <emu-note>
-        In some languages, certain letters with diacritic marks are considered base letters. For example, in Swedish, "ö" is a base letter that's different from "o".
+          The mapping from input code points to base letters can include arbitrary contractions, expansions, and collisions, including those that apply special treatment to certain characters with diacritic marks. For example, in Swedish, "ö" is a base letter that differs from "o", and "v" and "w" are considered to be the same base letter. In Slovak, "ch" is a single base letter, and in English, "æ" is a sequence of base letters starting with "a" and ending with "e".
         </emu-note>
 
         <p>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -222,9 +222,9 @@
         <emu-table id="table-collator-comparestrings-sensitivity">
           <emu-caption>Effects of Collator Sensitivity</emu-caption>
           <table class="real-table">
-            <thead>
+            <thead style="white-space: nowrap">
               <tr>
-                <th>_collator_.[[Sensitivity]]</th>
+                <th>[[Sensitivity]]</th>
                 <th>Description</th>
                 <th>*"a"* vs. *"á"*</th>
                 <th>*"a"* vs. *"A"*</th>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -212,7 +212,7 @@
         <h1>CompareStrings ( _collator_, _x_, _y_ )</h1>
 
         <p>
-          When the CompareStrings abstract operation is called with arguments _collator_ (which must be an object initialized as a Collator), _x_ and _y_ (which must be String values), it returns a Number other than *NaN* that represents the result of a locale-sensitive String comparison of _x_ with _y_. The two Strings are compared in an implementation-defined fashion. The result is intended to order String values in the sort order specified by the effective locale and collation options computed during construction of _collator_, and will be negative, zero, or positive, depending on whether _x_ comes before _y_ in the sort order, the Strings are equal under the sort order, or _x_ comes after _y_ in the sort order, respectively. String values must be interpreted as UTF-16 code unit sequences, and a surrogate pair (a code unit in the range 0xD800 to 0xDBFF followed by a code unit in the range 0xDC00 to 0xDFFF) within a string must be interpreted as the corresponding code point.
+          When the CompareStrings abstract operation is called with arguments _collator_ (which must be an object initialized as a Collator), _x_ and _y_ (which must be String values), it returns a Number other than *NaN* representing the result of an implementation-defined locale-sensitive String comparison of _x_ with _y_. The result is intended to correspond with a sort order of String values according to the effective locale and collation options of _collator_, and will be negative when _x_ is ordered before _y_, positive when _x_ is ordered after _y_, and zero in all other cases (representing no relative ordering between _x_ and _y_). String values must be interpreted as UTF-16 code unit sequences as described in es2023, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and a surrogate pair (a code unit in the range 0xD800 to 0xDBFF followed by a code unit in the range 0xDC00 to 0xDFFF) within a string must be interpreted as the corresponding code point.
         </p>
 
         <p>
@@ -239,11 +239,7 @@
         </p>
 
         <p>
-          The CompareStrings abstract operation with any given _collator_ argument, if considered as a function of the remaining two arguments _x_ and _y_, must be a consistent comparison function (as defined in es2023, <emu-xref href="#sec-array.prototype.sort"></emu-xref>) on the set of all Strings.
-        </p>
-
-        <p>
-          The actual return values are implementation-defined to permit implementers to encode additional information in the value. The method is required to return *+0*<sub>𝔽</sub> when comparing Strings that are considered canonically equivalent by the Unicode Standard.
+          The actual return values are implementation-defined to permit encoding additional information in them, but this operation for any given _collator_, when considered as a function of _x_ and _y_, is required to be a consistent comparator defining a total ordering on the set of all Strings. This operation is also required to recognize and honour canonical equivalence according to the Unicode Standard, including returning *+0*<sub>𝔽</sub> when comparing distinguishable Strings that are canonically equivalent.
         </p>
 
         <emu-note>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -235,7 +235,7 @@
         </p>
 
         <p>
-          For the interpretation of options settable through extension keys, see Unicode Technical Standard 35.
+          For the interpretation of options settable through locale extension keys, see <a href="https://unicode.org/reports/tr35/#Key_And_Type_Definitions_">Unicode Technical Standard #35 LDML § 3.6.1 U Extension Key And Type Definitions</a>.
         </p>
 
         <p>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -216,14 +216,14 @@
         </p>
 
         <p>
-          The sensitivity of _collator_ is interpreted as follows:
+          Behaviour depends upon _collator_.[[Sensitivity]] as follows:
         </p>
 
         <ul>
-          <li>base: Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A.</li>
-          <li>accent: Only strings that differ in base letters or accents and other diacritic marks compare as unequal. Examples: a ≠ b, a ≠ á, a = A.</li>
-          <li>case: Only strings that differ in base letters or case compare as unequal. Examples: a ≠ b, a = á, a ≠ A.</li>
-          <li>variant: Strings that differ in base letters, accents and other diacritic marks, or case compare as unequal. Other differences may also be taken into consideration. Examples: a ≠ b, a ≠ á, a ≠ A.</li>
+          <li>*"base"*: Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A.</li>
+          <li>*"accent"*: Only strings that differ in base letters or accents and other diacritic marks compare as unequal. Examples: a ≠ b, a ≠ á, a = A.</li>
+          <li>*"case"*: Only strings that differ in base letters or case compare as unequal. Examples: a ≠ b, a = á, a ≠ A.</li>
+          <li>*"variant"*: Strings that differ in base letters, accents and other diacritic marks, or case compare as unequal. Other differences may also be taken into consideration. Examples: a ≠ b, a ≠ á, a ≠ A.</li>
         </ul>
 
         <emu-note>
@@ -231,7 +231,7 @@
         </emu-note>
 
         <p>
-          If the collator is set to ignore punctuation, then strings that differ only in punctuation compare as equal.
+          If _collator_.[[IgnorePunctuation]] is *true*, then punctuation is ignored (e.g., strings that differ only in punctuation compare as equal).
         </p>
 
         <p>


### PR DESCRIPTION
* Align with ECMA-262 [String.prototype.localeCompare](https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.localecompare).
* Reference _collator_ properties (with correct data type).
* Link to UTS \#35.
* Elaborate on "base letter" and provide more examples.
* Clarify the effects of [[Sensitivity]] by switching to a table.