### PR TITLE
Editorial: Replace use of privileged language values in GetOption

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -37,24 +37,24 @@
       <emu-alg>
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
-        1. Let _usage_ be ? GetOption(_options_, *"usage"*, *"string"*, &laquo; *"sort"*, *"search"* &raquo;, *"sort"*).
+        1. Let _usage_ be ? GetOption(_options_, *"usage"*, String, &laquo; *"sort"*, *"search"* &raquo;, *"sort"*).
         1. Set _collator_.[[Usage]] to _usage_.
         1. If _usage_ is *"sort"*, then
           1. Let _localeData_ be %Collator%.[[SortLocaleData]].
         1. Else,
           1. Let _localeData_ be %Collator%.[[SearchLocaleData]].
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _collation_ be ? GetOption(_options_, *"collation"*, *"string"*, *undefined*, *undefined*).
+        1. Let _collation_ be ? GetOption(_options_, *"collation"*, String, ~empty~, *undefined*).
         1. If _collation_ is not *undefined*, then
           1. If _collation_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[co]] to _collation_.
-        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, *"boolean"*, *undefined*, *undefined*).
+        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, Boolean, ~empty~, *undefined*).
         1. If _numeric_ is not *undefined*, then
           1. Let _numeric_ be ! ToString(_numeric_).
         1. Set _opt_.[[kn]] to _numeric_.
-        1. Let _caseFirst_ be ? GetOption(_options_, *"caseFirst"*, *"string"*, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
+        1. Let _caseFirst_ be ? GetOption(_options_, *"caseFirst"*, String, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
         1. Set _opt_.[[kf]] to _caseFirst_.
         1. Let _relevantExtensionKeys_ be %Collator%.[[RelevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(%Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
@@ -66,7 +66,7 @@
           1. Set _collator_.[[Numeric]] to SameValue(_r_.[[kn]], *"true"*).
         1. If _relevantExtensionKeys_ contains *"kf"*, then
           1. Set _collator_.[[CaseFirst]] to _r_.[[kf]].
-        1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, *"string"*, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
+        1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, String, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
         1. If _sensitivity_ is *undefined*, then
           1. If _usage_ is *"sort"*, then
             1. Let _sensitivity_ be *"variant"*.
@@ -75,7 +75,7 @@
             1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
             1. Let _sensitivity_ be _dataLocaleData_.[[sensitivity]].
         1. Set _collator_.[[Sensitivity]] to _sensitivity_.
-        1. Let _ignorePunctuation_ be ? GetOption(_options_, *"ignorePunctuation"*, *"boolean"*, *undefined*, *false*).
+        1. Let _ignorePunctuation_ be ? GetOption(_options_, *"ignorePunctuation"*, Boolean, ~empty~, *false*).
         1. Set _collator_.[[IgnorePunctuation]] to _ignorePunctuation_.
         1. Return _collator_.
       </emu-alg>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -37,24 +37,24 @@
       <emu-alg>
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
-        1. Let _usage_ be ? GetOption(_options_, *"usage"*, String, &laquo; *"sort"*, *"search"* &raquo;, *"sort"*).
+        1. Let _usage_ be ? GetOption(_options_, *"usage"*, ~string~, &laquo; *"sort"*, *"search"* &raquo;, *"sort"*).
         1. Set _collator_.[[Usage]] to _usage_.
         1. If _usage_ is *"sort"*, then
           1. Let _localeData_ be %Collator%.[[SortLocaleData]].
         1. Else,
           1. Let _localeData_ be %Collator%.[[SearchLocaleData]].
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _collation_ be ? GetOption(_options_, *"collation"*, String, ~empty~, *undefined*).
+        1. Let _collation_ be ? GetOption(_options_, *"collation"*, ~string~, ~empty~, *undefined*).
         1. If _collation_ is not *undefined*, then
           1. If _collation_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[co]] to _collation_.
-        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, Boolean, ~empty~, *undefined*).
+        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, ~boolean~, ~empty~, *undefined*).
         1. If _numeric_ is not *undefined*, then
           1. Let _numeric_ be ! ToString(_numeric_).
         1. Set _opt_.[[kn]] to _numeric_.
-        1. Let _caseFirst_ be ? GetOption(_options_, *"caseFirst"*, String, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
+        1. Let _caseFirst_ be ? GetOption(_options_, *"caseFirst"*, ~string~, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
         1. Set _opt_.[[kf]] to _caseFirst_.
         1. Let _relevantExtensionKeys_ be %Collator%.[[RelevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(%Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
@@ -66,7 +66,7 @@
           1. Set _collator_.[[Numeric]] to SameValue(_r_.[[kn]], *"true"*).
         1. If _relevantExtensionKeys_ contains *"kf"*, then
           1. Set _collator_.[[CaseFirst]] to _r_.[[kf]].
-        1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, String, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
+        1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, ~string~, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
         1. If _sensitivity_ is *undefined*, then
           1. If _usage_ is *"sort"*, then
             1. Let _sensitivity_ be *"variant"*.
@@ -75,7 +75,7 @@
             1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
             1. Let _sensitivity_ be _dataLocaleData_.[[sensitivity]].
         1. Set _collator_.[[Sensitivity]] to _sensitivity_.
-        1. Let _ignorePunctuation_ be ? GetOption(_options_, *"ignorePunctuation"*, Boolean, ~empty~, *false*).
+        1. Let _ignorePunctuation_ be ? GetOption(_options_, *"ignorePunctuation"*, ~boolean~, ~empty~, *false*).
         1. Set _collator_.[[IgnorePunctuation]] to _ignorePunctuation_.
         1. Return _collator_.
       </emu-alg>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -53,18 +53,18 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? ToDateTimeOptions(_options_, *"any"*, *"date"*).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, *"string"*, *undefined*, *undefined*).
+        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, String, ~empty~, *undefined*).
         1. If _calendar_ is not *undefined*, then
           1. If _calendar_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[ca]] to _calendar_.
-        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
+        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, String, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
-        1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, *"boolean"*, *undefined*, *undefined*).
-        1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
+        1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, Boolean, ~empty~, *undefined*).
+        1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, String, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
         1. If _hour12_ is not *undefined*, then
           1. Set _hourCycle_ to *null*.
         1. Set _opt_.[[hc]] to _hourCycle_.
@@ -104,14 +104,14 @@
             1. Let _value_ be ? GetNumberOption(_options_, *"fractionalSecondDigits"*, 1, 3, *undefined*).
           1. Else,
             1. Let _values_ be a List whose elements are the strings given in the Values column of the row.
-            1. Let _value_ be ? GetOption(_options_, _prop_, *"string"*, _values_, *undefined*).
+            1. Let _value_ be ? GetOption(_options_, _prop_, String, _values_, *undefined*).
           1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
           1. If _value_ is not *undefined*, then
             1. Set _hasExplicitFormatComponents_ to *true*.
-        1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, *"string"*, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
-        1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, *"string"*, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
+        1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, String, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, String, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.
-        1. Let _timeStyle_ be ? GetOption(_options_, *"timeStyle"*, *"string"*, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
+        1. Let _timeStyle_ be ? GetOption(_options_, *"timeStyle"*, String, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[TimeStyle]] to _timeStyle_.
         1. If _dateStyle_ is not *undefined* or _timeStyle_ is not *undefined*, then
           1. If _hasExplicitFormatComponents_ is *true*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -53,18 +53,18 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? ToDateTimeOptions(_options_, *"any"*, *"date"*).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, String, ~empty~, *undefined*).
+        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, ~string~, ~empty~, *undefined*).
         1. If _calendar_ is not *undefined*, then
           1. If _calendar_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[ca]] to _calendar_.
-        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, String, ~empty~, *undefined*).
+        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, ~string~, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
-        1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, Boolean, ~empty~, *undefined*).
-        1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, String, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
+        1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, ~boolean~, ~empty~, *undefined*).
+        1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, ~string~, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
         1. If _hour12_ is not *undefined*, then
           1. Set _hourCycle_ to *null*.
         1. Set _opt_.[[hc]] to _hourCycle_.
@@ -104,14 +104,14 @@
             1. Let _value_ be ? GetNumberOption(_options_, *"fractionalSecondDigits"*, 1, 3, *undefined*).
           1. Else,
             1. Let _values_ be a List whose elements are the strings given in the Values column of the row.
-            1. Let _value_ be ? GetOption(_options_, _prop_, String, _values_, *undefined*).
+            1. Let _value_ be ? GetOption(_options_, _prop_, ~string~, _values_, *undefined*).
           1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
           1. If _value_ is not *undefined*, then
             1. Set _hasExplicitFormatComponents_ to *true*.
-        1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, String, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
-        1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, String, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
+        1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, ~string~, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, ~string~, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.
-        1. Let _timeStyle_ be ? GetOption(_options_, *"timeStyle"*, String, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
+        1. Let _timeStyle_ be ? GetOption(_options_, *"timeStyle"*, ~string~, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[TimeStyle]] to _timeStyle_.
         1. If _dateStyle_ is not *undefined* or _timeStyle_ is not *undefined*, then
           1. If _hasExplicitFormatComponents_ is *true*, then

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -23,22 +23,22 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _localeData_ be %DisplayNames%.[[LocaleData]].
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _r_ be ResolveLocale(%DisplayNames%.[[AvailableLocales]], _requestedLocales_, _opt_, %DisplayNames%.[[RelevantExtensionKeys]]).
-        1. Let _style_ be ? GetOption(_options_, *"style"*, String, &laquo; *"narrow"*, *"short"*, *"long"* &raquo;, *"long"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"narrow"*, *"short"*, *"long"* &raquo;, *"long"*).
         1. Set _displayNames_.[[Style]] to _style_.
-        1. Let _type_ be ? GetOption(_options_, *"type"*, String, &laquo; *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* &raquo;, *undefined*).
+        1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* &raquo;, *undefined*).
         1. If _type_ is *undefined*, throw a *TypeError* exception.
         1. Set _displayNames_.[[Type]] to _type_.
-        1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, String, &laquo; *"code"*, *"none"* &raquo;, *"code"*).
+        1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, &laquo; *"code"*, *"none"* &raquo;, *"code"*).
         1. Set _displayNames_.[[Fallback]] to _fallback_.
         1. Set _displayNames_.[[Locale]] to _r_.[[locale]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _types_ be _dataLocaleData_.[[types]].
         1. Assert: _types_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
-        1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, String, &laquo; *"dialect"*, *"standard"* &raquo;, *"dialect"*).
+        1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, ~string~, &laquo; *"dialect"*, *"standard"* &raquo;, *"dialect"*).
         1. Let _typeFields_ be _types_.[[&lt;_type_&gt;]].
         1. Assert: _typeFields_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. If _type_ is *"language"*, then

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -23,22 +23,22 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _localeData_ be %DisplayNames%.[[LocaleData]].
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _r_ be ResolveLocale(%DisplayNames%.[[AvailableLocales]], _requestedLocales_, _opt_, %DisplayNames%.[[RelevantExtensionKeys]]).
-        1. Let _style_ be ? GetOption(_options_, *"style"*, *"string"*, &laquo; *"narrow"*, *"short"*, *"long"* &raquo;, *"long"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, String, &laquo; *"narrow"*, *"short"*, *"long"* &raquo;, *"long"*).
         1. Set _displayNames_.[[Style]] to _style_.
-        1. Let _type_ be ? GetOption(_options_, *"type"*, *"string"*, &laquo; *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* &raquo;, *undefined*).
+        1. Let _type_ be ? GetOption(_options_, *"type"*, String, &laquo; *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* &raquo;, *undefined*).
         1. If _type_ is *undefined*, throw a *TypeError* exception.
         1. Set _displayNames_.[[Type]] to _type_.
-        1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, *"string"*, &laquo; *"code"*, *"none"* &raquo;, *"code"*).
+        1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, String, &laquo; *"code"*, *"none"* &raquo;, *"code"*).
         1. Set _displayNames_.[[Fallback]] to _fallback_.
         1. Set _displayNames_.[[Locale]] to _r_.[[locale]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _types_ be _dataLocaleData_.[[types]].
         1. Assert: _types_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
-        1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, *"string"*, &laquo; *"dialect"*, *"standard"* &raquo;, *"dialect"*).
+        1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, String, &laquo; *"dialect"*, *"standard"* &raquo;, *"dialect"*).
         1. Let _typeFields_ be _types_.[[&lt;_type_&gt;]].
         1. Assert: _typeFields_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. If _type_ is *"language"*, then

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -21,14 +21,14 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be %ListFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %ListFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _listFormat_.[[Locale]] to _r_.[[locale]].
-        1. Let _type_ be ? GetOption(_options_, *"type"*, String, &laquo; *"conjunction"*, *"disjunction"*, *"unit"* &raquo;, *"conjunction"*).
+        1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"conjunction"*, *"disjunction"*, *"unit"* &raquo;, *"conjunction"*).
         1. Set _listFormat_.[[Type]] to _type_.
-        1. Let _style_ be ? GetOption(_options_, *"style"*, String, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _listFormat_.[[Style]] to _style_.
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -21,14 +21,14 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be %ListFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %ListFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _listFormat_.[[Locale]] to _r_.[[locale]].
-        1. Let _type_ be ? GetOption(_options_, *"type"*, *"string"*, &laquo; *"conjunction"*, *"disjunction"*, *"unit"* &raquo;, *"conjunction"*).
+        1. Let _type_ be ? GetOption(_options_, *"type"*, String, &laquo; *"conjunction"*, *"disjunction"*, *"unit"* &raquo;, *"conjunction"*).
         1. Set _listFormat_.[[Type]] to _type_.
-        1. Let _style_ be ? GetOption(_options_, *"style"*, *"string"*, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, String, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _listFormat_.[[Style]] to _style_.
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -33,22 +33,22 @@
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Set _tag_ to ? ApplyOptionsToTag(_tag_, _options_).
         1. Let _opt_ be a new Record.
-        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, String, ~empty~, *undefined*).
+        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, ~string~, ~empty~, *undefined*).
         1. If _calendar_ is not *undefined*, then
           1. If _calendar_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[ca]] to _calendar_.
-        1. Let _collation_ be ? GetOption(_options_, *"collation"*, String, ~empty~, *undefined*).
+        1. Let _collation_ be ? GetOption(_options_, *"collation"*, ~string~, ~empty~, *undefined*).
         1. If _collation_ is not *undefined*, then
           1. If _collation_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[co]] to _collation_.
-        1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, String, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
+        1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, ~string~, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
         1. Set _opt_.[[hc]] to _hc_.
-        1. Let _kf_ be ? GetOption(_options_, *"caseFirst"*, String, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
+        1. Let _kf_ be ? GetOption(_options_, *"caseFirst"*, ~string~, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
         1. Set _opt_.[[kf]] to _kf_.
-        1. Let _kn_ be ? GetOption(_options_, *"numeric"*, Boolean, ~empty~, *undefined*).
+        1. Let _kn_ be ? GetOption(_options_, *"numeric"*, ~boolean~, ~empty~, *undefined*).
         1. If _kn_ is not *undefined*, set _kn_ to ! ToString(_kn_).
         1. Set _opt_.[[kn]] to _kn_.
-        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, String, ~empty~, *undefined*).
+        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, ~string~, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
@@ -79,13 +79,13 @@
         1. Assert: Type(_tag_) is String.
         1. Assert: Type(_options_) is Object.
         1. If ! IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
-        1. Let _language_ be ? GetOption(_options_, *"language"*, String, ~empty~, *undefined*).
+        1. Let _language_ be ? GetOption(_options_, *"language"*, ~string~, ~empty~, *undefined*).
         1. If _language_ is not *undefined*, then
           1. If _language_ does not match the `unicode_language_subtag` production, throw a *RangeError* exception.
-        1. Let _script_ be ? GetOption(_options_, *"script"*, String, ~empty~, *undefined*).
+        1. Let _script_ be ? GetOption(_options_, *"script"*, ~string~, ~empty~, *undefined*).
         1. If _script_ is not *undefined*, then
           1. If _script_ does not match the `unicode_script_subtag` production, throw a *RangeError* exception.
-        1. Let _region_ be ? GetOption(_options_, *"region"*, String, ~empty~, *undefined*).
+        1. Let _region_ be ? GetOption(_options_, *"region"*, ~string~, ~empty~, *undefined*).
         1. If _region_ is not *undefined*, then
           1. If _region_ does not match the `unicode_region_subtag` production, throw a *RangeError* exception.
         1. Set _tag_ to ! CanonicalizeUnicodeLocaleId(_tag_).

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -33,22 +33,22 @@
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Set _tag_ to ? ApplyOptionsToTag(_tag_, _options_).
         1. Let _opt_ be a new Record.
-        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, *"string"*, *undefined*, *undefined*).
+        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, String, ~empty~, *undefined*).
         1. If _calendar_ is not *undefined*, then
           1. If _calendar_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[ca]] to _calendar_.
-        1. Let _collation_ be ? GetOption(_options_, *"collation"*, *"string"*, *undefined*, *undefined*).
+        1. Let _collation_ be ? GetOption(_options_, *"collation"*, String, ~empty~, *undefined*).
         1. If _collation_ is not *undefined*, then
           1. If _collation_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[co]] to _collation_.
-        1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, *"string"*, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
+        1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, String, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
         1. Set _opt_.[[hc]] to _hc_.
-        1. Let _kf_ be ? GetOption(_options_, *"caseFirst"*, *"string"*, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
+        1. Let _kf_ be ? GetOption(_options_, *"caseFirst"*, String, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
         1. Set _opt_.[[kf]] to _kf_.
-        1. Let _kn_ be ? GetOption(_options_, *"numeric"*, *"boolean"*, *undefined*, *undefined*).
+        1. Let _kn_ be ? GetOption(_options_, *"numeric"*, Boolean, ~empty~, *undefined*).
         1. If _kn_ is not *undefined*, set _kn_ to ! ToString(_kn_).
         1. Set _opt_.[[kn]] to _kn_.
-        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
+        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, String, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
@@ -79,13 +79,13 @@
         1. Assert: Type(_tag_) is String.
         1. Assert: Type(_options_) is Object.
         1. If ! IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
-        1. Let _language_ be ? GetOption(_options_, *"language"*, *"string"*, *undefined*, *undefined*).
+        1. Let _language_ be ? GetOption(_options_, *"language"*, String, ~empty~, *undefined*).
         1. If _language_ is not *undefined*, then
           1. If _language_ does not match the `unicode_language_subtag` production, throw a *RangeError* exception.
-        1. Let _script_ be ? GetOption(_options_, *"script"*, *"string"*, *undefined*, *undefined*).
+        1. Let _script_ be ? GetOption(_options_, *"script"*, String, ~empty~, *undefined*).
         1. If _script_ is not *undefined*, then
           1. If _script_ does not match the `unicode_script_subtag` production, throw a *RangeError* exception.
-        1. Let _region_ be ? GetOption(_options_, *"region"*, *"string"*, *undefined*, *undefined*).
+        1. Let _region_ be ? GetOption(_options_, *"region"*, String, ~empty~, *undefined*).
         1. If _region_ is not *undefined*, then
           1. If _region_ does not match the `unicode_region_subtag` production, throw a *RangeError* exception.
         1. Set _tag_ to ! CanonicalizeUnicodeLocaleId(_tag_).

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -290,7 +290,7 @@
 
       <emu-alg>
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. If _matcher_ is *"best fit"*, then
           1. Let _supportedLocales_ be BestFitSupportedLocales(_availableLocales_, _requestedLocales_).
         1. Else,
@@ -332,29 +332,29 @@
         GetOption (
           _options_: an Object,
           _property_: a property key,
-          _type_: *"boolean"*, *"number"*, or *"string"*,
-          _values_: *undefined* or a List of ECMAScript language values,
+          _type_: Boolean, Number, or String,
+          _values_: ~empty~ or a List of ECMAScript language values,
           _default_: ~required~ or an ECMAScript language value,
         )
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It extracts the value of the specified property of _options_, converts it to the required _type_, checks whether it is allowed by _values_ if _values_ is not *undefined*, and substitutes _default_ if the value is *undefined*.</dd>
+        <dd>It extracts the value of the specified property of _options_, converts it to the required _type_, checks whether it is allowed by _values_ if _values_ is not ~empty~, and substitutes _default_ if the value is *undefined*.</dd>
       </dl>
       <emu-alg>
         1. Let _value_ be ? Get(_options_, _property_).
         1. If _value_ is *undefined*, then
           1. If _default_ is ~required~, throw a *RangeError* exception.
           1. Return _default_.
-        1. If _type_ is *"boolean"*, then
+        1. If _type_ is Boolean, then
           1. Set _value_ to ToBoolean(_value_).
-        1. Else if _type_ is *"number"*, then
+        1. Else if _type_ is Number, then
           1. Set _value_ to ? ToNumber(_value_).
           1. If _value_ is *NaN*, throw a *RangeError* exception.
         1. Else,
-          1. Assert: _type_ is *"string"*.
+          1. Assert: _type_ is String.
           1. Set _value_ to ? ToString(_value_).
-        1. If _values_ is not *undefined* and _values_ does not contain an element equal to _value_, throw a *RangeError* exception.
+        1. If _values_ is not ~empty~ and _values_ does not contain an element equal to _value_, throw a *RangeError* exception.
         1. Return _value_.
       </emu-alg>
     </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -290,7 +290,7 @@
 
       <emu-alg>
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. If _matcher_ is *"best fit"*, then
           1. Let _supportedLocales_ be BestFitSupportedLocales(_availableLocales_, _requestedLocales_).
         1. Else,
@@ -332,7 +332,7 @@
         GetOption (
           _options_: an Object,
           _property_: a property key,
-          _type_: Boolean, Number, or String,
+          _type_: ~boolean~, ~number~, or ~string~,
           _values_: ~empty~ or a List of ECMAScript language values,
           _default_: ~required~ or an ECMAScript language value,
         )
@@ -346,13 +346,13 @@
         1. If _value_ is *undefined*, then
           1. If _default_ is ~required~, throw a *RangeError* exception.
           1. Return _default_.
-        1. If _type_ is Boolean, then
+        1. If _type_ is ~boolean~, then
           1. Set _value_ to ToBoolean(_value_).
-        1. Else if _type_ is Number, then
+        1. Else if _type_ is ~number~, then
           1. Set _value_ to ? ToNumber(_value_).
           1. If _value_ is *NaN*, throw a *RangeError* exception.
         1. Else,
-          1. Assert: _type_ is String.
+          1. Assert: _type_ is ~string~.
           1. Set _value_ to ? ToString(_value_).
         1. If _values_ is not ~empty~ and _values_ does not contain an element equal to _value_, throw a *RangeError* exception.
         1. Return _value_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -53,9 +53,9 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, String, ~empty~, *undefined*).
+        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, ~string~, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
@@ -77,15 +77,15 @@
             1. Let _mxfdDefault_ be 0.
           1. Else,
             1. Let _mxfdDefault_ be 3.
-        1. Let _notation_ be ? GetOption(_options_, *"notation"*, String, &laquo; *"standard"*, *"scientific"*, *"engineering"*, *"compact"* &raquo;, *"standard"*).
+        1. Let _notation_ be ? GetOption(_options_, *"notation"*, ~string~, &laquo; *"standard"*, *"scientific"*, *"engineering"*, *"compact"* &raquo;, *"standard"*).
         1. Set _numberFormat_.[[Notation]] to _notation_.
         1. Perform ? SetNumberFormatDigitOptions(_numberFormat_, _options_, _mnfdDefault_, _mxfdDefault_, _notation_).
-        1. Let _compactDisplay_ be ? GetOption(_options_, *"compactDisplay"*, String, &laquo; *"short"*, *"long"* &raquo;, *"short"*).
+        1. Let _compactDisplay_ be ? GetOption(_options_, *"compactDisplay"*, ~string~, &laquo; *"short"*, *"long"* &raquo;, *"short"*).
         1. If _notation_ is *"compact"*, then
           1. Set _numberFormat_.[[CompactDisplay]] to _compactDisplay_.
-        1. Let _useGrouping_ be ? GetOption(_options_, *"useGrouping"*, Boolean, ~empty~, *true*).
+        1. Let _useGrouping_ be ? GetOption(_options_, *"useGrouping"*, ~boolean~, ~empty~, *true*).
         1. Set _numberFormat_.[[UseGrouping]] to _useGrouping_.
-        1. Let _signDisplay_ be ? GetOption(_options_, *"signDisplay"*, String, &laquo; *"auto"*, *"never"*, *"always"*, *"exceptZero"* &raquo;, *"auto"*).
+        1. Let _signDisplay_ be ? GetOption(_options_, *"signDisplay"*, ~string~, &laquo; *"auto"*, *"never"*, *"always"*, *"exceptZero"* &raquo;, *"auto"*).
         1. Set _numberFormat_.[[SignDisplay]] to _signDisplay_.
         1. Return _numberFormat_.
       </emu-alg>
@@ -160,21 +160,21 @@
       <emu-alg>
         1. Assert: Type(_intlObj_) is Object.
         1. Assert: Type(_options_) is Object.
-        1. Let _style_ be ? GetOption(_options_, *"style"*, String, &laquo; *"decimal"*, *"percent"*, *"currency"*, *"unit"* &raquo;, *"decimal"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"decimal"*, *"percent"*, *"currency"*, *"unit"* &raquo;, *"decimal"*).
         1. Set _intlObj_.[[Style]] to _style_.
-        1. Let _currency_ be ? GetOption(_options_, *"currency"*, String, ~empty~, *undefined*).
+        1. Let _currency_ be ? GetOption(_options_, *"currency"*, ~string~, ~empty~, *undefined*).
         1. If _currency_ is *undefined*, then
           1. If _style_ is *"currency"*, throw a *TypeError* exception.
         1. Else,
           1. If ! IsWellFormedCurrencyCode(_currency_) is *false*, throw a *RangeError* exception.
-        1. Let _currencyDisplay_ be ? GetOption(_options_, *"currencyDisplay"*, String, &laquo; *"code"*, *"symbol"*, *"narrowSymbol"*, *"name"* &raquo;, *"symbol"*).
-        1. Let _currencySign_ be ? GetOption(_options_, *"currencySign"*, String, &laquo; *"standard"*, *"accounting"* &raquo;, *"standard"*).
-        1. Let _unit_ be ? GetOption(_options_, *"unit"*, String, ~empty~, *undefined*).
+        1. Let _currencyDisplay_ be ? GetOption(_options_, *"currencyDisplay"*, ~string~, &laquo; *"code"*, *"symbol"*, *"narrowSymbol"*, *"name"* &raquo;, *"symbol"*).
+        1. Let _currencySign_ be ? GetOption(_options_, *"currencySign"*, ~string~, &laquo; *"standard"*, *"accounting"* &raquo;, *"standard"*).
+        1. Let _unit_ be ? GetOption(_options_, *"unit"*, ~string~, ~empty~, *undefined*).
         1. If _unit_ is *undefined*, then
           1. If _style_ is *"unit"*, throw a *TypeError* exception.
         1. Else,
           1. If ! IsWellFormedUnitIdentifier(_unit_) is *false*, throw a *RangeError* exception.
-        1. Let _unitDisplay_ be ? GetOption(_options_, *"unitDisplay"*, String, &laquo; *"short"*, *"narrow"*, *"long"* &raquo;, *"short"*).
+        1. Let _unitDisplay_ be ? GetOption(_options_, *"unitDisplay"*, ~string~, &laquo; *"short"*, *"narrow"*, *"long"* &raquo;, *"short"*).
         1. If _style_ is *"currency"*, then
           1. Set _intlObj_.[[Currency]] to the ASCII-uppercase of _currency_.
           1. Set _intlObj_.[[CurrencyDisplay]] to _currencyDisplay_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -53,9 +53,9 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
+        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, String, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
@@ -77,15 +77,15 @@
             1. Let _mxfdDefault_ be 0.
           1. Else,
             1. Let _mxfdDefault_ be 3.
-        1. Let _notation_ be ? GetOption(_options_, *"notation"*, *"string"*, &laquo; *"standard"*, *"scientific"*, *"engineering"*, *"compact"* &raquo;, *"standard"*).
+        1. Let _notation_ be ? GetOption(_options_, *"notation"*, String, &laquo; *"standard"*, *"scientific"*, *"engineering"*, *"compact"* &raquo;, *"standard"*).
         1. Set _numberFormat_.[[Notation]] to _notation_.
         1. Perform ? SetNumberFormatDigitOptions(_numberFormat_, _options_, _mnfdDefault_, _mxfdDefault_, _notation_).
-        1. Let _compactDisplay_ be ? GetOption(_options_, *"compactDisplay"*, *"string"*, &laquo; *"short"*, *"long"* &raquo;, *"short"*).
+        1. Let _compactDisplay_ be ? GetOption(_options_, *"compactDisplay"*, String, &laquo; *"short"*, *"long"* &raquo;, *"short"*).
         1. If _notation_ is *"compact"*, then
           1. Set _numberFormat_.[[CompactDisplay]] to _compactDisplay_.
-        1. Let _useGrouping_ be ? GetOption(_options_, *"useGrouping"*, *"boolean"*, *undefined*, *true*).
+        1. Let _useGrouping_ be ? GetOption(_options_, *"useGrouping"*, Boolean, ~empty~, *true*).
         1. Set _numberFormat_.[[UseGrouping]] to _useGrouping_.
-        1. Let _signDisplay_ be ? GetOption(_options_, *"signDisplay"*, *"string"*, &laquo; *"auto"*, *"never"*, *"always"*, *"exceptZero"* &raquo;, *"auto"*).
+        1. Let _signDisplay_ be ? GetOption(_options_, *"signDisplay"*, String, &laquo; *"auto"*, *"never"*, *"always"*, *"exceptZero"* &raquo;, *"auto"*).
         1. Set _numberFormat_.[[SignDisplay]] to _signDisplay_.
         1. Return _numberFormat_.
       </emu-alg>
@@ -160,21 +160,21 @@
       <emu-alg>
         1. Assert: Type(_intlObj_) is Object.
         1. Assert: Type(_options_) is Object.
-        1. Let _style_ be ? GetOption(_options_, *"style"*, *"string"*, &laquo; *"decimal"*, *"percent"*, *"currency"*, *"unit"* &raquo;, *"decimal"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, String, &laquo; *"decimal"*, *"percent"*, *"currency"*, *"unit"* &raquo;, *"decimal"*).
         1. Set _intlObj_.[[Style]] to _style_.
-        1. Let _currency_ be ? GetOption(_options_, *"currency"*, *"string"*, *undefined*, *undefined*).
+        1. Let _currency_ be ? GetOption(_options_, *"currency"*, String, ~empty~, *undefined*).
         1. If _currency_ is *undefined*, then
           1. If _style_ is *"currency"*, throw a *TypeError* exception.
         1. Else,
           1. If ! IsWellFormedCurrencyCode(_currency_) is *false*, throw a *RangeError* exception.
-        1. Let _currencyDisplay_ be ? GetOption(_options_, *"currencyDisplay"*, *"string"*, &laquo; *"code"*, *"symbol"*, *"narrowSymbol"*, *"name"* &raquo;, *"symbol"*).
-        1. Let _currencySign_ be ? GetOption(_options_, *"currencySign"*, *"string"*, &laquo; *"standard"*, *"accounting"* &raquo;, *"standard"*).
-        1. Let _unit_ be ? GetOption(_options_, *"unit"*, *"string"*, *undefined*, *undefined*).
+        1. Let _currencyDisplay_ be ? GetOption(_options_, *"currencyDisplay"*, String, &laquo; *"code"*, *"symbol"*, *"narrowSymbol"*, *"name"* &raquo;, *"symbol"*).
+        1. Let _currencySign_ be ? GetOption(_options_, *"currencySign"*, String, &laquo; *"standard"*, *"accounting"* &raquo;, *"standard"*).
+        1. Let _unit_ be ? GetOption(_options_, *"unit"*, String, ~empty~, *undefined*).
         1. If _unit_ is *undefined*, then
           1. If _style_ is *"unit"*, throw a *TypeError* exception.
         1. Else,
           1. If ! IsWellFormedUnitIdentifier(_unit_) is *false*, throw a *RangeError* exception.
-        1. Let _unitDisplay_ be ? GetOption(_options_, *"unitDisplay"*, *"string"*, &laquo; *"short"*, *"narrow"*, *"long"* &raquo;, *"short"*).
+        1. Let _unitDisplay_ be ? GetOption(_options_, *"unitDisplay"*, String, &laquo; *"short"*, *"narrow"*, *"long"* &raquo;, *"short"*).
         1. If _style_ is *"currency"*, then
           1. Set _intlObj_.[[Currency]] to the ASCII-uppercase of _currency_.
           1. Set _intlObj_.[[CurrencyDisplay]] to _currencyDisplay_.

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -33,9 +33,9 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _t_ be ? GetOption(_options_, *"type"*, String, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
+        1. Let _t_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, *+0*<sub>𝔽</sub>, *3*<sub>𝔽</sub>, *"standard"*).
         1. Let _localeData_ be %PluralRules%.[[LocaleData]].

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -33,9 +33,9 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _t_ be ? GetOption(_options_, *"type"*, *"string"*, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
+        1. Let _t_ be ? GetOption(_options_, *"type"*, String, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, *+0*<sub>𝔽</sub>, *3*<sub>𝔽</sub>, *"standard"*).
         1. Let _localeData_ be %PluralRules%.[[LocaleData]].

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -37,9 +37,9 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[LocaleMatcher]] to _matcher_.
-        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, String, ~empty~, *undefined*).
+        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, ~string~, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
@@ -49,9 +49,9 @@
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
         1. Set _relativeTimeFormat_.[[DataLocale]] to _r_.[[dataLocale]].
         1. Set _relativeTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _style_ be ? GetOption(_options_, *"style"*, String, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _relativeTimeFormat_.[[Style]] to _style_.
-        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, String, &laquo; *"always"*, *"auto"* &raquo;, *"always"*).
+        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, ~string~, &laquo; *"always"*, *"auto"* &raquo;, *"always"*).
         1. Set _relativeTimeFormat_.[[Numeric]] to _numeric_.
         1. Let _relativeTimeFormat_.[[NumberFormat]] be ! Construct(%NumberFormat%, &laquo; _locale_ &raquo;).
         1. Let _relativeTimeFormat_.[[PluralRules]] be ! Construct(%PluralRules%, &laquo; _locale_ &raquo;).

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -37,9 +37,9 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[LocaleMatcher]] to _matcher_.
-        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
+        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, String, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
@@ -49,9 +49,9 @@
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
         1. Set _relativeTimeFormat_.[[DataLocale]] to _r_.[[dataLocale]].
         1. Set _relativeTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _style_ be ? GetOption(_options_, *"style"*, *"string"*, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, String, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _relativeTimeFormat_.[[Style]] to _style_.
-        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, *"string"*, &laquo; *"always"*, *"auto"* &raquo;, *"always"*).
+        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, String, &laquo; *"always"*, *"auto"* &raquo;, *"always"*).
         1. Set _relativeTimeFormat_.[[Numeric]] to _numeric_.
         1. Let _relativeTimeFormat_.[[NumberFormat]] be ! Construct(%NumberFormat%, &laquo; _locale_ &raquo;).
         1. Let _relativeTimeFormat_.[[PluralRules]] be ! Construct(%PluralRules%, &laquo; _locale_ &raquo;).

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -22,12 +22,12 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be %Segmenter%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Segmenter%.[[AvailableLocales]], _requestedLocales_, _opt_, %Segmenter%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _segmenter_.[[Locale]] to _r_.[[locale]].
-        1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, String, &laquo; *"grapheme"*, *"word"*, *"sentence"* &raquo;, *"grapheme"*).
+        1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, ~string~, &laquo; *"grapheme"*, *"word"*, *"sentence"* &raquo;, *"grapheme"*).
         1. Set _segmenter_.[[SegmenterGranularity]] to _granularity_.
         1. Return _segmenter_.
       </emu-alg>

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -22,12 +22,12 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, String, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be %Segmenter%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Segmenter%.[[AvailableLocales]], _requestedLocales_, _opt_, %Segmenter%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _segmenter_.[[Locale]] to _r_.[[locale]].
-        1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, *"string"*, &laquo; *"grapheme"*, *"word"*, *"sentence"* &raquo;, *"grapheme"*).
+        1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, String, &laquo; *"grapheme"*, *"word"*, *"sentence"* &raquo;, *"grapheme"*).
         1. Set _segmenter_.[[SegmenterGranularity]] to _granularity_.
         1. Return _segmenter_.
       </emu-alg>


### PR DESCRIPTION
cf. https://github.com/tc39/ecma402/pull/687#discussion_r888113770

Use of privileged language values in abstract operation arguments is bad form. The generally preferred alternative is to use spec enum values, but [Temporal GetOption](https://tc39.es/proposal-temporal/#sec-getoption) currently uses an alternative approach that directly references [Types](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-ecmascript-data-types-and-values).

I'm not sure which we we want to go here, so I took the Temporal Type-reference approach in the first commit and the conventional ECMA-262 spec-enum-approach in the second for easy adoption of either. I'm interested to hear others' opinions.

Note also that Temporal will move GetOption into ECMA-262, so this is really a question of pre-alignment.