### PR TITLE
Meta: Replace use of prohibited character range

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - main
       - master
-      - es[0-9.]+
+      - es[0-9]+
+      - es[0-9]*.[0-9]*
 
 jobs:
   deploy:


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
> `[]`… Ranges can only include `a-z`, `A-Z`, and `0-9`.