### PR TITLE
Normative: Add "microsecond" and "nanosecond" to IsSanctionedSingleUnitIdentifier

### DIFF
--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -294,6 +294,7 @@
           <tr><td>megabit</td></tr>
           <tr><td>megabyte</td></tr>
           <tr><td>meter</td></tr>
+          <tr><td>microsecond</td></tr>
           <tr><td>mile</td></tr>
           <tr><td>mile-scandinavian</td></tr>
           <tr><td>milliliter</td></tr>
@@ -301,6 +302,7 @@
           <tr><td>millisecond</td></tr>
           <tr><td>minute</td></tr>
           <tr><td>month</td></tr>
+          <tr><td>nanosecond</td></tr>
           <tr><td>ounce</td></tr>
           <tr><td>percent</td></tr>
           <tr><td>petabyte</td></tr>


### PR DESCRIPTION
Address https://github.com/tc39/ecma402/issues/702 and needed by https://github.com/tc39/proposal-intl-duration-format/pull/122

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
