### PR TITLE
Normative: Add new numbering systems "kawi" and "nagm"

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -785,6 +785,10 @@
             <td>U+A900 to U+A909</td>
           </tr>
           <tr>
+            <td>kawi</td>
+            <td>U+11F50 to U+11F59</td>
+          </tr>
+          <tr>
             <td>khmr</td>
             <td>U+17E0 to U+17E9</td>
           </tr>
@@ -867,6 +871,10 @@
           <tr>
             <td>mymrtlng</td>
             <td>U+A9F0 to U+A9F9</td>
+          </tr>
+          <tr>
+            <td>nagm</td>
+            <td>U+1E4F0 to U+1E4F9</td>
           </tr>
           <tr>
             <td>newa</td>


### PR DESCRIPTION
Add "kawi" and "nagm" to the table of numbering systems with simple digit mappings. Both are new additions from Unicode 15.

Also see: unicode-org/cldr#2041
