### PR TITLE
Normative: Stage4 PR for proposal-intl-enumeration

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -117,5 +117,32 @@
         1. Return CreateArrayFromList(_ll_).
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-intl.supportedvaluesof">
+      <h1>Intl.supportedValuesOf ( _key_ )</h1>
+
+      <p>
+      When the `supportedValuesOf` method is called with argument _key_ , the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _key_ be ? ToString(_key_).
+        1. If _key_ is *"calendar"*, then
+          1. Let _list_ be AvailableCanonicalCalendars( ).
+        1. Else if _key_ is *"collation"*, then
+          1. Let _list_ be AvailableCanonicalCollations( ).
+        1. Else if _key_ is *"currency"*, then
+          1. Let _list_ be AvailableCanonicalCurrencies( ).
+        1. Else if _key_ is *"numberingSystem"*, then
+          1. Let _list_ be AvailableCanonicalNumberingSystems( ).
+        1. Else if _key_ is *"timeZone"*, then
+          1. Let _list_ be AvailableCanonicalTimeZones( ).
+        1. Else if _key_ is *"unit"*, then
+          1. Let _list_ be AvailableCanonicalUnits( ).
+        1. Else,
+          1. Throw a *RangeError* exception.
+        1. Return CreateArrayFromList( _list_ ).
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -361,7 +361,7 @@
     <h1>Numbering System Identifiers</h1>
 
     <p>
-      The ECMAScript 2023 Internationalization API Specification identifies numbering systems using a <em>numbering system identifier</em> as defined by <a href="https://unicode.org/reports/tr35/tr35-numbers.html#Numbering_Systems">Unicode Technical Standard #35, Part 3, Section 1</a>. Their canonical form is a string containing all lowercase letters.
+      This specification identifies numbering systems using a <dfn variants="numbering system identifiers">numbering system identifier</dfn> corresponding with the name referenced by <a href="https://unicode.org/reports/tr35/tr35-numbers.html#Numbering_Systems">Unicode Technical Standard #35 Part 3 Numbers, Section 1 Numbering Systems</a>. Their canonical form is a string containing only Unicode Basic Latin lowercase letters (U+0061 LATIN SMALL LETTER A through U+007A LATIN SMALL LETTER Z).
     </p>
 
     <emu-clause id="sec-availablecanonicalnumberingsystems" type="implementation-defined abstract operation">

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -1,8 +1,8 @@
 <emu-clause id="locales-currencies-tz">
-  <h1>Identification of Locales, Currencies, Time Zones, and Measurement Units</h1>
+  <h1>Identification of Locales, Currencies, Time Zones, Measurement Units, Numbering Systems, Collations, and Calendars</h1>
 
   <p>
-    This clause describes the String values used in the ECMAScript 2023 Internationalization API Specification to identify locales, currencies, time zones, and measurement units.
+    This clause describes the String values used in the ECMAScript 2023 Internationalization API Specification to identify locales, currencies, time zones, measurement units, numbering systems, collations, and calendars.
   </p>
 
   <emu-clause id="sec-case-sensitivity-and-case-mapping">
@@ -159,6 +159,15 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-availablecanonicalcurrencies" type="implementation-defined abstract operation">
+    <h1>AvailableCanonicalCurrencies (
+    ): a List of Strings</h1>
+    <dl class="header">
+    <dt>description</dt>
+      <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique, well-formed, and upper case canonicalized 3-letter ISO 4217 currency codes, identifying the currencies for which the implementation provides the functionality of Intl.DisplayNames and Intl.NumberFormat objects.</dd>
+    </dl>
+  </emu-clause>
+
   <emu-clause id="sec-time-zone-names">
     <h1>Time Zone Names</h1>
 
@@ -212,6 +221,29 @@
       <p>
         The DefaultTimeZone abstract operation returns a String value representing the valid (<emu-xref href="#sec-isvalidtimezonename"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizetimezonename"></emu-xref>) time zone name for the host environment's current time zone.
       </p>
+    </emu-clause>
+
+    <emu-clause id="sec-availablecanonicaltimezones" type="implementation-defined abstract operation">
+      <h1>
+        AvailableCanonicalTimeZones (
+        ): a List of Strings
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>The returned List is a sorted List of supported Zone and Link names in the IANA Time Zone Database.</dd>
+      </dl>
+
+      <emu-alg>
+        1. Let _names_ be a List of all supported Zone and Link names in the IANA Time Zone Database.
+        1. Let _result_ be a new empty List.
+        1. For each element _name_ of _names_, do
+          1. Assert: ! IsValidTimeZoneName( _name_ ) is *true*.
+          1. Let _canonical_ be ! CanonicalizeTimeZoneName( _name_ ).
+          1. If _result_ does not contain an element equal to _canonical_, then
+            1. Append _canonical_ to the end of _result_.
+        1. Sort _result_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
+        1. Return _result_.
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 
@@ -314,6 +346,65 @@
           <tr><td>year</td></tr>
         </table>
       </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-availablecanonicalunits" type="abstract operation">
+      <h1>AvailableCanonicalUnits (
+      ): a List of Strings</h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and consists of the unique values of simple unit identifiers listed in every row of <emu-xref href="#table-sanctioned-single-unit-identifiers"></emu-xref>, except the header row.</dd>
+      </dl>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-numberingsystem-identifiers">
+    <h1>Numbering System Identifiers</h1>
+
+    <p>
+      The ECMAScript 2023 Internationalization API Specification identifies numbering systems using a <em>numbering system identifier</em> as defined by <a href="https://unicode.org/reports/tr35/tr35-numbers.html#Numbering_Systems">Unicode Technical Standard #35, Part 3, Section 1</a>. Their canonical form is a string containing all lowercase letters.
+    </p>
+
+    <emu-clause id="sec-availablecanonicalnumberingsystems" type="implementation-defined abstract operation">
+      <h1>AvailableCanonicalNumberingSystems (
+      ): a List of Strings</h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique numbering systems identifiers identifying the numbering systems for which the implementation provides the functionality of Intl.DateTimeFormat, Intl.NumberFormat, and Intl.RelativeTimeFormat objects. The list must include the Numbering System value of every row of <emu-xref href="#table-numbering-system-digits"></emu-xref>, except the header row.</dd>
+      </dl>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-collation-types">
+    <h1>Collation Types</h1>
+
+    <p>
+      The ECMAScript 2023 Internationalization API Specification identifies collations using a <em>collation type</em> as defined by <a href="https://unicode.org/reports/tr35/tr35-collation.html#Collation_Types">Unicode Technical Standard #35, Part 5, Section 3.1</a>. Their canonical form is a string containing all lowercase letters with zero or more hyphens.
+    </p>
+
+    <emu-clause id="sec-availablecanonicalcollations" type="implementation-defined abstract operation">
+      <h1>AvailableCanonicalCollations (
+      ): a List of Strings</h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique collation types identifying the collations for which the implementation provides the functionality of Intl.Collator objects.</dd>
+      </dl>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-calendar-types">
+    <h1>Calendar Types</h1>
+
+    <p>
+      The ECMAScript 2023 Internationalization API Specification identifies calendars using a <em>calendar type</em> as defined by <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Elements">Unicode Technical Standard #35, Part 4, Section 2</a>. Their canonical form is a string containing all lower case letters with zero or more hyphens.
+    </p>
+
+    <emu-clause id="sec-availablecanonicalcalendars" type="implementation-defined abstract operation">
+      <h1>AvailableCanonicalCalendars (
+      ): a List of Strings</h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique calendar types identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects. The list must include *"iso8601"*.</dd>
+      </dl>
     </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -378,7 +378,7 @@
     <h1>Collation Types</h1>
 
     <p>
-      The ECMAScript 2023 Internationalization API Specification identifies collations using a <em>collation type</em> as defined by <a href="https://unicode.org/reports/tr35/tr35-collation.html#Collation_Types">Unicode Technical Standard #35, Part 5, Section 3.1</a>. Their canonical form is a string containing all lowercase letters with zero or more hyphens.
+      This specification identifies collations using a <dfn variants="collation types">collation type</dfn> as defined by <a href="https://unicode.org/reports/tr35/tr35-collation.html#Collation_Types">Unicode Technical Standard #35 Part 5 Collation, Section 3.1 Collation Types</a>. Their canonical form is a string containing only Unicode Basic Latin lowercase letters (U+0061 LATIN SMALL LETTER A through U+007A LATIN SMALL LETTER Z) with zero or more medial hyphens (U+002D HYPHEN-MINUS).
     </p>
 
     <emu-clause id="sec-availablecanonicalcollations" type="implementation-defined abstract operation">

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -234,7 +234,7 @@
       </dl>
 
       <emu-alg>
-        1. Let _names_ be a List of all supported Zone and Link names in the IANA Time Zone Database.
+        1. Let _names_ be a List of all Zone and Link names in the IANA Time Zone Database that are supported by the implementation.
         1. Let _result_ be a new empty List.
         1. For each element _name_ of _names_, do
           1. Assert: ! IsValidTimeZoneName( _name_ ) is *true*.

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -369,7 +369,7 @@
       ): a List of Strings</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique numbering systems identifiers identifying the numbering systems for which the implementation provides the functionality of Intl.DateTimeFormat, Intl.NumberFormat, and Intl.RelativeTimeFormat objects. The list must include the Numbering System value of every row of <emu-xref href="#table-numbering-system-digits"></emu-xref>, except the header row.</dd>
+        <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique canonical numbering systems identifiers identifying the numbering systems for which the implementation provides the functionality of Intl.DateTimeFormat, Intl.NumberFormat, and Intl.RelativeTimeFormat objects. The list must include the Numbering System value of every row of <emu-xref href="#table-numbering-system-digits"></emu-xref>, except the header row.</dd>
       </dl>
     </emu-clause>
   </emu-clause>
@@ -386,7 +386,7 @@
       ): a List of Strings</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique collation types identifying the collations for which the implementation provides the functionality of Intl.Collator objects.</dd>
+        <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique canonical collation types identifying the collations for which the implementation provides the functionality of Intl.Collator objects.</dd>
       </dl>
     </emu-clause>
   </emu-clause>
@@ -403,7 +403,7 @@
       ): a List of Strings</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique calendar types identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects. The list must include *"iso8601"*.</dd>
+        <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique canonical calendar types identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects. The list must include *"iso8601"*.</dd>
       </dl>
     </emu-clause>
   </emu-clause>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -395,7 +395,7 @@
     <h1>Calendar Types</h1>
 
     <p>
-      The ECMAScript 2023 Internationalization API Specification identifies calendars using a <dfn variants="calendar types">calendar type</dfn> as defined by <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Elements">Unicode Technical Standard #35 Part 4 Dates, Section 2 Calendar Elements</a>. Their canonical form is a string containing only Unicode Basic Latin lowercase letters (U+0061 LATIN SMALL LETTER A through U+007A LATIN SMALL LETTER Z) with zero or more medial hyphens (U+002D HYPHEN-MINUS).
+      This specification identifies calendars using a <dfn variants="calendar types">calendar type</dfn> as defined by <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Elements">Unicode Technical Standard #35 Part 4 Dates, Section 2 Calendar Elements</a>. Their canonical form is a string containing only Unicode Basic Latin lowercase letters (U+0061 LATIN SMALL LETTER A through U+007A LATIN SMALL LETTER Z) with zero or more medial hyphens (U+002D HYPHEN-MINUS).
     </p>
 
     <emu-clause id="sec-availablecanonicalcalendars" type="implementation-defined abstract operation">

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -241,7 +241,7 @@
           1. Let _canonical_ be ! CanonicalizeTimeZoneName( _name_ ).
           1. If _result_ does not contain _canonical_, then
             1. Append _canonical_ to the end of _result_.
-        1. Sort _result_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
+        1. [declared="comparefn"] Sort _result_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -395,7 +395,7 @@
     <h1>Calendar Types</h1>
 
     <p>
-      The ECMAScript 2023 Internationalization API Specification identifies calendars using a <em>calendar type</em> as defined by <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Elements">Unicode Technical Standard #35, Part 4, Section 2</a>. Their canonical form is a string containing all lower case letters with zero or more hyphens.
+      The ECMAScript 2023 Internationalization API Specification identifies calendars using a <dfn variants="calendar types">calendar type</dfn> as defined by <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Elements">Unicode Technical Standard #35 Part 4 Dates, Section 2 Calendar Elements</a>. Their canonical form is a string containing only Unicode Basic Latin lowercase letters (U+0061 LATIN SMALL LETTER A through U+007A LATIN SMALL LETTER Z) with zero or more medial hyphens (U+002D HYPHEN-MINUS).
     </p>
 
     <emu-clause id="sec-availablecanonicalcalendars" type="implementation-defined abstract operation">

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -2,7 +2,7 @@
   <h1>Identification of Locales, Currencies, Time Zones, Measurement Units, Numbering Systems, Collations, and Calendars</h1>
 
   <p>
-    This clause describes the String values used in the ECMAScript 2023 Internationalization API Specification to identify locales, currencies, time zones, measurement units, numbering systems, collations, and calendars.
+    This clause describes the String values used in this specification to identify locales, currencies, time zones, measurement units, numbering systems, collations, and calendars.
   </p>
 
   <emu-clause id="sec-case-sensitivity-and-case-mapping">

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -239,7 +239,7 @@
         1. For each element _name_ of _names_, do
           1. Assert: ! IsValidTimeZoneName( _name_ ) is *true*.
           1. Let _canonical_ be ! CanonicalizeTimeZoneName( _name_ ).
-          1. If _result_ does not contain an element equal to _canonical_, then
+          1. If _result_ does not contain _canonical_, then
             1. Append _canonical_ to the end of _result_.
         1. Sort _result_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
         1. Return _result_.


### PR DESCRIPTION
Plan to suggest moving to Stage 4 in Nov 2022
https://github.com/tc39/proposal-intl-enumeration

It is already implemented in Chrome m99, Safari 15.4 and Firefox 93.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#browser_compatibility

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
