### PR TITLE
Meta: bump ecmarkup to 16.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN https://tc39.es/ecma402/#sec-copyright-and-software-license",
       "dependencies": {
         "@tc39/ecma262-biblio": "2.1.2458",
-        "ecmarkup": "^12.1.1"
+        "ecmarkup": "^16.0.0"
       },
       "devDependencies": {}
     },
@@ -493,23 +493,23 @@
       }
     },
     "node_modules/ecmarkdown": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.0.0.tgz",
-      "integrity": "sha512-hJxPALjSOpSMMcFjSzwzJBk8EWOu20mYlTfV7BnVTh9er0FEaT2eSx16y36YxqQfdFxPUsa0CSH4fLf0qUclKw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.2.0.tgz",
+      "integrity": "sha512-p0C4SJCvnvtm0y9gPhXBb5DlNbHsNS44ihVKBw3MXviZG2QQpZNH4z/3PbkpgECOjKOeZI+m84ISHVV9WLECFQ==",
       "dependencies": {
         "escape-html": "^1.0.1"
       }
     },
     "node_modules/ecmarkup": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-12.1.1.tgz",
-      "integrity": "sha512-VYeNBks2LB8aVC5oOg6apA/1ZMnxynUuTidRoD1SL1p3hUpkDgjbzF0s2hLIn68XBwBFPygcX8fgb2MbYkYi9Q==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-16.0.0.tgz",
+      "integrity": "sha512-12TCAQG072ywauddgoah7N9/K8rA8v3t3MJsnSbPZDM98bNG224x5ShMxBkdVaGf5ncENTFlVom58TGCW5V0wQ==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
-        "ecmarkdown": "^7.0.0",
+        "ecmarkdown": "^7.2.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "fast-glob": "^3.2.7",
         "grammarkdown": "^3.2.0",
@@ -517,6 +517,7 @@
         "html-escape": "^1.0.2",
         "js-yaml": "^3.13.1",
         "jsdom": "^19.0.0",
+        "nwsapi": "2.2.0",
         "parse5": "^6.0.1",
         "prex": "^0.4.7",
         "promise-debounce": "^1.0.1"
@@ -1773,23 +1774,23 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "ecmarkdown": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.0.0.tgz",
-      "integrity": "sha512-hJxPALjSOpSMMcFjSzwzJBk8EWOu20mYlTfV7BnVTh9er0FEaT2eSx16y36YxqQfdFxPUsa0CSH4fLf0qUclKw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.2.0.tgz",
+      "integrity": "sha512-p0C4SJCvnvtm0y9gPhXBb5DlNbHsNS44ihVKBw3MXviZG2QQpZNH4z/3PbkpgECOjKOeZI+m84ISHVV9WLECFQ==",
       "requires": {
         "escape-html": "^1.0.1"
       }
     },
     "ecmarkup": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-12.1.1.tgz",
-      "integrity": "sha512-VYeNBks2LB8aVC5oOg6apA/1ZMnxynUuTidRoD1SL1p3hUpkDgjbzF0s2hLIn68XBwBFPygcX8fgb2MbYkYi9Q==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-16.0.0.tgz",
+      "integrity": "sha512-12TCAQG072ywauddgoah7N9/K8rA8v3t3MJsnSbPZDM98bNG224x5ShMxBkdVaGf5ncENTFlVom58TGCW5V0wQ==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
-        "ecmarkdown": "^7.0.0",
+        "ecmarkdown": "^7.2.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "fast-glob": "^3.2.7",
         "grammarkdown": "^3.2.0",
@@ -1797,6 +1798,7 @@
         "html-escape": "^1.0.2",
         "js-yaml": "^3.13.1",
         "jsdom": "^19.0.0",
+        "nwsapi": "2.2.0",
         "parse5": "^6.0.1",
         "prex": "^0.4.7",
         "promise-debounce": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-to": "ecmarkup --verbose --load-biblio @tc39/ecma262-biblio spec/index.html",
     "prebuild-only": "npm run clean && mkdir out && cp -R img out",
     "build-only": "npm run build-to -- out/index.html --css-out out/ecmarkup.css --js-out out/ecmarkup.js",
-    "build": "npm run build-only -- --lint-spec",
+    "build": "npm run build-only -- --lint-spec --strict",
     "build-for-pdf": "npm run build -- --old-toc",
     "test": "npm run build-to -- --lint-spec /dev/null",
     "watch": "npm run build -- --watch"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma402/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma402/",
   "dependencies": {
-    "ecmarkup": "^12.1.1",
+    "ecmarkup": "^16.0.0",
     "@tc39/ecma262-biblio": "2.1.2458"
   },
   "devDependencies": {

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -131,7 +131,7 @@
             1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
         1. If _dateTimeFormat_.[[Hour]] is *undefined*, then
           1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
-        1. If _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then
+        1. If _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
           1. Let _pattern_ be _bestFormat_.[[pattern12]].
           1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns12]].
         1. Else,

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -95,7 +95,7 @@
           (The result is a Unicode BCP 47 locale identifier, in canonical syntax but not necessarily in canonical form.)
         1. Let _localeId_ be the string _localeId_ after performing the algorithm to <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">transform it to canonical form</a>.
           (The result is a Unicode BCP 47 locale identifier, in both canonical syntax and canonical form.)
-        1. If _localeId_ contains a substring _extension_ that is a Unicode locale extension sequence, then
+        1. [declared="extension"] If _localeId_ contains a substring _extension_ that is a Unicode locale extension sequence, then
           1. Let _components_ be ! UnicodeExtensionComponents(_extension_).
           1. Let _attributes_ be _components_.[[Attributes]].
           1. Let _keywords_ be _components_.[[Keywords]].

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -173,9 +173,9 @@
       </p>
 
       <emu-alg>
-        1. Assert: _locale_ does not contain a substring that is a Unicode locale extension sequence.
+        1. Assert: _locale_ matches the `unicode_locale_id` production.
+        1. Assert: _locale_ does not contain a Unicode locale extension sequence.
         1. Assert: _extension_ is a Unicode locale extension sequence.
-        1. Assert: _tag_ matches the `unicode_locale_id` production.
         1. Let _privateIndex_ be StringIndexOf(_locale_, *"-x-"*, 0).
         1. If _privateIndex_ = -1, then
           1. Let _locale_ be the string-concatenation of _locale_ and _extension_.


### PR DESCRIPTION
This bumps ecmarkup, which now includes a lint for variables being declared before being used. I've marked two sites which appear to be introducing a variable as doing so, and corrected a typo in a third place.

There's [another place](https://github.com/tc39/ecma402/blob/469814ca60a2d5e1283e7caabf038393f55a44d8/spec/negotiation.html#L178) which refers to a variable which doesn't appear to be defined anywhere, but I couldn't figure out what that was supposed to be doing, so I've left it alone. That should cause this to fail CI. Please feel free to push up a commit fixing that issue before landing this.

Edit: oh, looks like lint rules aren't enforced in CI, so it's not failing the build. You might want to do that - it's just a matter of adding `--strict` to the build command.

(Ignore the branch name; I was originally intending for this to include a github action to publish the biblio but I'll do that as a followup.)