### PR TITLE
Editorial: Adapt to ECMA-262 DefaultTimeZone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "9.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma402/#sec-copyright-and-software-license",
       "dependencies": {
-        "@tc39/ecma262-biblio": "^2.0.2329",
+        "@tc39/ecma262-biblio": "2.1.2458",
         "ecmarkup": "^12.1.1"
       },
       "devDependencies": {}
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@tc39/ecma262-biblio": {
-      "version": "2.0.2332",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.0.2332.tgz",
-      "integrity": "sha512-fSQwtUzRqHG+G/LcrFkD5m9/MLF+oabdWRih1mfJvVcoBkerlMXWCkyEOODZpR/I+1cMQAjDcabwhEh24mOcyQ=="
+      "version": "2.1.2458",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2458.tgz",
+      "integrity": "sha512-Gallnt+z+iCITiDGrcZIYsF/KfN21qt+owKhQWiTvzwCtnq3f+2nCZkjxO1599DUOYk/QD0B8k9tvAn4jsbgng=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -1555,9 +1555,9 @@
       }
     },
     "@tc39/ecma262-biblio": {
-      "version": "2.0.2332",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.0.2332.tgz",
-      "integrity": "sha512-fSQwtUzRqHG+G/LcrFkD5m9/MLF+oabdWRih1mfJvVcoBkerlMXWCkyEOODZpR/I+1cMQAjDcabwhEh24mOcyQ=="
+      "version": "2.1.2458",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2458.tgz",
+      "integrity": "sha512-Gallnt+z+iCITiDGrcZIYsF/KfN21qt+owKhQWiTvzwCtnq3f+2nCZkjxO1599DUOYk/QD0B8k9tvAn4jsbgng=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://tc39.es/ecma402/",
   "dependencies": {
     "ecmarkup": "^12.1.1",
-    "@tc39/ecma262-biblio": "^2.0.2329"
+    "@tc39/ecma262-biblio": "2.1.2458"
   },
   "devDependencies": {
   }

--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -16,7 +16,7 @@
           The default locale (<emu-xref href="#sec-defaultlocale"></emu-xref>)
         </li>
         <li>
-          The default time zone (<emu-xref href="#sec-defaulttimezone"></emu-xref>)
+          The default time zone (<emu-xref href="#sup-defaulttimezone"></emu-xref>)
         </li>
         <li>
           The set of available locales for each constructor (<emu-xref href="#sec-internal-slots"></emu-xref>)

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -88,7 +88,7 @@
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then
-          1. Set _timeZone_ to ! DefaultTimeZone().
+          1. Set _timeZone_ to DefaultTimeZone().
         1. Else,
           1. Set _timeZone_ to ? ToString(_timeZone_).
           1. If the result of ! IsValidTimeZoneName(_timeZone_) is *false*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -927,7 +927,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, _fractionalSecondDigits_).
           1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
           1. Let _nf3_ be ? Construct(%NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
-        1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
+        1. Let _tm_ be ToLocalTime(ℤ(ℝ(_x_) &times; 10<sup>6</sup>), _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _result_ be a new empty List.
         1. For each Record { [[Type]], [[Value]] } _patternPart_ in _patternParts_, do
           1. Let _p_ be _patternPart_.[[Type]].
@@ -1057,8 +1057,8 @@
         1. If _x_ is *NaN*, throw a *RangeError* exception.
         1. Let _y_ be TimeClip(_y_).
         1. If _y_ is *NaN*, throw a *RangeError* exception.
-        1. Let _tm1_ be ToLocalTime(_x_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
-        1. Let _tm2_ be ToLocalTime(_y_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
+        1. Let _tm1_ be ToLocalTime(ℤ(ℝ(_x_) &times; 10<sup>6</sup>), _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
+        1. Let _tm2_ be ToLocalTime(ℤ(ℝ(_y_) &times; 10<sup>6</sup>), _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _rangePatterns_ be _dateTimeFormat_.[[RangePatterns]].
         1. Let _rangePattern_ be *undefined*.
         1. Let _dateFieldsPracticallyEqual_ be *true*.
@@ -1162,7 +1162,7 @@
     <emu-clause id="sec-tolocaltime" type="implementation-defined abstract operation">
       <h1>
         ToLocalTime (
-          _t_: a finite time value,
+          _epochNs_: a BigInt,
           _calendar_: a String,
           _timeZone_: a String,
         )
@@ -1174,11 +1174,8 @@
       </dl>
 
       <emu-alg>
-        1. Let _epochNs_ be ℤ(ℝ(_t_) &times; 10<sup>6</sup>).
         1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_timeZone_, _epochNs_).
-        1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
-        1. Let _tz_ be _t_ + 𝔽(_offsetMs_).
-        1. Assert: _tz_ is an integral Number.
+        1. Let _tz_ be ℝ(_epochNs_) + _offsetNs_.
         1. If _calendar_ is *"gregory"*, then
           1. Return a record with fields calculated from _tz_ according to <emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref>.
         1. Else,
@@ -1196,15 +1193,15 @@
           </thead>
           <tr>
             <td>[[Weekday]]</td>
-            <td>`WeekDay(tz)` specified in es2023's <emu-xref href="#sec-week-day">Week Day</emu-xref></td>
+            <td>WeekDay(𝔽(floor(_tz_ / 10<sup>6</sup>)))</td>
           </tr>
           <tr>
             <td>[[Era]]</td>
-            <td>Let `year` be `YearFromTime(tz)` specified in es2023's <emu-xref href="#sec-year-number">Year Number</emu-xref>. If `year` is less than 0, return 'BC', else, return 'AD'.</td>
+            <td>Let _year_ be YearFromTime(𝔽(floor(_tz_ / 10<sup>6</sup>))). If _year_ &lt; *-0*<sub>𝔽</sub>, return *"BC"*, else return *"AD"*.</td>
           </tr>
           <tr>
             <td>[[Year]]</td>
-            <td>`YearFromTime(tz)` specified in es2023's <emu-xref href="#sec-year-number">Year Number</emu-xref></td>
+            <td>YearFromTime(𝔽(floor(_tz_ / 10<sup>6</sup>)))</td>
           </tr>
           <tr>
             <td>[[RelatedYear]]</td>
@@ -1216,27 +1213,27 @@
           </tr>
           <tr>
             <td>[[Month]]</td>
-            <td>`MonthFromTime(tz)` specified in es2023's <emu-xref href="#sec-month-number">Month Number</emu-xref></td>
+            <td>MonthFromTime(𝔽(floor(_tz_ / 10<sup>6</sup>)))</td>
           </tr>
           <tr>
             <td>[[Day]]</td>
-            <td>`DateFromTime(tz)` specified in es2023's <emu-xref href="#sec-date-number">Date Number</emu-xref></td>
+            <td>DateFromTime(𝔽(floor(_tz_ / 10<sup>6</sup>)))</td>
           </tr>
           <tr>
             <td>[[Hour]]</td>
-            <td>`HourFromTime(tz)` specified in es2023's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
+            <td>HourFromTime(𝔽(floor(_tz_ / 10<sup>6</sup>)))</td>
           </tr>
           <tr>
             <td>[[Minute]]</td>
-            <td>`MinFromTime(tz)` specified in es2023's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
+            <td>MinFromTime(𝔽(floor(_tz_ / 10<sup>6</sup>)))</td>
           </tr>
           <tr>
             <td>[[Second]]</td>
-            <td>`SecFromTime(tz)` specified in es2023's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
+            <td>SecFromTime(𝔽(floor(_tz_ / 10<sup>6</sup>)))</td>
           </tr>
           <tr>
             <td>[[Millisecond]]</td>
-            <td>`msFromTime(tz)` specified in es2023's <emu-xref href="#sec-hours-minutes-second-and-milliseconds">Hours, Minutes, Second, and Milliseconds</emu-xref></td>
+            <td>msFromTime(𝔽(floor(_tz_ / 10<sup>6</sup>)))</td>
           </tr>
           <tr>
             <td>[[InDST]]</td>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1159,21 +1159,30 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-tolocaltime" aoid="ToLocalTime">
-      <h1>ToLocalTime ( _t_, _calendar_, _timeZone_ )</h1>
+    <emu-clause id="sec-tolocaltime" type="implementation-defined abstract operation">
+      <h1>
+        ToLocalTime (
+          _t_: a finite time value,
+          _calendar_: a String,
+          _timeZone_: a String,
+        )
+      </h1>
 
-      <p>
-        When the ToLocalTime abstract operation is called with arguments _t_, _calendar_, and _timeZone_, the following steps are taken:
-      </p>
+      <dl class="header">
+        <dt>description</dt>
+        <dd></dd>
+      </dl>
 
       <emu-alg>
-        1. Assert: Type(_t_) is Number.
+        1. Let _epochNs_ be ℤ(ℝ(_t_) &times; 10<sup>6</sup>).
+        1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_timeZone_, _epochNs_).
+        1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
+        1. Let _tz_ be _t_ + 𝔽(_offsetMs_).
+        1. Assert: _tz_ is an integral Number.
         1. If _calendar_ is *"gregory"*, then
-          1. Let _timeZoneOffset_ be the value calculated according to <emu-xref href="#sec-local-time-zone-adjustment">LocalTZA(_t_, *true*)</emu-xref> where the local time zone is replaced with timezone _timeZone_.
-          1. Let _tz_ be the time value _t_ + _timeZoneOffset_.
           1. Return a record with fields calculated from _tz_ according to <emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref>.
         1. Else,
-          1. Return a record with the fields of Column 1 of <emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref> calculated from _t_ for the given _calendar_ and _timeZone_. The calculations should use best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules.
+          1. Return a record with the fields of Column 1 of <emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref> calculated from _tz_ for the given _calendar_. The calculations should use best available information about the specified _calendar_.
       </emu-alg>
 
       <emu-table id="table-datetimeformat-tolocaltime-record">

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -206,11 +206,16 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-defaulttimezone" aoid="DefaultTimeZone">
-      <h1>DefaultTimeZone ( )</h1>
+    <emu-clause id="sup-defaulttimezone" oldids="sec-defaulttimezone" type="implementation-defined abstract operation">
+      <h1>DefaultTimeZone ( ): a String</h1>
+
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a String value representing the host environment's current time zone, which is a valid (<emu-xref href="#sec-isvalidtimezonename"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizetimezonename"></emu-xref>) time zone name.</dd>
+      </dl>
 
       <p>
-        The DefaultTimeZone abstract operation returns a String value representing the valid (<emu-xref href="#sec-isvalidtimezonename"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizetimezonename"></emu-xref>) time zone name for the host environment's current time zone.
+        This definition supersedes the definition provided in es2023, <emu-xref href="#sec-defaulttimezone"></emu-xref>.
       </p>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This makes some editorial changes as a result of https://github.com/tc39/ecma262/pull/2781:
- ECMA-262 now has its own DefaultTimeZone operation, so ECMA-402 should note that it supersedes the ECMA-262 one.
- The LocalTZA operation is gone from ECMA-262, so instead use the GetNamedTimeZoneOffsetNanoseconds operation in ToLocalTime.
- GetNamedTimeZoneOffsetNanoseconds encapsulates the requirement to use best-available time zone information, so we can remove one instance of that language and simplify ToLocalTime by calculating the local time regardless of calendar.
- Add structured headers to DefaultTimeZone and ToLocalTime while we're at it.

Closes: #684