### PR TITLE
Normative: Canonicalise "GMT" to "UTC"

### DIFF
--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -201,7 +201,7 @@
       <emu-alg>
         1. Let _ianaTimeZone_ be the String value of the Zone or Link name of the IANA Time Zone Database that is an ASCII-case-insensitive match for _timeZone_.
         1. If _ianaTimeZone_ is a Link name, let _ianaTimeZone_ be the String value of the corresponding Zone name as specified in the file <code>backward</code> of the IANA Time Zone Database.
-        1. If _ianaTimeZone_ is *"Etc/UTC"* or *"Etc/GMT"*, return *"UTC"*.
+        1. If _ianaTimeZone_ is one of *"Etc/UTC"*, *"Etc/GMT"*, or *"GMT"*, return *"UTC"*.
         1. Return _ianaTimeZone_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
tzdata 2022f using vanguard format made "GMT" a zone and "Etc/GMT" a link to "GMT". Rearguard format still has this the other way around, i.e. "Etc/GMT" is a zone and "GMT" a link to "Etc/GMT". Because we don't control if vanguard or rearguard format is used by an implementation, the `CanonicalizeTimeZoneName` operation should canonicalise both "Etc/GMT" and "GMT" to "UTC".

