### PR TITLE
Meta: Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,0 +1,11 @@
+---
+name: "\U0001F680 Feature request"
+about: Propose changes for future versions of the specification.
+
+---
+
+<!--
+Thank you for your interest in proposing a feature. Your goal will be to convince others that it is a useful addition and recruit TC39 members to help shepherd it into the specification.
+
+Please review the guidelines in [CONTRIBUTING.md](https://github.com/tc39/ecma402/blob/HEAD/CONTRIBUTING.md#ecma-402-guidelines-for-feature-requests-and-proposals).
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,9 @@
 --- 
 blank_issues_enabled: true
 contact_links: 
-  - 
-    about: "See the contributing guidelines for feature requests and proposals"
-    name: "\U0001F680 Feature request"
-    url: "https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md"
-  - 
-    about: "This repository is a TC39 project and subscribes to its code of conduct"
-    name: "\U0001F4AC Code of Conduct"
+  - name: "Proposal guidelines"
+    about: "Criteria against which feature requests and proposals are evaluated."
+    url: "https://github.com/tc39/ecma402/blob/HEAD/CONTRIBUTING.md#ecma-402-guidelines-for-feature-requests-and-proposals"
+  - name: "\U0001F4AC Code of conduct"
+    about: "This repository is a TC39 project and subscribes to its code of conduct."
     url: "https://tc39.es/code-of-conduct/"


### PR DESCRIPTION
Keep the guidelines link (but correct its target to ECMA-402 CONTRIBUTING.md) and add a template specifically for proposals (with a guidelines link of its own).