### PR TITLE
editorial: CreatePartsFromList type change

### DIFF
--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -281,7 +281,7 @@
       <h1>CreatePartsFromList ( _listFormat_, _list_ )</h1>
 
       <p>
-        The CreatePartsFromList abstract operation is called with arguments _listFormat_ (which must be an object initialized as a ListFormat) and _list_ (which must be a List of String values), and creates the corresponding list of parts according to the effective locale and the formatting options of _listFormat_.
+        The CreatePartsFromList abstract operation is called with arguments _listFormat_ (which must be an object initialized as a ListFormat) and _list_ (which must be a List), and creates the corresponding list of parts according to the effective locale and the formatting options of _listFormat_.
         Each part is a Record with two fields: [[Type]], which must be a string with values "element" or "literal", and [[Value]] which must be a string or a number.
         The following steps are taken:
       </p>


### PR DESCRIPTION
Change the expected type of the "list" argument for the CreatePartsFromList abstract operation from a List of String values to a simple List. This makes no outside observable normative change but allows other built-ins to use this operation in more interesting ways, primarily motivated by `Intl.DurationFormat` which utilizes this operation in order to format the list of different duration units.

Refs: https://github.com/tc39/proposal-intl-duration-format/issues/103

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
