### PR TITLE
Editorial: Explicitly provide all GetIterator arguments

### DIFF
--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -364,7 +364,7 @@
       <emu-alg>
         1. If _iterable_ is *undefined*, then
           1. Return a new empty List.
-        1. Let _iteratorRecord_ be ? GetIterator(_iterable_).
+        1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
         1. Let _list_ be a new empty List.
         1. Let _next_ be *true*.
         1. Repeat, while _next_ is not *false*,


### PR DESCRIPTION
https://github.com/tc39/ecma262/pull/3021 proposes removing optionality from the second argument