### PR TITLE
Normative: Change the hourCycle default logic

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -205,7 +205,7 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle]] must be a String value equal to *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle12]] must be a String value equal to *"h11"*, *"h12"*.
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle12]] must be a String value equal to *"h11"* or *"h12"*.
         </li>
         <li>
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle24]] must be a String value equal to *"h23"*, or *"h24"*.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -77,7 +77,7 @@
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. If _hour12_ is *true*, then
-          1. Let _hc_ to _dataLocaleData_.[[hourCycle12]].
+          1. Let _hc_ be _dataLocaleData_.[[hourCycle12]].
         1. Else if _hour12_ is *false*, then
           1. Let _hc_ be _dataLocaleData_.[[hourCycle24]].
         1. Else,

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -76,15 +76,14 @@
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
         1. If _hour12_ is *true*, then
-          1. If _hcDefault_ is *"h11"* or *"h23"*, let _hc_ be *"h11"*. Otherwise, let _hc_ be *"h12"*.
+          1. Let _hc_ to _dataLocaleData_.[[hourCycle12]].
         1. Else if _hour12_ is *false*, then
-          1. Let _hc_ be *"h23"*.
+          1. Let _hc_ to _dataLocaleData_.[[hourCycle24]].
         1. Else,
           1. Assert: _hour12_ is *undefined*.
           1. Let _hc_ be _r_.[[hc]].
-          1. If _hc_ is *null*, set _hc_ to _hcDefault_.
+          1. If _hc_ is *null*, set _hc_ to _dataLocaleData_.[[hourCycle]].
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then
@@ -204,6 +203,12 @@
         </li>
         <li>
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle]] must be a String value equal to *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
+        </li>
+        <li>
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle12]] must be a String value equal to *"h11"*, *"h12"*.
+        </li>
+        <li>
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle24]] must be a String value equal to *"h23"*, or *"h24"*.
         </li>
         <li>
           [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. This [[formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a list of records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -76,15 +76,15 @@
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
         1. If _hour12_ is *true*, then
-          1. Let _hc_ be *"h12"*.
+          1. If _hcDefault_ is *"h11"* or *"h23"*, let _hc_ be *"h11"*. Otherwise, let _hc_ be *"h12"*.
         1. Else if _hour12_ is *false*, then
           1. Let _hc_ be *"h23"*.
         1. Else,
           1. Assert: _hour12_ is *undefined*.
           1. Let _hc_ be _r_.[[hc]].
-          1. If _hc_ is *null*, then
-            1. Set _hc_ to _dataLocaleData_.[[hourCycle]].
+          1. If _hc_ is *null*, set _hc_ to _hcDefault_.
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -76,15 +76,16 @@
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
         1. If _hour12_ is *true*, then
-          1. If _hcDefault_ is *"h11"* or *"h23"*, let _hc_ be *"h11"*. Otherwise, let _hc_ be *"h12"*.
+          1. Let _hc_ be *"h12"*.
         1. Else if _hour12_ is *false*, then
-          1. If _hcDefault_ is *"h11"* or *"h23"*, let _hc_ be *"h23"*. Otherwise, let _hc_ be *"h24"*.
+          1. Let _hc_ be *"h23"*.
         1. Else,
           1. Assert: _hour12_ is *undefined*.
           1. Let _hc_ be _r_.[[hc]].
-          1. If _hc_ is *null*, set _hc_ to _hcDefault_.
+          1. If _hc_ is *null*, then
+            1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
+            1. Set _hc_ to _hcDefault_.
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -79,7 +79,7 @@
         1. If _hour12_ is *true*, then
           1. Let _hc_ to _dataLocaleData_.[[hourCycle12]].
         1. Else if _hour12_ is *false*, then
-          1. Let _hc_ to _dataLocaleData_.[[hourCycle24]].
+          1. Let _hc_ be _dataLocaleData_.[[hourCycle24]].
         1. Else,
           1. Assert: _hour12_ is *undefined*.
           1. Let _hc_ be _r_.[[hc]].

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -84,8 +84,7 @@
           1. Assert: _hour12_ is *undefined*.
           1. Let _hc_ be _r_.[[hc]].
           1. If _hc_ is *null*, then
-            1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
-            1. Set _hc_ to _hcDefault_.
+            1. Set _hc_ to _dataLocaleData_.[[hourCycle]].
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -208,7 +208,7 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle12]] must be a String value equal to *"h11"* or *"h12"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle24]] must be a String value equal to *"h23"*, or *"h24"*.
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle24]] must be a String value equal to *"h23"* or *"h24"*.
         </li>
         <li>
           [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. This [[formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a list of records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:


### PR DESCRIPTION
While hour12 is  false, let hourCycle to be alwasyt 'h23' but not 'h24'.

The current logic is not reasonable. We see no region in the CLDR use  h24 hour cycle as default.  While we set a hour12: false on a 12 hour system region (which use 1:00 - 12:59), we should set to h23 instead of h24

We need to make this change
so while hour12 is false on 'en' locale, it will be set to h23 instead of h24
but also while hour12 is true on 'ja' locale, it will be set to h11 but not h12.

Address https://github.com/tc39/ecma402/issues/402

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
