### PR TITLE
Editorial: remove `!` from two calls to AOs that can't throw

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -91,9 +91,9 @@
           1. Set _timeZone_ to DefaultTimeZone().
         1. Else,
           1. Set _timeZone_ to ? ToString(_timeZone_).
-          1. If the result of ! IsValidTimeZoneName(_timeZone_) is *false*, then
+          1. If the result of IsValidTimeZoneName(_timeZone_) is *false*, then
             1. Throw a *RangeError* exception.
-          1. Set _timeZone_ to ! CanonicalizeTimeZoneName(_timeZone_).
+          1. Set _timeZone_ to CanonicalizeTimeZoneName(_timeZone_).
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
         1. Let _formatOptions_ be a new Record.
         1. Set _formatOptions_.[[hourCycle]] to _hc_.


### PR DESCRIPTION
This commit removes the `!` from two AO calls that return regular values, not abrupt completions.

From a quick look it seems that there are quite a few other AOs that cannot throw but still are called with `!` in the spec, so it's probably worth a full scrub at some point. For this PR I'm only worried about calls that I noticed while reviewing a Temporal PR.