### PR TITLE
Editorial: update time zone identifier text

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -629,7 +629,7 @@
       </p>
 
       <emu-note>
-        In this version of the ECMAScript 2023 Internationalization API, the *"timeZone"* property will be the name of the default time zone if no *"timeZone"* property was provided in the options object provided to the Intl.DateTimeFormat constructor. The first edition left the *"timeZone"* property *undefined* in this case.
+        In this version of the ECMAScript 2023 Internationalization API, the *"timeZone"* property will be the identifier of the host environment's time zone if no *"timeZone"* property was provided in the options object provided to the Intl.DateTimeFormat constructor. The first edition left the *"timeZone"* property *undefined* in this case.
       </emu-note>
 
       <emu-note>
@@ -657,7 +657,7 @@
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
       <li>[[Calendar]] is a String value with the *"type"* given in Unicode Technical Standard #35 for the calendar used for formatting.</li>
       <li>[[NumberingSystem]] is a String value with the *"type"* given in Unicode Technical Standard #35 for the numbering system used for formatting.</li>
-      <li>[[TimeZone]] is a String value with the IANA time zone name of the time zone used for formatting.</li>
+      <li>[[TimeZone]] is a String value that is a time zone identifier from the IANA Time Zone Database used for formatting.</li>
       <li>[[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]] are each either *undefined*, indicating that the component is not used for formatting, or one of the String values given in <emu-xref href="#table-datetimeformat-components"></emu-xref>, indicating how the component should be presented in the formatted output.</li>
       <li>[[FractionalSecondDigits]] is either *undefined* or a positive, non-zero integer Number value indicating the fraction digits to be used for fractional seconds. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
       <li>[[HourCycle]] is a String value indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[Hour]] is not *undefined*.</li>
@@ -991,7 +991,7 @@
       </emu-note>
 
       <emu-note>
-        It is recommended that implementations use the time zone information of the IANA Time Zone Database.
+        A conforming implementation must recognize *"UTC"* and all other Zone and Link names (and <strong>only</strong> such names), and use best available current and historical information about their offsets from UTC and their daylight saving time rules in calculations.
       </emu-note>
     </emu-clause>
 
@@ -1164,7 +1164,7 @@
         ToLocalTime (
           _epochNs_: a BigInt,
           _calendar_: a String,
-          _timeZone_: a String,
+          _timeZoneIdentifier_: a String,
         )
       </h1>
 
@@ -1174,7 +1174,7 @@
       </dl>
 
       <emu-alg>
-        1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_timeZone_, _epochNs_).
+        1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_timeZoneIdentifier_, _epochNs_).
         1. Let _tz_ be ℝ(_epochNs_) + _offsetNs_.
         1. If _calendar_ is *"gregory"*, then
           1. Return a record with fields calculated from _tz_ according to <emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref>.
@@ -1237,13 +1237,13 @@
           </tr>
           <tr>
             <td>[[InDST]]</td>
-            <td>Calculate *true* or *false* using the best available information about the specified _calendar_ and _timeZone_, including current and historical information about time zone offsets from UTC and daylight saving time rules.</td>
+            <td>Calculate *true* or *false* using the best available information about the specified _calendar_ and _timeZoneIdentifier_, including current and historical information from the IANA Time Zone Database about time zone offsets from UTC and daylight saving time rules.</td>
           </tr>
         </table>
       </emu-table>
 
       <emu-note>
-        It is recommended that implementations use the time zone information of the IANA Time Zone Database.
+        A conforming implementation must recognize *"UTC"* and all other Zone and Link names (and <strong>only</strong> such names), and use best available current and historical information about their offsets from UTC and their daylight saving time rules in calculations.
       </emu-note>
     </emu-clause>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -989,10 +989,6 @@
       <emu-note>
         It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="https://cldr.unicode.org/">https://cldr.unicode.org/</a>), and use CLDR *"abbreviated"* strings for DateTimeFormat *"short"* strings, and CLDR *"wide"* strings for DateTimeFormat *"long"* strings.
       </emu-note>
-
-      <emu-note>
-        A conforming implementation must recognize *"UTC"* and all other Zone and Link names (and <strong>only</strong> such names), and use best available current and historical information about their offsets from UTC and their daylight saving time rules in calculations.
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-partitiondatetimepattern" aoid="PartitionDateTimePattern">
@@ -1243,7 +1239,7 @@
       </emu-table>
 
       <emu-note>
-        A conforming implementation must recognize *"UTC"* and all other Zone and Link names (and <strong>only</strong> such names), and use best available current and historical information about their offsets from UTC and their daylight saving time rules in calculations.
+        A conforming implementation must recognize *"UTC"* and all Zone and Link names from the IANA Time Zone Database (and <strong>only</strong> such names), and use best available current and historical information about their offsets from UTC and their daylight saving time rules in calculations.
       </emu-note>
     </emu-clause>
 


### PR DESCRIPTION
This PR includes a few minor updates to spec text about time zone identifiers that I noticed while preparing the Time Zone Canonicalization proposal:
* Fixes an inconsistency between text in [#sec-time-zone-names](https://tc39.es/ecma402/#sec-time-zone-names) (which requires IANA Time Zone Database) and text in two AOs that implies that such support is optional. This PR replaces the latter optional-implying text with the text from #sec-time-zone-names.
* Renames `_timeZone_` variable to `_timeZoneIdentifier_` when it's guaranteed to be a string.
* Replaces "name" with the more precise "identifier" in a few places.
