### PR TITLE
Normative: Reorder NF resolved option "roundingPriority"

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -17,7 +17,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingMode]], [[RoundingIncrement]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
+        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingMode]], [[RoundingIncrement]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
         1. Perform ? InitializeNumberFormat(_numberFormat_, _locales_, _options_).
         1. If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then
           1. Let _this_ be the *this* value.
@@ -166,14 +166,19 @@
           1. Set _intlObj_.[[MinimumSignificantDigits]] to 1.
           1. Set _intlObj_.[[MaximumSignificantDigits]] to 2.
           1. Set _intlObj_.[[RoundingType]] to ~morePrecision~.
+          1. Set _intlObj_.[[ComputedRoundingPriority]] to *"morePrecision"*.
         1. Else if _roundingPriority_ is *"morePrecision"*, then
           1. Set _intlObj_.[[RoundingType]] to ~morePrecision~.
+          1. Set _intlObj_.[[ComputedRoundingPriority]] to *"morePrecision"*.
         1. Else if _roundingPriority_ is *"lessPrecision"*, then
           1. Set _intlObj_.[[RoundingType]] to ~lessPrecision~.
+          1. Set _intlObj_.[[ComputedRoundingPriority]] to *"lessPrecision"*.
         1. Else if _hasSd_ is *true*, then
           1. Set _intlObj_.[[RoundingType]] to ~significantDigits~.
+          1. Set _intlObj_.[[ComputedRoundingPriority]] to *"auto"*.
         1. Else,
           1. Set _intlObj_.[[RoundingType]] to ~fractionDigits~.
+          1. Set _intlObj_.[[ComputedRoundingPriority]] to *"auto"*.
         1. If _roundingIncrement_ is not 1, then
           1. If _intlObj_.[[RoundingType]] is not ~fractionDigits~, throw a *TypeError* exception.
           1. If _intlObj_.[[MaximumFractionDigits]] is not equal to _intlObj_.[[MinimumFractionDigits]], throw a *RangeError* exception.
@@ -409,12 +414,6 @@
           1. Let _v_ be the value of _nf_'s internal slot whose name is the Internal Slot value of the current row.
           1. If _v_ is not *undefined*, then
             1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
-        1. If _nf_.[[RoundingType]] is ~morePrecision~, then
-          1. Perform ! CreateDataPropertyOrThrow(_options_, *"roundingPriority"*, *"morePrecision"*).
-        1. Else if _nf_.[[RoundingType]] is ~lessPrecision~, then
-          1. Perform ! CreateDataPropertyOrThrow(_options_, *"roundingPriority"*, *"lessPrecision"*).
-        1. Else,
-          1. Perform ! CreateDataPropertyOrThrow(_options_, *"roundingPriority"*, *"auto"*).
         1. Return _options_.
       </emu-alg>
 
@@ -506,6 +505,10 @@
           <tr>
             <td>[[TrailingZeroDisplay]]</td>
             <td>*"trailingZeroDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[ComputedRoundingPriority]]</td>
+            <td>*"roundingPriority"*</td>
           </tr>
         </table>
       </emu-table>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -503,12 +503,12 @@
             <td>*"roundingIncrement"*</td>
           </tr>
           <tr>
-            <td>[[TrailingZeroDisplay]]</td>
-            <td>*"trailingZeroDisplay"*</td>
-          </tr>
-          <tr>
             <td>[[ComputedRoundingPriority]]</td>
             <td>*"roundingPriority"*</td>
+          </tr>
+          <tr>
+            <td>[[TrailingZeroDisplay]]</td>
+            <td>*"trailingZeroDisplay"*</td>
           </tr>
         </table>
       </emu-table>


### PR DESCRIPTION
The second commit is a normative reordering of property sequence; the first commit is a supporting editorial change that should land in some form even if the normative change is rejected.