### PR TITLE
Editorial: Refactor to replace camelCase slot and field names with PascalCase equivalents

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -45,7 +45,7 @@
           1. Let _localeData_ be %Collator%.[[SearchLocaleData]].
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
-        1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Set _opt_.[[LocaleMatcher]] to _matcher_.
         1. Let _collation_ be ? GetOption(_options_, *"collation"*, ~string~, ~empty~, *undefined*).
         1. If _collation_ is not *undefined*, then
           1. If _collation_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
@@ -58,7 +58,7 @@
         1. Set _opt_.[[kf]] to _caseFirst_.
         1. Let _relevantExtensionKeys_ be %Collator%.[[RelevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(%Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
-        1. Set _collator_.[[Locale]] to _r_.[[locale]].
+        1. Set _collator_.[[Locale]] to _r_.[[Locale]].
         1. Let _collation_ be _r_.[[co]].
         1. If _collation_ is *null*, let _collation_ be *"default"*.
         1. Set _collator_.[[Collation]] to _collation_.
@@ -71,9 +71,9 @@
           1. If _usage_ is *"sort"*, then
             1. Let _sensitivity_ be *"variant"*.
           1. Else,
-            1. Let _dataLocale_ be _r_.[[dataLocale]].
+            1. Let _dataLocale_ be _r_.[[DataLocale]].
             1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-            1. Let _sensitivity_ be _dataLocaleData_.[[sensitivity]].
+            1. Let _sensitivity_ be _dataLocaleData_.[[Sensitivity]].
         1. Set _collator_.[[Sensitivity]] to _sensitivity_.
         1. Let _ignorePunctuation_ be ? GetOption(_options_, *"ignorePunctuation"*, ~boolean~, ~empty~, *false*).
         1. Set _collator_.[[IgnorePunctuation]] to _ignorePunctuation_.
@@ -133,7 +133,7 @@
       <ul>
         <li>The first element of [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] must be *null*.</li>
         <li>The values *"standard"* and *"search"* must not be used as elements in any [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] list.</li>
-        <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] must have a [[sensitivity]] field with a String value equal to *"base"*, *"accent"*, *"case"*, or *"variant"*.</li>
+        <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] must have a [[Sensitivity]] field with a String value equal to *"base"*, *"accent"*, *"case"*, or *"variant"*.</li>
       </ul>
     </emu-clause>
   </emu-clause>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -54,7 +54,7 @@
         1. Set _options_ to ? ToDateTimeOptions(_options_, *"any"*, *"date"*).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
-        1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Set _opt_.[[LocaleMatcher]] to _matcher_.
         1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, ~string~, ~empty~, *undefined*).
         1. If _calendar_ is not *undefined*, then
           1. If _calendar_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
@@ -70,13 +70,13 @@
         1. Set _opt_.[[hc]] to _hourCycle_.
         1. Let _localeData_ be %DateTimeFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%DateTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %DateTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _dateTimeFormat_.[[Locale]] to _r_.[[locale]].
+        1. Set _dateTimeFormat_.[[Locale]] to _r_.[[Locale]].
         1. Let _resolvedCalendar_ be _r_.[[ca]].
         1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _dataLocale_ be _r_.[[dataLocale]].
+        1. Let _dataLocale_ be _r_.[[DataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].
+        1. Let _hcDefault_ be _dataLocaleData_.[[HourCycle]].
         1. If _hour12_ is *true*, then
           1. If _hcDefault_ is *"h11"* or *"h23"*, let _hc_ be *"h11"*. Otherwise, let _hc_ be *"h12"*.
         1. Else if _hour12_ is *false*, then
@@ -96,7 +96,7 @@
           1. Set _timeZone_ to CanonicalizeTimeZoneName(_timeZone_).
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
         1. Let _formatOptions_ be a new Record.
-        1. Set _formatOptions_.[[hourCycle]] to _hc_.
+        1. Set _formatOptions_.[[HourCycle]] to _hc_.
         1. Let _hasExplicitFormatComponents_ be *false*.
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
           1. Let _prop_ be the name given in the Property column of the row.
@@ -105,7 +105,10 @@
           1. Else,
             1. Let _values_ be a List whose elements are the strings given in the Values column of the row.
             1. Let _value_ be ? GetOption(_options_, _prop_, ~string~, _values_, *undefined*).
-          1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
+          1. Let _first_ be the ASCII-uppercase of the substring of _prop_ from 0 to 1.
+          1. Let _rest_ be the substring of prop from 1.
+          1. Let _field_ be the string-concatenation of _first_ and _rest_.
+          1. Set _formatOptions_.[[&lt;_field_&gt;]] to _value_.
           1. If _value_ is not *undefined*, then
             1. Set _hasExplicitFormatComponents_ to *true*.
         1. Let _matcher_ be ? GetOption(_options_, *"formatMatcher"*, ~string~, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
@@ -116,27 +119,30 @@
         1. If _dateStyle_ is not *undefined* or _timeStyle_ is not *undefined*, then
           1. If _hasExplicitFormatComponents_ is *true*, then
             1. Throw a *TypeError* exception.
-          1. Let _styles_ be _dataLocaleData_.[[styles]].[[&lt;_resolvedCalendar_&gt;]].
+          1. Let _styles_ be _dataLocaleData_.[[Styles]].[[&lt;_resolvedCalendar_&gt;]].
           1. Let _bestFormat_ be DateTimeStyleFormat(_dateStyle_, _timeStyle_, _styles_).
         1. Else,
-          1. Let _formats_ be _dataLocaleData_.[[formats]].[[&lt;_resolvedCalendar_&gt;]].
+          1. Let _formats_ be _dataLocaleData_.[[Formats]].[[&lt;_resolvedCalendar_&gt;]].
           1. If _matcher_ is *"basic"*, then
             1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
           1. Else,
             1. Let _bestFormat_ be BestFitFormatMatcher(_formatOptions_, _formats_).
         1. For each row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
           1. Let _prop_ be the name given in the Property column of the row.
-          1. If _bestFormat_ has a field [[&lt;_prop_&gt;]], then
-            1. Let _p_ be _bestFormat_.[[&lt;_prop_&gt;]].
+          1. Let _first_ be the ASCII-uppercase of the substring of _prop_ from 0 to 1.
+          1. Let _rest_ be the substring of prop from 1.
+          1. Let _field_ be the string-concatenation of _first_ and _rest_.
+          1. If _bestFormat_ has a field [[&lt;_field_&gt;]], then
+            1. Let _p_ be _bestFormat_.[[&lt;_field_&gt;]].
             1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
         1. If _dateTimeFormat_.[[Hour]] is *undefined*, then
           1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
         1. If _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
-          1. Let _pattern_ be _bestFormat_.[[pattern12]].
-          1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns12]].
+          1. Let _pattern_ be _bestFormat_.[[Pattern12]].
+          1. Let _rangePatterns_ be _bestFormat_.[[RangePatterns12]].
         1. Else,
-          1. Let _pattern_ be _bestFormat_.[[pattern]].
-          1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns]].
+          1. Let _pattern_ be _bestFormat_.[[Pattern]].
+          1. Let _rangePatterns_ be _bestFormat_.[[RangePatterns]].
         1. Set _dateTimeFormat_.[[Pattern]] to _pattern_.
         1. Set _dateTimeFormat_.[[RangePatterns]] to _rangePatterns_.
         1. Return _dateTimeFormat_.
@@ -203,33 +209,33 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hc]] must be &laquo; *null*, *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle]] must be a String value equal to *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[HourCycle]] must be a String value equal to *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. This [[formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a list of records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[Formats]] field. This [[Formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a list of records, each of which has a subset of the fields shown in the Internal slot/Field column of <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
           <ul>
-            <li>weekday, year, month, day, hour, minute, second, fractionalSecondDigits</li>
-            <li>weekday, year, month, day, hour, minute, second</li>
-            <li>weekday, year, month, day</li>
-            <li>year, month, day</li>
-            <li>year, month</li>
-            <li>month, day</li>
-            <li>hour, minute, second, fractionalSecondDigits</li>
-            <li>hour, minute, second</li>
-            <li>hour, minute</li>
-            <li>dayPeriod, hour</li>
-            <li>dayPeriod, hour, minute, second</li>
-            <li>dayPeriod, hour, minute</li>
+            <li>[[Weekday]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]]</li>
+            <li>[[Weekday]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]]</li>
+            <li>[[Weekday]], [[Year]], [[Month]], [[Day]]</li>
+            <li>[[Year]], [[Month]], [[Day]]</li>
+            <li>[[Year]], [[Month]]</li>
+            <li>[[Month]], [[Day]]</li>
+            <li>[[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]]</li>
+            <li>[[Hour]], [[Minute]], [[Second]]</li>
+            <li>[[Hour]], [[Minute]]</li>
+            <li>[[DayPeriod]], [[Hour]]</li>
+            <li>[[DayPeriod]], [[Hour]], [[Minute]], [[Second]]</li>
+            <li>[[DayPeriod]], [[Hour]], [[Minute]]</li>
           </ul>
           Each of the records must also have the following fields:
           <ol>
-            <li>A [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*.</li>
-            <li>If the record has an [[hour]] field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the [[pattern]] field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</li>
-            <li>If the record has a [[year]] field, the [[pattern]] and [[pattern12]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</li>
+            <li>A [[Pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*.</li>
+            <li>If the record has an [[Hour]] field, it must also have a [[Pattern12]] field, whose value is a String value that, in addition to the substrings of the [[Pattern]] field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</li>
+            <li>If the record has a [[Year]] field, the [[Pattern]] and [[Pattern12]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</li>
             <li>
-              A [[rangePatterns]] field with a Record value:
+              A [[RangePatterns]] field with a Record value:
                 <ul>
-                  <li>The [[rangePatterns]] record may have any of the fields in <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref>, where each field represents a range pattern and its value is a Record.
+                  <li>The [[RangePatterns]] record may have any of the fields in <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref>, where each field represents a range pattern and its value is a Record.
                     <ul>
                       <li>The name of the field indicates the largest calendar element that must be different between the start and end dates in order to use this range pattern. For example, if the field name is [[Month]], it contains the range pattern that should be used to format a date range where the era and year values are the same, but the month value is different.</li>
                       <li>The record will contain the following fields:</li>
@@ -239,37 +245,37 @@
                         </ul>
                     </ul>
                   </li>
-                  <li>The [[rangePatterns]] record must have a [[Default]] field which contains the default range pattern used when the specific range pattern is not available. Its value is a list of records with the same structure as the other fields in the [[rangePatterns]] record.</li>
+                  <li>The [[RangePatterns]] record must have a [[Default]] field which contains the default range pattern used when the specific range pattern is not available. Its value is a list of records with the same structure as the other fields in the [[RangePatterns]] record.</li>
                 </ul>
             </li>
-            <li>If the record has an [[hour]] field, it must also have a [[rangePatterns12]] field. Its value is similar to the Record in [[rangePatterns]], but it uses a String similar to [[pattern12]] for each part of the range pattern.</li>
-            <li>If the record has a [[year]] field, the [[rangePatterns]] and [[rangePatterns12]] fields may contain range patterns where the [[Pattern]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</li>
+            <li>If the record has an [[Hour]] field, it must also have a [[RangePatterns12]] field. Its value is similar to the Record in [[RangePatterns]], but it uses a String similar to [[Pattern12]] for each part of the range pattern.</li>
+            <li>If the record has a [[Year]] field, the [[RangePatterns]] and [[RangePatterns12]] fields may contain range patterns where the [[Pattern]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</li>
           </ol>
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[styles]] field. The [[styles]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The calendar records must contain [[DateFormat]], [[TimeFormat]], [[DateTimeFormat]] and [[DateTimeRangeFormat]] fields, the value of these fields are Records, where each of which has [[full]], [[long]], [[medium]] and [[short]] fields. For [[DateFormat]] and [[TimeFormat]], the value of these fields must be a record, which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Each of the records must also have the following fields:
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[Styles]] field. The [[Styles]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The calendar records must contain [[DateFormat]], [[TimeFormat]], [[DateTimeFormat]] and [[DateTimeRangeFormat]] fields, the value of these fields are Records, where each of which has [[Full]], [[Long]], [[Medium]] and [[Short]] fields. For [[DateFormat]] and [[TimeFormat]], the value of these fields must be a record, which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Each of the records must also have the following fields:
           <ol>
-            <li>A [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*.</li>
-            <li>If the record has an [[hour]] field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the pattern field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</li>
-            <li>A [[rangePatterns]] field that contains a record similar to the one described in the [[formats]] field.</li>
-            <li>If the record has an [[hour]] field, it must also have a [[rangePatterns12]] field. Its value is similar to the record in [[rangePatterns]] but it uses a string similar to [[pattern12]] for each range pattern.</li>
+            <li>A [[Pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*.</li>
+            <li>If the record has an [[Hour]] field, it must also have a [[Pattern12]] field, whose value is a String value that, in addition to the substrings of the pattern field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</li>
+            <li>A [[RangePatterns]] field that contains a record similar to the one described in the [[Formats]] field.</li>
+            <li>If the record has an [[Hour]] field, it must also have a [[RangePatterns12]] field. Its value is similar to the record in [[RangePatterns]] but it uses a string similar to [[Pattern12]] for each range pattern.</li>
           </ol>
-          For [[DateTimeFormat]], the field value must be a string pattern which contains the strings *"{0}"* and *"{1}"*. For [[DateTimeRangeFormat]] the value of these fields must be a nested record which also has [[full]], [[long]], [[medium]] and [[short]] fields. The [[full]], [[long]], [[medium]] and [[short]] fields in the enclosing record refer to the date style of the range pattern, while the fields in the nested record refers to the time style of the range pattern. The value of these fields in the nested record is a record with a [[rangePatterns]] field and a [[rangePatterns12]] field which are similar to the [[rangePatterns]] and [rangePatterns12]] fields in [[DateFormat]] and [[TimeFormat]].
+          For [[DateTimeFormat]], the field value must be a string pattern which contains the strings *"{0}"* and *"{1}"*. For [[DateTimeRangeFormat]] the value of these fields must be a nested record which also has [[Full]], [[Long]], [[Medium]] and [[Short]] fields. The [[Full]], [[Long]], [[Medium]] and [[Short]] fields in the enclosing record refer to the date style of the range pattern, while the fields in the nested record refers to the time style of the range pattern. The value of these fields in the nested record is a record with a [[RangePatterns]] field and a [[RangePatterns12]] field which are similar to the [[RangePatterns]] and [[RangePatterns12]] fields in [[DateFormat]] and [[TimeFormat]].
          </li>
       </ul>
 
       <emu-note>
         For example, an implementation might include the following record as part of its English locale data:
         <ul>
-          <li>[[hour]]: *"numeric"*</li>
-          <li>[[minute]]: *"numeric"*</li>
-          <li>[[pattern]]: *"{hour}:{minute}"*</li>
-          <li>[[pattern12]]: *"{hour}:{minute} {ampm}"*</li>
-          <li>[[rangePatterns]]:</li>
+          <li>[[Hour]]: *"numeric"*</li>
+          <li>[[Minute]]: *"numeric"*</li>
+          <li>[[Pattern]]: *"{hour}:{minute}"*</li>
+          <li>[[Pattern12]]: *"{hour}:{minute} {ampm}"*</li>
+          <li>[[RangePatterns]]:</li>
           <ul>
             <li>[[Hour]]:<ul>
-              <li>[[hour]]: *"numeric"*</li>
-              <li>[[minute]]: *"numeric"*</li>
+              <li>[[Hour]]: *"numeric"*</li>
+              <li>[[Minute]]: *"numeric"*</li>
               <li>[[PatternParts]]:</li>
               <ul>
                 <li>{[[Source]]: *"startRange"*, [[Pattern]]: *"{hour}:{minute}"*}</li>
@@ -278,8 +284,8 @@
               </ul>
             </ul></li>
             <li>[[Minute]]:<ul>
-              <li>[[hour]]: *"numeric"*</li>
-              <li>[[minute]]: *"numeric"*</li>
+              <li>[[Hour]]: *"numeric"*</li>
+              <li>[[Minute]]: *"numeric"*</li>
               <li>[[PatternParts]]:</li>
               <ul>
                 <li>{[[Source]]: *"startRange"*, [[Pattern]]: *"{hour}:{minute}"*}</li>
@@ -288,11 +294,11 @@
               </ul>
             </ul></li>
             <li>[[Default]]:<ul>
-              <li>[[year]]: *"2-digit"*</li>
-              <li>[[month]]: *"numeric"*</li>
-              <li>[[day]]: *"numeric"*</li>
-              <li>[[hour]]: *"numeric"*</li>
-              <li>[[minute]]: *"numeric"*</li>
+              <li>[[Year]]: *"2-digit"*</li>
+              <li>[[Month]]: *"numeric"*</li>
+              <li>[[Day]]: *"numeric"*</li>
+              <li>[[Hour]]: *"numeric"*</li>
+              <li>[[Minute]]: *"numeric"*</li>
               <li>[[PatternParts]]:</li>
               <ul>
                 <li>{[[Source]]: *"startRange"*, [[Pattern]]: *"{day}/{month}/{year}, {hour}:{minute}"*}</li>
@@ -301,11 +307,11 @@
               </ul>
             </ul></li>
           </ul>
-          <li>[[rangePatterns12]]:
+          <li>[[RangePatterns12]]:
           <ul>
             <li>[[Hour]]:<ul>
-              <li>[[hour]]: *"numeric"*</li>
-              <li>[[minute]]: *"numeric"*</li>
+              <li>[[Hour]]: *"numeric"*</li>
+              <li>[[Minute]]: *"numeric"*</li>
               <li>[[PatternParts]]:</li>
               <ul>
                 <li>{[[Source]]: *"startRange"*, [[Pattern]]: *"{hour}:{minute}"*}</li>
@@ -315,8 +321,8 @@
               </ul>
             </ul></li>
             <li>[[Minute]]:<ul>
-              <li>[[hour]]: *"numeric"*</li>
-              <li>[[minute]]: *"numeric"*</li>
+              <li>[[Hour]]: *"numeric"*</li>
+              <li>[[Minute]]: *"numeric"*</li>
               <li>[[PatternParts]]:</li>
               <ul>
                 <li>{[[Source]]: *"startRange"*, [[Pattern]]: *"{hour}:{minute}"*}</li>
@@ -326,11 +332,11 @@
               </ul>
             </ul></li>
             <li>[[Default]]:<ul>
-              <li>[[year]]: *"2-digit"*</li>
-              <li>[[month]]: *"numeric"*</li>
-              <li>[[day]]: *"numeric"*</li>
-              <li>[[hour]]: *"numeric"*</li>
-              <li>[[minute]]: *"numeric"*</li>
+              <li>[[Year]]: *"2-digit"*</li>
+              <li>[[Month]]: *"numeric"*</li>
+              <li>[[Day]]: *"numeric"*</li>
+              <li>[[Hour]]: *"numeric"*</li>
+              <li>[[Minute]]: *"numeric"*</li>
               <li>[[PatternParts]]:</li>
               <ul>
                 <li>{[[Source]]: *"startRange"*, [[Pattern]]: *"{day}/{month}/{year}, {hour}:{minute} {ampm}"*}</li>
@@ -683,7 +689,7 @@
       <table class="real-table">
         <thead>
           <tr>
-            <th>Internal Slot</th>
+            <th>Internal Slot/Field</th>
             <th>Property</th>
             <th>Values</th>
           </tr>
@@ -784,28 +790,40 @@
 
     <emu-clause id="sec-date-time-style-format" aoid="DateTimeStyleFormat">
       <h1>DateTimeStyleFormat ( _dateStyle_, _timeStyle_, _styles_ )</h1>
-      <p>The DateTimeStyleFormat abstract operation accepts arguments _dateStyle_ and _timeStyle_, which are each either *undefined*, *"full"*, *"long"*, *"medium"*, or *"short"*, at least one of which is not *undefined*, and _styles_, which is a record from %DateTimeFormat%.[[LocaleData]].[[&lt;_locale_&gt;]].[[styles]].[[&lt;_calendar_&gt;]] for some locale _locale_ and calendar _calendar_. It returns the appropriate format record for date time formatting based on the parameters.</p>
+      <p>The DateTimeStyleFormat abstract operation accepts arguments _dateStyle_ and _timeStyle_, which are each either *undefined*, *"full"*, *"long"*, *"medium"*, or *"short"*, at least one of which is not *undefined*, and _styles_, which is a record from %DateTimeFormat%.[[LocaleData]].[[&lt;_locale_&gt;]].[[Styles]].[[&lt;_calendar_&gt;]] for some locale _locale_ and calendar _calendar_. It returns the appropriate format record for date time formatting based on the parameters.</p>
       <emu-alg>
         1. If _timeStyle_ is not *undefined*, then
           1. Assert: _timeStyle_ is one of *"full"*, *"long"*, *"medium"*, or *"short"*.
-          1. Let _timeFormat_ be _styles_.[[TimeFormat]].[[&lt;_timeStyle_&gt;]].
+          1. Let _first_ be the ASCII-uppercase of the substring of _timeStyle_ from 0 to 1.
+          1. Let _rest_ be the substring of _timeStyle_ from 1.
+          1. Let _timeStyleField_ be the string-concatenation of _first_ and _rest_.
+          1. Let _timeFormat_ be _styles_.[[TimeFormat]].[[&lt;_timeStyleField_&gt;]].
         1. If _dateStyle_ is not *undefined*, then
           1. Assert: _dateStyle_ is one of *"full"*, *"long"*, *"medium"*, or *"short"*.
-          1. Let _dateFormat_ be _styles_.[[DateFormat]].[[&lt;_dateStyle_&gt;]].
+          1. Let _first_ be the ASCII-uppercase of the substring of _dateStyle_ from 0 to 1.
+          1. Let _rest_ be the substring of _dateStyle_ from 1.
+          1. Let _dateStyleField_ be the string-concatenation of _first_ and _rest_.
+          1. Let _dateFormat_ be _styles_.[[DateFormat]].[[&lt;_dateStyleField_&gt;]].
         1. If _dateStyle_ is not *undefined* and _timeStyle_ is not *undefined*, then
           1. Let _format_ be a new Record.
-          1. Add to _format_ all fields from _dateFormat_ except [[pattern]] and [[rangePatterns]].
-          1. Add to _format_ all fields from _timeFormat_ except [[pattern]], [[rangePatterns]], [[pattern12]], and [[rangePatterns12]], if present.
-          1. Let _connector_ be _styles_.[[DateTimeFormat]].[[&lt;_dateStyle_&gt;]].
-          1. Let _pattern_ be the string _connector_ with the substring *"{0}"* replaced with _timeFormat_.[[pattern]] and the substring *"{1}"* replaced with _dateFormat_.[[pattern]].
-          1. Set _format_.[[pattern]] to _pattern_.
-          1. If _timeFormat_ has a [[pattern12]] field, then
-            1. Let _pattern12_ be the string _connector_ with the substring *"{0}"* replaced with _timeFormat_.[[pattern12]] and the substring *"{1}"* replaced with _dateFormat_.[[pattern]].
-            1. Set _format_.[[pattern12]] to _pattern12_.
-          1. Let _dateTimeRangeFormat_ be _styles_.[[DateTimeRangeFormat]].[[&lt;_dateStyle_&gt;]].[[&lt;_timeStyle_&gt;]].
-          1. Set _format_.[[rangePatterns]] to _dateTimeRangeFormat_.[[rangePatterns]].
-          1. If _dateTimeRangeFormat_ has a [[rangePatterns12]] field, then
-            1. Set _format_.[[rangePatterns12]] to _dateTimeRangeFormat_.[[rangePatterns12]].
+          1. Add to _format_ all fields from _dateFormat_ except [[Pattern]] and [[RangePatterns]].
+          1. Add to _format_ all fields from _timeFormat_ except [[Pattern]], [[RangePatterns]], [[Pattern12]], and [[RangePatterns12]], if present.
+          1. Let _first_ be the ASCII-uppercase of the substring of _dateStyle_ from 0 to 1.
+          1. Let _rest_ be the substring of _dateStyle_ from 1.
+          1. Let _dateStyleField_ be the string-concatenation of _first_ and _rest_.
+          1. Let _first_ be the ASCII-uppercase of the substring of _dateStyle_ from 0 to 1.
+          1. Let _rest_ be the substring of _dateStyle_ from 1.
+          1. Let _timeStyleField_ be the string-concatenation of _first_ and _rest_.
+          1. Let _connector_ be _styles_.[[DateTimeFormat]].[[&lt;_dateStyleField_&gt;]].
+          1. Let _pattern_ be the string _connector_ with the substring *"{0}"* replaced with _timeFormat_.[[Pattern]] and the substring *"{1}"* replaced with _dateFormat_.[[Pattern]].
+          1. Set _format_.[[Pattern]] to _pattern_.
+          1. If _timeFormat_ has a [[Pattern12]] field, then
+            1. Let _pattern12_ be the string _connector_ with the substring *"{0}"* replaced with _timeFormat_.[[Pattern12]] and the substring *"{1}"* replaced with _dateFormat_.[[Pattern]].
+            1. Set _format_.[[Pattern12]] to _pattern12_.
+          1. Let _dateTimeRangeFormat_ be _styles_.[[DateTimeRangeFormat]].[[&lt;_dateStyleField_&gt;]].[[&lt;_timeStyleField_&gt;]].
+          1. Set _format_.[[RangePatterns]] to _dateTimeRangeFormat_.[[RangePatterns]].
+          1. If _dateTimeRangeFormat_ has a [[RangePatterns12]] field, then
+            1. Set _format_.[[RangePatterns12]] to _dateTimeRangeFormat_.[[RangePatterns12]].
           1. Return _format_.
         1. If _timeStyle_ is not *undefined*, then
           1. Return _timeFormat_.
@@ -834,12 +852,15 @@
         1. Assert: Type(_formats_) is List.
         1. For each element _format_ of _formats_, do
           1. Let _score_ be 0.
-          1. For each property name _property_ shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, do
-            1. If _options_ has a field [[&lt;_property_&gt;]], let _optionsProp_ be _options_.[[&lt;_property_&gt;]]; else let _optionsProp_ be *undefined*.
-            1. If _format_ has a field [[&lt;_property_&gt;]], let _formatProp_ be _format_.[[&lt;_property_&gt;]]; else let _formatProp_ be *undefined*.
+          1. For each property name _prop_ shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, do
+            1. Let _first_ be the ASCII-uppercase of the substring of _prop_ from 0 to 1.
+            1. Let _rest_ be the substring of _prop_ from 1.
+            1. Let _field_ be the string-concatenation of _first_ and _rest_.
+            1. If _options_ has a field [[&lt;_field_&gt;]], let _optionsProp_ be _options_.[[&lt;_field_&gt;]]; else let _optionsProp_ be *undefined*.
+            1. If _format_ has a field [[&lt;_field_&gt;]], let _formatProp_ be _format_.[[&lt;_field_&gt;]]; else let _formatProp_ be *undefined*.
             1. If _optionsProp_ is *undefined* and _formatProp_ is not *undefined*, decrease _score_ by _additionPenalty_.
             1. Else if _optionsProp_ is not *undefined* and _formatProp_ is *undefined*, decrease _score_ by _removalPenalty_.
-            1. Else if _property_ is *"timeZoneName"*, then
+            1. Else if _prop_ is *"timeZoneName"*, then
               1. If _optionsProp_ is *"short"* or *"shortGeneric"*, then
                 1. If _formatProp_ is *"shortOffset"*, decrease _score_ by _offsetPenalty_.
                 1. Else if _formatProp_ is *"longOffset"*, decrease _score_ by (_offsetPenalty_ + _shortMorePenalty_).
@@ -856,7 +877,7 @@
               1. Else if _optionsProp_ is *"longOffset"* and _formatProp_ is *"shortOffset"*, decrease _score_ by _longLessPenalty_.
               1. Else if _optionsProp_ &ne; _formatProp_, decrease _score_ by _removalPenalty_.
             1. Else if _optionsProp_ &ne; _formatProp_, then
-              1. If _property_ is *"fractionalSecondDigits"*, then
+              1. If _prop_ is *"fractionalSecondDigits"*, then
                 1. Let _values_ be &laquo; *1*<sub>𝔽</sub>, *2*<sub>𝔽</sub>, *3*<sub>𝔽</sub> &raquo;.
               1. Else,
                 1. Let _values_ be &laquo; *"2-digit"*, *"numeric"*, *"narrow"*, *"short"*, *"long"* &raquo;.
@@ -907,7 +928,7 @@
       <h1>FormatDateTimePattern ( _dateTimeFormat_, _patternParts_, _x_, _rangeFormatOptions_ )</h1>
 
       <p>
-        The FormatDateTimePattern abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat), _patternParts_ (which is a list of Records as returned by PartitionPattern), _x_ (which must be a Number value), and _rangeFormatOptions_ (which is a range pattern Record as used in [[rangePattern]] or *undefined*), interprets _x_ as a time value as specified in es2023, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according _pattern_ and to the effective locale and the formatting options of _dateTimeFormat_ and _rangeFormatOptions_. The following steps are taken:
+        The FormatDateTimePattern abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat), _patternParts_ (which is a list of Records as returned by PartitionPattern), _x_ (which must be a Number value), and _rangeFormatOptions_ (which is a range pattern Record as used in [[RangePattern]] or *undefined*), interprets _x_ as a time value as specified in es2023, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according _pattern_ and to the effective locale and the formatting options of _dateTimeFormat_ and _rangeFormatOptions_. The following steps are taken:
       </p>
 
       <emu-alg>
@@ -963,7 +984,7 @@
             1. Else if _f_ is *"2-digit"*, then
               1. Let _fv_ be FormatNumeric(_nf2_, _v_).
               1. If the *"length"* property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
-            1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether _dateTimeFormat_.[[Day]] is *undefined*. If _p_ is *"month"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[day]] is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether _dateTimeFormat_.[[Era]] is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[era]] is *undefined*. If the implementation does not have a localized representation of _f_, then use the String value of _v_ itself.
+            1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether _dateTimeFormat_.[[Day]] is *undefined*. If _p_ is *"month"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[Day]] is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether _dateTimeFormat_.[[Era]] is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[Era]] is *undefined*. If the implementation does not have a localized representation of _f_, then use the String value of _v_ itself.
             1. Append a new Record { [[Type]]: _p_, [[Value]]: _fv_ } as the last element of the list _result_.
           1. Else if _p_ is equal to *"ampm"*, then
             1. Let _v_ be _tm_.[[Hour]].

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -212,7 +212,7 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[HourCycle]] must be a String value equal to *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[Formats]] field. This [[Formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a list of records, each of which has a subset of the fields shown in the Internal slot/Field column of <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[Formats]] field. This [[Formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a list of records, each of which has a subset of the fields shown in the Internal Slot/Field column of <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified in the Values column of the corresponding row. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
           <ul>
             <li>[[Weekday]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]]</li>
             <li>[[Weekday]], [[Year]], [[Month]], [[Day]], [[Hour]], [[Minute]], [[Second]]</li>

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -24,7 +24,7 @@
         1. Let _opt_ be a new Record.
         1. Let _localeData_ be %DisplayNames%.[[LocaleData]].
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
-        1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Set _opt_.[[LocaleMatcher]] to _matcher_.
         1. Let _r_ be ResolveLocale(%DisplayNames%.[[AvailableLocales]], _requestedLocales_, _opt_, %DisplayNames%.[[RelevantExtensionKeys]]).
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"narrow"*, *"short"*, *"long"* &raquo;, *"long"*).
         1. Set _displayNames_.[[Style]] to _style_.
@@ -33,23 +33,66 @@
         1. Set _displayNames_.[[Type]] to _type_.
         1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, &laquo; *"code"*, *"none"* &raquo;, *"code"*).
         1. Set _displayNames_.[[Fallback]] to _fallback_.
-        1. Set _displayNames_.[[Locale]] to _r_.[[locale]].
-        1. Let _dataLocale_ be _r_.[[dataLocale]].
+        1. Set _displayNames_.[[Locale]] to _r_.[[Locale]].
+        1. Let _dataLocale_ be _r_.[[DataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _types_ be _dataLocaleData_.[[types]].
+        1. Let _types_ be _dataLocaleData_.[[Types]].
         1. Assert: _types_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, ~string~, &laquo; *"dialect"*, *"standard"* &raquo;, *"dialect"*).
-        1. Let _typeFields_ be _types_.[[&lt;_type_&gt;]].
+        1. Let _typeFields_ be the field of the Fields column of <emu-xref href="#table-displaynames-types"></emu-xref> in the row with _type_ in its Type Names column.
         1. Assert: _typeFields_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. If _type_ is *"language"*, then
           1. Set _displayNames_.[[LanguageDisplay]] to _languageDisplay_.
-          1. Let _typeFields_ be _typeFields_.[[&lt;_languageDisplay_&gt;]].
+          1. If _languageDisplay_ is *"standard"*, then
+            1. Let _typeFields_ be _typeFields_.[[Standard]].
+          1. Else,
+            1. Let _typeFields_ be _typeFields_.[[Dialect]].
           1. Assert: _typeFields_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
-        1. Let _styleFields_ be _typeFields_.[[&lt;_style_&gt;]].
+        1. If _style_ is *"narrow"*, then
+          1. Let _styleFields_ be _typeFields_.[[Narrow]].
+        1. Else if _style_ is *"short*", then
+          1. Let _styleFields_ be _typeFields_.[[Short]].
+        1. Else,
+          1. Let _styleFields_ be _typeFields_.[[Long]].
         1. Assert: _styleFields_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. Set _displayNames_.[[Fields]] to _styleFields_.
         1. Return _displayNames_.
       </emu-alg>
+      <emu-table id="table-displaynames-types">
+        <emu-caption>Fields Corresponding to Type Names</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>Type Names</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[Language]]</td>
+            <td>*"language"*</td>
+          </tr>
+          <tr>
+            <td>[[Region]]</td>
+            <td>*"region"*</td>
+          </tr>
+          <tr>
+            <td>[[Script]]</td>
+            <td>*"script"*</td>
+          </tr>
+          <tr>
+            <td>[[Currency]]</td>
+            <td>*"currency"*</td>
+          </tr>
+          <tr>
+            <td>[[Calendar]]</td>
+            <td>*"calendar"*</td>
+          </tr>
+          <tr>
+            <td>[[DateTimeField]]</td>
+            <td>*"dateTimeField"*</td>
+          </tr>
+        </table>
+      </emu-table>
     </emu-clause>
   </emu-clause>
 
@@ -101,18 +144,17 @@
       </p>
 
       <ul>
-        <li>[[LocaleData]].[[&lt;_locale_&gt;]] must have a [[types]] field for all locale values _locale_. The value of this field must be a Record, which must have fields with the names of all display name types: *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, and *"dateTimeField"*.</li>
-        <li>The value of the field *"language"* must be a Record which must have fields with the names of one of the valid language displays: *"dialect"* and *"standard"*.</li>
-        <li>The language display fields under display name type *"language"* should contain Records which must have fields with the names of one of the valid display name styles: *"narrow"*, *"short"*, and *"long"*.</li>
-        <li>The value of the fields *"region"*, *"script"*, *"currency"*, *"calendar"*, and *"dateTimeField"* must be Records, which must have fields with the names of all display name styles: *"narrow"*, *"short"*, and *"long"*.</li>
-        <li>The display name style fields under display name type *"language"* should contain Records with keys corresponding to language codes matching the `unicode_language_id` production. The value of these fields must be string values.</li>
-        <li>The display name style fields under display name type *"region"* should contain Records with keys corresponding to region codes. The value of these fields must be string values.</li>
-        <li>The display name style fields under display name type *"script"* should contain Records with keys corresponding to script codes. The value of these fields must be string values.</li>
-        <li>The display name style fields under display name type *"currency"* should contain Records with keys corresponding to currency codes. The value of these fields must be string values.</li>
-        <li>The display name style fields under display name type *"calendar"* should contain Records with keys corresponding to a String value with the `type` given in Unicode Technical Standard 35 for the calendar used for formatting. The value of these fields must be string values.</li>
-        <li>The display name style fields under display name type *"dateTimeField"* should contain Records with keys corresponding to codes listed in <emu-xref href="#table-validcodefordatetimefield"></emu-xref>. The value of these fields must be string values.</li>
+        <li>[[LocaleData]].[[&lt;_locale_&gt;]] must have a [[Types]] field for all locale values _locale_. The value of this field must be a Record, which must have fields corresponding to all display name type names as given in <emu-xref href="#table-displaynames-types"></emu-xref>.</li>
+        <li>The value of the field [[Language]] must be a Record which must have fields [[Dialect]] and [[Standard]], corresponding to the names of the valid language displays: *"dialect"* and *"standard"*.</li>
+        <li>The language display fields of [[Language]] should contain Records which must have fields [[Narrow]], [[Short]], and [[Long]], corresponding to the valid display name styles: *"narrow"*, *"short"*, and *"long"*.</li>
+        <li>The value of the fields [[Region]], [[Script]], [[Currency]], [[Calendar]], and [[DateTimeField]] must be Records, which must have fields [[Narrow]], [[Short]], and [[Long]], corresponding to the valid display name styles: *"narrow"*, *"short*", and *"long"*.</li>
+        <li>The display name style fields of [[Language]] should contain Records with keys corresponding to language codes matching the `unicode_language_id` production. The value of these fields must be string values.</li>
+        <li>The display name style fields under display name type [[Region]] should contain Records with keys corresponding to region codes. The value of these fields must be string values.</li>
+        <li>The display name style fields under display name type [[Script]] should contain Records with keys corresponding to script codes. The value of these fields must be string values.</li>
+        <li>The display name style fields under display name type [[Currency]] should contain Records with keys corresponding to currency codes. The value of these fields must be string values.</li>
+        <li>The display name style fields under display name type [[Calendar]] should contain Records with keys corresponding to a String value with the `type` given in Unicode Technical Standard 35 for the calendar used for formatting. The value of these fields must be string values.</li>
+        <li>The display name style fields under display name type [[DateTimeField]] should contain Records with the fields listed in the Fields row of <emu-xref href="#table-validcodefordatetimefield"></emu-xref>. The values of these fields must be string values.</li>
       </ul>
-
       <emu-note>
         It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="https://cldr.unicode.org/">https://cldr.unicode.org/</a>).
       </emu-note>
@@ -280,74 +322,87 @@
     <emu-clause id="sec-isvaliddatetimefieldcode" type="abstract operation">
       <h1>
         IsValidDateTimeFieldCode (
-          _field_: a String,
+          _fieldCode_: a String,
         )
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It verifies that the _field_ argument represents a valid date time field code.</dd>
+        <dd>It verifies that the _fieldCode_ argument represents a valid date time field code.</dd>
       </dl>
       <emu-alg>
-        1. If _field_ is listed in the Code column of <emu-xref href="#table-validcodefordatetimefield"></emu-xref>, return *true*.
+        1. If _fieldCode_ is listed in the Code column of <emu-xref href="#table-validcodefordatetimefield"></emu-xref>, return *true*.
         1. Return *false*.
       </emu-alg>
 
       <emu-table id="table-validcodefordatetimefield">
-        <emu-caption>Codes For Date Time Field of DisplayNames</emu-caption>
+        <emu-caption>Fields and Codes For DateTimeField of DisplayNames</emu-caption>
         <table class="real-table">
           <thead>
             <tr>
+              <th>Fields</th>
               <th>Code</th>
               <th>Description</th>
             </tr>
           </thead>
           <tr>
+            <td>[[Era]]</td>
             <td>*"era"*</td>
-            <td>The field indicating the era, e.g. AD or BC in the Gregorian or Julian calendar.</td>
+            <td>The era, e.g. AD or BC in the Gregorian or Julian calendar.</td>
           </tr>
           <tr>
+            <td>[[Year]]</td>
             <td>*"year"*</td>
-            <td>The field indicating the year (within an era).</td>
+            <td>The year (within an era).</td>
           </tr>
           <tr>
+            <td>[[Quarter]]</td>
             <td>*"quarter"*</td>
-            <td>The field indicating the quarter, e.g. Q2, 2nd quarter, etc.</td>
+            <td>The quarter, e.g. Q2, 2nd quarter, etc.</td>
           </tr>
           <tr>
+            <td>[[Month]]</td>
             <td>*"month"*</td>
-            <td>The field indicating the month, e.g. Sep, September, etc.</td>
+            <td>The month, e.g. Sep, September, etc.</td>
           </tr>
           <tr>
+            <td>[[WeekOfYear]]</td>
             <td>*"weekOfYear"*</td>
-            <td>The field indicating the week number within a year.</td>
+            <td>The week number within a year.</td>
           </tr>
           <tr>
+            <td>[[Weekday]]</td>
             <td>*"weekday"*</td>
-            <td>The field indicating the day of week, e.g. Tue, Tuesday, etc.</td>
+            <td>The day of week, e.g. Tue, Tuesday, etc.</td>
           </tr>
           <tr>
+            <td>[[Day]]</td>
             <td>*"day"*</td>
-            <td>The field indicating the day in month.</td>
+            <td>The day in month.</td>
           </tr>
           <tr>
+            <td>[[DayPeriod]]</td>
             <td>*"dayPeriod"*</td>
-            <td>The field indicating the day period, either am, pm, etc. or noon, evening, etc..</td>
+            <td>The day period, either am, pm, etc. or noon, evening, etc.</td>
           </tr>
           <tr>
+            <td>[[Hour]]</td>
             <td>*"hour"*</td>
-            <td>The field indicating the hour.</td>
+            <td>The hour.</td>
           </tr>
           <tr>
+            <td>[[Minute]]</td>
             <td>*"minute"*</td>
-            <td>The field indicating the minute.</td>
+            <td>The minute.</td>
           </tr>
           <tr>
+            <td>[[Second]]</td>
             <td>*"second"*</td>
-            <td>The field indicating the second.</td>
+            <td>The second.</td>
           </tr>
           <tr>
+            <td>[[TimeZoneName]]</td>
             <td>*"timeZoneName"*</td>
-            <td>The field indicating the time zone name, e.g. PDT, Pacific Daylight Time, etc.</td>
+            <td>The time zone name, e.g. PDT, Pacific Daylight Time, etc.</td>
           </tr>
         </table>
       </emu-table>

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -22,18 +22,29 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
-        1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Set _opt_.[[LocaleMatcher]] to _matcher_.
         1. Let _localeData_ be %ListFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %ListFormat%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _listFormat_.[[Locale]] to _r_.[[locale]].
+        1. Set _listFormat_.[[Locale]] to _r_.[[Locale]].
         1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"conjunction"*, *"disjunction"*, *"unit"* &raquo;, *"conjunction"*).
         1. Set _listFormat_.[[Type]] to _type_.
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _listFormat_.[[Style]] to _style_.
-        1. Let _dataLocale_ be _r_.[[dataLocale]].
+        1. Let _dataLocale_ be _r_.[[DataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _dataLocaleTypes_ be _dataLocaleData_.[[&lt;_type_&gt;]].
-        1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[&lt;_style_&gt;]].
+        1. Let _dataLocaleTypes_ be *undefined*.
+        1. If _type_ is *"conjunction"*, then
+          1. Set _dataLocaleTypes_ to _dataLocaleData_.[[Conjunction]].
+        1. Else if _type_ is *"disjunction"*, then
+          1. Set _dataLocaleTypes_ to _dataLocaleData_.[[Disjunction]].
+        1. Else,
+          1. Set _dataLocaleTypes_ to _dataLocaleData_.[[Unit]].
+        1. If _style_ is *"long"*, then
+          1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[Long]].
+        1. Else if _style_ is *"short"*, then
+          1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[Short]].
+        1. Else,
+          1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[Narrow]].
         1. Return _listFormat_.
       </emu-alg>
     </emu-clause>
@@ -91,12 +102,12 @@
       </p>
 
       <ul>
-        <li>[[LocaleData]].[[&lt;_locale_&gt;]] is a Record which has three fields [[conjunction]], [[disjunction]], and [[unit]]. Each of these is a Record which must have fields with the names of three formatting styles: [[long]], [[short]], and [[narrow]].</li>
+        <li>[[LocaleData]].[[&lt;_locale_&gt;]] is a Record which has three fields [[Conjunction]], [[Disjunction]], and [[Unit]]. Each of these is a Record which must have fields with the names of three formatting styles: [[Long]], [[Short]], and [[Narrow]].</li>
         <li>Each of those fields is considered a <dfn>ListFormat template set</dfn>, which must be a List of Records with fields named: [[Pair]], [[Start]], [[Middle]], and [[End]]. Each of those fields must be a template string as specified in LDML List Format Rules. Each template string must contain the substrings *"{0}"* and *"{1}"* exactly once. The substring *"{0}"* should occur before the substring *"{1}"*.</li>
       </ul>
 
       <emu-note>
-        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="https://cldr.unicode.org/">https://cldr.unicode.org/</a>). In <a href="https://unicode.org/reports/tr35/tr35-general.html#ListPatterns">LDML's listPattern</a>, `conjunction` corresponds to "standard", `disjunction` corresponds to "or", and `unit` corresponds to "unit".
+        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="https://cldr.unicode.org/">https://cldr.unicode.org/</a>). In <a href="https://unicode.org/reports/tr35/tr35-general.html#ListPatterns">LDML's listPattern</a>, `Conjunction` corresponds to "standard", `disjunction` corresponds to "or", and `unit` corresponds to "unit".
       </emu-note>
 
       <emu-note>

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -53,7 +53,7 @@
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _r_ be ! ApplyUnicodeExtensionToTag(_tag_, _opt_, _relevantExtensionKeys_).
-        1. Set _locale_.[[Locale]] to _r_.[[locale]].
+        1. Set _locale_.[[Locale]] to _r_.[[Locale]].
         1. Set _locale_.[[Calendar]] to _r_.[[ca]].
         1. Set _locale_.[[Collation]] to _r_.[[co]].
         1. Set _locale_.[[HourCycle]] to _r_.[[hc]].
@@ -147,7 +147,7 @@
         1. Let _newExtension_ be a Unicode BCP 47 U Extension based on _attributes_ and _keywords_.
         1. If _newExtension_ is not the empty String, then
           1. Let _locale_ be ! InsertUnicodeExtensionAndCanonicalize(_locale_, _newExtension_).
-        1. Set _result_.[[locale]] to _locale_.
+        1. Set _result_.[[Locale]] to _locale_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -105,18 +105,18 @@
           1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
           1. Let _availableLocale_ be ! BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
           1. If _availableLocale_ is not *undefined*, then
-            1. Set _result_.[[locale]] to _availableLocale_.
+            1. Set _result_.[[Locale]] to _availableLocale_.
             1. If _locale_ and _noExtensionsLocale_ are not the same String value, then
               1. Let _extension_ be the String value consisting of the substring of the Unicode locale extension sequence within _locale_.
-              1. Set _result_.[[extension]] to _extension_.
+              1. Set _result_.[[Extension]] to _extension_.
             1. Return _result_.
         1. Let _defLocale_ be ! DefaultLocale().
-        1. Set _result_.[[locale]] to _defLocale_.
+        1. Set _result_.[[Locale]] to _defLocale_.
         1. Return _result_.
       </emu-alg>
 
       <emu-note>
-        The algorithm is based on the Lookup algorithm described in RFC 4647 section 3.4, but options specified through Unicode locale extension sequences are ignored in the lookup. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
+        The algorithm is based on the Lookup algorithm described in RFC 4647 section 3.4, but options specified through Unicode locale extension sequences are ignored in the lookup. Information about such subsequences is returned separately. The abstract operation returns a record with a [[Locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[Extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
       </emu-note>
     </emu-clause>
 
@@ -124,7 +124,7 @@
       <h1>BestFitMatcher ( _availableLocales_, _requestedLocales_ )</h1>
 
       <p>
-        The BestFitMatcher abstract operation compares _requestedLocales_, which must be a List as returned by CanonicalizeLocaleList, against the locales in _availableLocales_ and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the LookupMatcher abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
+        The BestFitMatcher abstract operation compares _requestedLocales_, which must be a List as returned by CanonicalizeLocaleList, against the locales in _availableLocales_ and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the LookupMatcher abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[Locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[Extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
       </p>
     </emu-clause>
 
@@ -200,16 +200,16 @@
       </p>
 
       <emu-alg>
-        1. Let _matcher_ be _options_.[[localeMatcher]].
+        1. Let _matcher_ be _options_.[[LocaleMatcher]].
         1. If _matcher_ is *"lookup"*, then
           1. Let _r_ be ! LookupMatcher(_availableLocales_, _requestedLocales_).
         1. Else,
           1. Let _r_ be ! BestFitMatcher(_availableLocales_, _requestedLocales_).
-        1. Let _foundLocale_ be _r_.[[locale]].
+        1. Let _foundLocale_ be _r_.[[Locale]].
         1. Let _result_ be a new Record.
-        1. Set _result_.[[dataLocale]] to _foundLocale_.
-        1. If _r_ has an [[extension]] field, then
-          1. Let _components_ be ! UnicodeExtensionComponents(_r_.[[extension]]).
+        1. Set _result_.[[DataLocale]] to _foundLocale_.
+        1. If _r_ has an [[Extension]] field, then
+          1. Let _components_ be ! UnicodeExtensionComponents(_r_.[[Extension]]).
           1. Let _keywords_ be _components_.[[Keywords]].
         1. Let _supportedExtension_ be *"-u"*.
         1. For each element _key_ of _relevantExtensionKeys_, do
@@ -220,7 +220,7 @@
           1. Let _value_ be _keyLocaleData_[0].
           1. Assert: Type(_value_) is either String or Null.
           1. Let _supportedExtensionAddition_ be *""*.
-          1. If _r_ has an [[extension]] field, then
+          1. If _r_ has an [[Extension]] field, then
             1. If _keywords_ contains an element whose [[Key]] is the same as _key_, then
               1. Let _entry_ be the element of _keywords_ whose [[Key]] is the same as _key_.
               1. Let _requestedValue_ be _entry_.[[Value]].
@@ -246,12 +246,12 @@
           1. Set _supportedExtension_ to the string-concatenation of _supportedExtension_ and _supportedExtensionAddition_.
         1. If _supportedExtension_ is not *"-u"*, then
           1. Set _foundLocale_ to InsertUnicodeExtensionAndCanonicalize(_foundLocale_, _supportedExtension_).
-        1. Set _result_.[[locale]] to _foundLocale_.
+        1. Set _result_.[[Locale]] to _foundLocale_.
         1. Return _result_.
       </emu-alg>
 
       <emu-note>
-        Non-normative summary: Two algorithms are available to match the locales: the Lookup algorithm described in RFC 4647 section 3.4, and an implementation dependent best-fit algorithm. Independent of the locale matching algorithm, options specified through Unicode locale extension sequences are negotiated separately, taking the caller's relevant extension keys and locale data as well as client-provided options into consideration. The abstract operation returns a record with a [[locale]] field whose value is the language tag of the selected locale, and fields for each key in _relevantExtensionKeys_ providing the selected value for that key.
+        Non-normative summary: Two algorithms are available to match the locales: the Lookup algorithm described in RFC 4647 section 3.4, and an implementation dependent best-fit algorithm. Independent of the locale matching algorithm, options specified through Unicode locale extension sequences are negotiated separately, taking the caller's relevant extension keys and locale data as well as client-provided options into consideration. The abstract operation returns a record with a [[Locale]] field whose value is the language tag of the selected locale, and fields for each key in _relevantExtensionKeys_ providing the selected value for that key.
       </emu-note>
     </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -54,15 +54,15 @@
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
-        1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Set _opt_.[[LocaleMatcher]] to _matcher_.
         1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, ~string~, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %NumberFormat%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _numberFormat_.[[Locale]] to _r_.[[locale]].
-        1. Set _numberFormat_.[[DataLocale]] to _r_.[[dataLocale]].
+        1. Set _numberFormat_.[[Locale]] to _r_.[[Locale]].
+        1. Set _numberFormat_.[[DataLocale]] to _r_.[[DataLocale]].
         1. Set _numberFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Perform ? SetNumberFormatUnitOptions(_numberFormat_, _options_).
         1. Let _style_ be _numberFormat_.[[Style]].
@@ -267,22 +267,14 @@
 
       <ul>
         <li>The list that is the value of the *"nu"* field of any locale field of [[LocaleData]] must not include the values *"native"*, *"traditio"*, or *"finance"*.</li>
-        <li>[[LocaleData]].[[&lt;_locale_&gt;]] must have a [[patterns]] field for all locale values _locale_. The value of this field must be a Record, which must have fields with the names of the four number format styles: *"decimal"*, *"percent"*, *"currency"*, and *"unit"*.</li>
+        <li>[[LocaleData]].[[&lt;_locale_&gt;]] must have a [[Patterns]] field for all locale values _locale_. The value of this field must be a Record, which must have fields [[Decimal]], [[Percent]], [[Currency]], and [[Unit]], corresponding to the names of the four number format styles *"decimal"*, *"percent"*, *"currency"*, and *"unit"*.</li>
         <li>
-          The two fields *"currency"* and *"unit"* noted above must be Records with at least one field, *"fallback"*.
-          The *"currency"* may have additional fields with keys corresponding to currency codes according to <emu-xref href="#sec-currency-codes"></emu-xref>.
-          Each field of *"currency"* must be a Record with fields corresponding to the possible currencyDisplay values: *"code"*, *"symbol"*, *"narrowSymbol"*, and *"name"*.
-          Each of those fields must contain a Record with fields corresponding to the possible currencySign values: *"standard"* or *"accounting"*. The *"unit"* field (of [[LocaleData]].[[&lt;_locale_&gt;]]) may have additional fields beyond the required field *"fallback"* with keys corresponding to core measurement unit identifiers corresponding to <emu-xref href="#sec-measurement-unit-identifiers"></emu-xref>.
-          Each field of *"unit"* must be a Record with fields corresponding to the possible unitDisplay values: *"narrow"*, *"short"*, and *"long"*.
-        </li>
-        <li>All of the leaf fields so far described for the patterns tree (*"decimal"*, *"percent"*, great-grandchildren of *"currency"*, and grandchildren of *"unit"*) must be Records with the keys *"positivePattern"*, *"zeroPattern"*, and *"negativePattern"*.</li>
+          The two fields [[Currency]] and [[Unit]] noted above must be Records with at least one field, [[Fallback]]. The [[Currency]] field may have additional fields with keys corresponding to currency codes according to <emu-xref href="#sec-currency-codes"></emu-xref>. Each field of [[Currency]] must be a Record with fields [[Code]], [[Symbol]], [[NarrowSymbol]], and [[Name]], corresponding to the possible currencyDisplay values *"code"*, *"symbol"*, *"narrowSymbol"*, and *"name"*. Each of those fields must contain a Record with fields [[Standard]] and [[Accounting]], corresponding to the possible currencySign values *"standard"* or *"accounting"*. The [[Unit]] field (of [[LocaleData]].[[&lt;_locale_&gt;]]) may have additional fields beyond the required field [[Fallback]] with keys corresponding to core measurement unit identifiers given in <emu-xref href="#sec-measurement-unit-identifiers"></emu-xref>. Each field of [[Unit]] must be a Record with fields corresponding to the possible unitDisplay values: *"narrow"*, *"short"*, and *"long"*.</li>
+        <li>All of the leaf fields so far described for the patterns tree ([[Decimal]], [[Percent]], great-grandchildren of [[Currency]], and grandchildren of [[Unit]]) must be Records with the fields [[PositivePattern]], [[ZeroPattern]], and [[NegativePattern]], corresponding to the possible signDisplay values *"positivePattern"*, *"zeroPattern"*, and *"negativePattern"*.</li>
         <li>
-          The value of the aforementioned fields (the sign-dependent pattern fields) must be string values that must contain the substring *"{number}"*.
-          *"positivePattern"* must contain the substring *"{plusSign}"* but not *"{minusSign}"*; *"negativePattern"* must contain the substring *"{minusSign}"* but not *"{plusSign}"*; and *"zeroPattern"* must not contain either *"{plusSign}"* or *"{minusSign}"*.
-          Additionally, the values within the *"percent"* field must also contain the substring *"{percentSign}"*; the values within the *"currency"* field must also contain one or more of the following substrings: *"{currencyCode}"*, *"{currencyPrefix}"*, or *"{currencySuffix}"*; and the values within the *"unit"* field must also contain one or more of the following substrings: *"{unitPrefix}"* or *"{unitSuffix}"*.
-          The pattern strings, when interpreted as a sequence of UTF-16 encoded code points as described in es2023, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, must not contain any code points in the General Category "Number, decimal digit" as specified by the Unicode Standard.
+          The value of the aforementioned fields (the sign-dependent pattern fields) must be string values that must contain the substring *"{number}"*. [[PositivePattern]] must contain the substring *"{plusSign}"* but not *"{minusSign}"*; [[NegativePattern]] must contain the substring *"{minusSign}"* but not *"{plusSign}"*; and [[ZeroPattern]] must not contain either *"{plusSign}"* or *"{minusSign}"*. Additionally, the values within the [[Percent]] field must also contain the substring *"{percentSign}"*; the values within the [[Currency]] field must also contain one or more of the following substrings: *"{currencyCode}"*, *"{currencyPrefix}"*, or *"{currencySuffix}"*; and the values within the [[Unit]] field must also contain one or more of the following substrings: *"{unitPrefix}"* or *"{unitSuffix}"*. The pattern strings, when interpreted as a sequence of UTF-16 encoded code points as described in es2023, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, must not contain any code points in the General Category "Number, decimal digit" as specified by the Unicode Standard.
         </li>
-        <li>[[LocaleData]].[[&lt;_locale_&gt;]] must also have a [[notationSubPatterns]] field for all locale values _locale_. The value of this field must be a Record, which must have two fields: [[scientific]] and [[compact]]. The [[scientific]] field must be a string value containing the substrings *"{number}"*, *"{scientificSeparator}"*, and *"{scientificExponent}"*. The [[compact]] field must be a Record with two fields: *"short"* and *"long"*. Each of these fields must be a Record with integer keys corresponding to all discrete magnitudes the implementation supports for compact notation. Each of these fields must be a string value which may contain the substring *"{number}"*. Strings descended from *"short"* must contain the substring *"{compactSymbol}"*, and strings descended from *"long"* must contain the substring *"{compactName}"*.</li>
+        <li>[[LocaleData]].[[&lt;_locale_&gt;]] must also have a [[NotationSubPatterns]] field for all locale values _locale_. The value of this field must be a Record, which must have two fields: [[Scientific]] and [[Compact]]. The [[Scientific]] field must be a string value containing the substrings *"{number}"*, *"{scientificSeparator}"*, and *"{scientificExponent}"*. The [[Compact]] field must be a Record with two fields: [[Short]] and [[Long]], corresponding to the possible compactDisplay values *"short"* and *"long"*. Each of these fields must be a Record with integer keys corresponding to all discrete magnitudes the implementation supports for compact notation. Each of these fields must be a string value which may contain the substring *"{number}"*. Strings descended from *"short"* must contain the substring *"{compactSymbol}"*, and strings descended from *"long"* must contain the substring *"{compactName}"*.</li>
       </ul>
 
       <emu-note>
@@ -1369,32 +1361,49 @@
         1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
         1. Let _dataLocale_ be _numberFormat_.[[DataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _patterns_ be _dataLocaleData_.[[patterns]].
+        1. Let _patterns_ be _dataLocaleData_.[[Patterns]].
         1. Assert: _patterns_ is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
         1. Let _style_ be _numberFormat_.[[Style]].
         1. If _style_ is *"percent"*, then
-          1. Let _patterns_ be _patterns_.[[percent]].
+          1. Let _patterns_ be _patterns_.[[Percent]].
         1. Else if _style_ is *"unit"*, then
           1. Let _unit_ be _numberFormat_.[[Unit]].
           1. Let _unitDisplay_ be _numberFormat_.[[UnitDisplay]].
-          1. Let _patterns_ be _patterns_.[[unit]].
-          1. If _patterns_ doesn't have a field [[&lt;_unit_&gt;]], then
-            1. Let _unit_ be *"fallback"*.
-          1. Let _patterns_ be _patterns_.[[&lt;_unit_&gt;]].
-          1. Let _patterns_ be _patterns_.[[&lt;_unitDisplay_&gt;]].
+          1. Let _patterns_ be _patterns_.[[Unit]].
+          1. If _patterns_ has a field [[&lt;_unit_&gt;]], then
+            1. Let _patterns_ be _patterns_.[[&lt;_unit_&gt;]].
+          1. Else,
+            1. Let _patterns_ be _patterns_.[[Fallback]].
+          1. If _unitDisplay_ is *"short"*, then
+            1. Let _patterns_ be _patterns_.[[Short]].
+          1. Else if _unitDisplay_ is *"narrow"*, then
+            1. Let _patterns_ be _patterns_.[[Narrow]].
+          1. Else,
+            1. Let _patterns_ be _patterns_.[[Long]].
         1. Else if _style_ is *"currency"*, then
           1. Let _currency_ be _numberFormat_.[[Currency]].
           1. Let _currencyDisplay_ be _numberFormat_.[[CurrencyDisplay]].
           1. Let _currencySign_ be _numberFormat_.[[CurrencySign]].
-          1. Let _patterns_ be _patterns_.[[currency]].
-          1. If _patterns_ doesn't have a field [[&lt;_currency_&gt;]], then
-            1. Let _currency_ be *"fallback"*.
-          1. Let _patterns_ be _patterns_.[[&lt;_currency_&gt;]].
-          1. Let _patterns_ be _patterns_.[[&lt;_currencyDisplay_&gt;]].
-          1. Let _patterns_ be _patterns_.[[&lt;_currencySign_&gt;]].
+          1. Let _patterns_ be _patterns_.[[Currency]].
+          1. If _patterns_ has a field [[&lt;_currency_&gt;]], then
+            1. Let _patterns_ be _patterns_.[[&lt;_currency_&gt;]].
+          1. Else,
+            1. Let _patterns_ be _patterns_.[[Fallback]].
+          1. If _currencyDisplay_ is *"code"*, then
+            1. Let _patterns_ be _patterns_.[[Code]].
+          1. Else if _currencyDisplay_ is *"symbol"*, then
+            1. Let _patterns_ be _patterns_.[[Symbol]].
+          1. Else if _currencyDisplay_ is *"narrowSymbol"*, then
+            1. Let _patterns_ be _patterns_.[[NarrowSymbol]].
+          1. Else,
+            1. Let _patterns_ be _patterns_.[[Name]].
+          1. If _currencySign_ is *"standard"*, then
+            1. Let _patterns_ be _patterns_.[[Standard]].
+          1. Else,
+            1. Let _patterns_ be _patterns_.[[Accounting]].
         1. Else,
           1. Assert: _style_ is *"decimal"*.
-          1. Let _patterns_ be _patterns_.[[decimal]].
+          1. Let _patterns_ be _patterns_.[[Decimal]].
         1. If _x_ is ~negative-infinity~, then
           1. Let _category_ be ~negative-non-zero~.
         1. Else if _x_ is ~negative-zero~, then
@@ -1413,30 +1422,30 @@
             1. Let _category_ be ~positive-zero~.
         1. Let _signDisplay_ be _numberFormat_.[[SignDisplay]].
         1. If _signDisplay_ is *"never"*, then
-          1. Let _pattern_ be _patterns_.[[zeroPattern]].
+          1. Let _pattern_ be _patterns_.[[ZeroPattern]].
         1. Else if _signDisplay_ is *"auto"*, then
           1. If _category_ is ~positive-non-zero~ or ~positive-zero~, then
-            1. Let _pattern_ be _patterns_.[[zeroPattern]].
+            1. Let _pattern_ be _patterns_.[[ZeroPattern]].
           1. Else,
-            1. Let _pattern_ be _patterns_.[[negativePattern]].
+            1. Let _pattern_ be _patterns_.[[NegativePattern]].
         1. Else if _signDisplay_ is *"always"*, then
           1. If _category_ is ~positive-non-zero~ or ~positive-zero~, then
-            1. Let _pattern_ be _patterns_.[[positivePattern]].
+            1. Let _pattern_ be _patterns_.[[PositivePattern]].
           1. Else,
-            1. Let _pattern_ be _patterns_.[[negativePattern]].
+            1. Let _pattern_ be _patterns_.[[NegativePattern]].
         1. Else if _signDisplay_ is *"exceptZero"*, then
           1. If _category_ is ~positive-zero~ or ~negative-zero~, then
-            1. Let _pattern_ be _patterns_.[[zeroPattern]].
+            1. Let _pattern_ be _patterns_.[[ZeroPattern]].
           1. Else if _category_ is ~positive-non-zero~, then
-            1. Let _pattern_ be _patterns_.[[positivePattern]].
+            1. Let _pattern_ be _patterns_.[[PositivePattern]].
           1. Else,
-            1. Let _pattern_ be _patterns_.[[negativePattern]].
+            1. Let _pattern_ be _patterns_.[[NegativePattern]].
         1. Else,
           1. Assert: _signDisplay_ is *"negative"*.
           1. If _category_ is ~negative-non-zero~, then
-            1. Let _pattern_ be _patterns_.[[negativePattern]].
+            1. Let _pattern_ be _patterns_.[[NegativePattern]].
           1. Else,
-            1. Let _pattern_ be _patterns_.[[zeroPattern]].
+            1. Let _pattern_ be _patterns_.[[ZeroPattern]].
         1. Return _pattern_.
       </emu-alg>
     </emu-clause>
@@ -1450,15 +1459,19 @@
         1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
         1. Let _dataLocale_ be _numberFormat_.[[DataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _notationSubPatterns_ be _dataLocaleData_.[[notationSubPatterns]].
+        1. Let _notationSubPatterns_ be _dataLocaleData_.[[NotationSubPatterns]].
         1. Assert: _notationSubPatterns_ is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
         1. Let _notation_ be _numberFormat_.[[Notation]].
         1. If _notation_ is *"scientific"* or _notation_ is *"engineering"*, then
-          1. Return _notationSubPatterns_.[[scientific]].
+          1. Return _notationSubPatterns_.[[Scientific]].
         1. Else if _exponent_ is not 0, then
           1. Assert: _notation_ is *"compact"*.
           1. Let _compactDisplay_ be _numberFormat_.[[CompactDisplay]].
-          1. Let _compactPatterns_ be _notationSubPatterns_.[[compact]].[[&lt;_compactDisplay_&gt;]].
+          1. Let _compactPatterns_ be _notationSubPatterns_.[[Compact]].
+          1. If _compactDisplay_ is "short", then
+            1. Let _compactPatterns_ be _compactPatterns_.[[Short]].
+          1. Else,
+            1. Let _compactPatterns_ be _compactPatterns_.[[Long]].
           1. Return _compactPatterns_.[[&lt;_exponent_&gt;]].
         1. Else,
           1. Return *"{number}"*.
@@ -1468,8 +1481,7 @@
     <emu-clause id="sec-computeexponent" aoid="ComputeExponent">
       <h1>ComputeExponent ( _numberFormat_, _x_ )</h1>
       <p>
-        The abstract operation ComputeExponent computes an exponent (power of ten) by which to scale _x_ according to the number formatting settings.
-        It handles cases such as 999 rounding up to 1000, requiring a different exponent.
+        The abstract operation ComputeExponent computes an exponent (power of ten) by which to scale _x_ according to the number formatting settings. It handles cases such as 999 rounding up to 1000, requiring a different exponent.
       </p>
       <emu-alg>
         1. If _x_ = 0, then

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -34,13 +34,13 @@
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
-        1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Set _opt_.[[LocaleMatcher]] to _matcher_.
         1. Let _t_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, *+0*<sub>𝔽</sub>, *3*<sub>𝔽</sub>, *"standard"*).
         1. Let _localeData_ be %PluralRules%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %PluralRules%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _pluralRules_.[[Locale]] to _r_.[[locale]].
+        1. Set _pluralRules_.[[Locale]] to _r_.[[Locale]].
         1. Return _pluralRules_.
       </emu-alg>
     </emu-clause>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -45,9 +45,9 @@
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _localeData_ be %RelativeTimeFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%RelativeTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %RelativeTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
-        1. Let _locale_ be _r_.[[locale]].
+        1. Let _locale_ be _r_.[[Locale]].
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
-        1. Set _relativeTimeFormat_.[[DataLocale]] to _r_.[[dataLocale]].
+        1. Set _relativeTimeFormat_.[[DataLocale]] to _r_.[[DataLocale]].
         1. Set _relativeTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _relativeTimeFormat_.[[Style]] to _style_.
@@ -112,9 +112,9 @@
       </p>
 
       <ul>
-        <li>[[LocaleData]].[[&lt;_locale_&gt;]] has fields *"second"*, *"minute"*, *"hour"*, *"day"*, *"week"*, *"month"*, *"quarter"*, and *"year"*. Additional fields may exist with the previous names concatenated with the strings *"-narrow"* or *"-short"*. The values corresponding to these fields are Records which contain these two categories of fields:
+        <li>[[LocaleData]].[[&lt;_locale_&gt;]] has fields [[Second]], [[Minute]], [[Hour]], [[Day]], [[Week]], [[Month]], [[Quarter]], and [[Year]]. Additional fields may exist with the previous names concatenated with the strings [[Narrow]] or [[Short]]. The values corresponding to these fields are Records which contain these two categories of fields:
         <ul>
-        <li>*"future"* and *"past"* fields, which are Records with a field for each of the plural categories relevant for _locale_. The value corresponding to those fields is a pattern which may contain *"{0}"* to be replaced by a formatted number.</li>
+        <li>[[Future]] and [[Past]] fields, which are Records with a field for each of the plural categories relevant for _locale_. The value corresponding to those fields is a pattern which may contain *"{0}"* to be replaced by a formatted number.</li>
         <li>Optionally, additional fields whose key is the result of ToString of a Number, and whose values are literal Strings which are not treated as templates.</li>
         </ul>
         </li>
@@ -299,13 +299,31 @@
         1. Let _dataLocale_ be _relativeTimeFormat_.[[DataLocale]].
         1. Let _fields_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _style_ be _relativeTimeFormat_.[[Style]].
+        1. Assert: _unit_ is *"second"*, "*minute"*, "*hour*", *"day"*, *"week"*, *"month*", *"quarter"*, or *"year"*.
+        1. Let _entry_ be _unit_.
+        1. If _entry_ is equal to *"second"*, then
+          1. Let _entry_ be *"Second"*.
+        1. Else if _entry_ is equal to *"minute"*, then
+          1. Let _entry_ be *"Minute"*.
+        1. Else if _entry_ is equal to *"hour"*, then
+          1. Let _entry_ be *"Hour"*.
+        1. Else if _entry_ is equal to *"day"*, then
+          1. Let _entry_ be *"Day"*.
+        1. Else if _entry_ is equal to *"week"*, then
+          1. Let _entry_ be *"Week"*.
+        1. Else if _entry_ is equal to *"month"*, then
+          1. Let _entry_ be *"Month"*.
+        1. Else if _entry_ is equal to *"quarter"*, then
+          1. Let _entry_ be *"Quarter"*.
+        1. Else,
+          1. Let _entry_ be *"Year"*.
         1. If _style_ is equal to *"short"*, then
-          1. Let _entry_ be the string-concatenation of _unit_ and *"-short"*.
+          1. Let _entry_ be the string-concatenation of _unit_ and *"Short"*.
         1. Else if _style_ is equal to *"narrow"*, then
-          1. Let _entry_ be the string-concatenation of _unit_ and *"-narrow"*.
+          1. Let _entry_ be the string-concatenation of _unit_ and *"Narrow"*.
         1. Else,
           1. Let _entry_ be _unit_.
-        1. If _fields_ doesn't have a field [[&lt;_entry_&gt;]], then
+        1. If _fields_ desn't have a field [[&lt;_entry_&gt;]], then
           1. Let _entry_ be _unit_.
         1. Let _patterns_ be _fields_.[[&lt;_entry_&gt;]].
         1. Let _numeric_ be _relativeTimeFormat_.[[Numeric]].
@@ -315,10 +333,9 @@
             1. Let _result_ be _patterns_.[[&lt;_valueString_&gt;]].
             1. Return a List containing the Record { [[Type]]: *"literal"*, [[Value]]: _result_ }.
         1. If _value_ is *-0*<sub>𝔽</sub> or if _value_ is less than 0, then
-          1. Let _tl_ be *"past"*.
+          1. Let _po_ be _patterns_.[[Past]].
         1. Else,
-          1. Let _tl_ be *"future"*.
-        1. Let _po_ be _patterns_.[[&lt;_tl_&gt;]].
+          1. Let _po_ be _patterns_.[[Future]].
         1. Let _fv_ be ! PartitionNumberPattern(_relativeTimeFormat_.[[NumberFormat]], _value_).
         1. Let _pr_ be ! ResolvePlural(_relativeTimeFormat_.[[PluralRules]], _value_).[[PluralCategory]].
         1. Let _pattern_ be _po_.[[&lt;_pr_&gt;]].

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -323,7 +323,7 @@
           1. Let _entry_ be the string-concatenation of _unit_ and *"Narrow"*.
         1. Else,
           1. Let _entry_ be _unit_.
-        1. If _fields_ desn't have a field [[&lt;_entry_&gt;]], then
+        1. If _fields_ doesn't have a field [[&lt;_entry_&gt;]], then
           1. Let _entry_ be _unit_.
         1. Let _patterns_ be _fields_.[[&lt;_entry_&gt;]].
         1. Let _numeric_ be _relativeTimeFormat_.[[Numeric]].

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -23,10 +23,10 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
-        1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Set _opt_.[[LocaleMatcher]] to _matcher_.
         1. Let _localeData_ be %Segmenter%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Segmenter%.[[AvailableLocales]], _requestedLocales_, _opt_, %Segmenter%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _segmenter_.[[Locale]] to _r_.[[locale]].
+        1. Set _segmenter_.[[Locale]] to _r_.[[Locale]].
         1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, ~string~, &laquo; *"grapheme"*, *"word"*, *"sentence"* &raquo;, *"grapheme"*).
         1. Set _segmenter_.[[SegmenterGranularity]] to _granularity_.
         1. Return _segmenter_.


### PR DESCRIPTION
fix #81 

Changed slot/field names, carefully avoiding changes to observable behavior that could result from dynamic accesses to those slots. The only names left unchanged are two-letter names like [[co]] and [[nu]], and slots/fields only accessed dynamically. 

