### PR TITLE
Editorial: Regularize self-references to ECMA-402

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -2,7 +2,7 @@
   <h1>Implementation Dependent Behaviour</h1>
 
   <p>
-    The following aspects of the ECMAScript 2023 Internationalization API Specification are implementation dependent:
+    The following aspects of this specification are implementation dependent:
   </p>
 
   <ul>

--- a/spec/conformance.html
+++ b/spec/conformance.html
@@ -1,10 +1,10 @@
 <emu-clause id="conformance">
   <h1>Conformance</h1>
   <p>
-    A conforming implementation of the ECMAScript 2023 Internationalization API Specification must conform to the ECMAScript 2023 Language Specification (ECMA-262 14<sup>th</sup> Edition, or successor), and must provide and support all the objects, properties, functions, and program semantics described in this specification. Nothing in this specification is intended to allow behaviour that is otherwise prohibited by ECMA-262, and any such conflict should be considered an editorial error rather than an override of constraints from ECMA-262.
+    A conforming implementation of this specification must conform to the ECMAScript 2023 Language Specification (ECMA-262 14<sup>th</sup> Edition, or successor), and must provide and support all the objects, properties, functions, and program semantics described in this specification. Nothing in this specification is intended to allow behaviour that is otherwise prohibited by ECMA-262, and any such conflict should be considered an editorial error rather than an override of constraints from ECMA-262.
   </p>
   <p>
-    A conforming implementation of the ECMAScript 2023 Internationalization API Specification is permitted to provide additional objects, properties, and functions beyond those described in this specification. In particular, a conforming implementation of the ECMAScript 2023 Internationalization API Specification is permitted to provide properties not described in this specification, and values for those properties, for objects that are described in this specification. A conforming implementation is not permitted to add optional arguments to the functions defined in this specification.
+    A conforming implementation is permitted to provide additional objects, properties, and functions beyond those described in this specification. In particular, a conforming implementation is permitted to provide properties not described in this specification, and values for those properties, for objects that are described herein. A conforming implementation is not permitted to add optional arguments to the functions defined in this specification.
   </p>
   <p>
     A conforming implementation is permitted to accept additional values, and then have implementation-defined behaviour instead of throwing a *RangeError*, for the following properties of _options_ arguments:

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -629,7 +629,7 @@
       </p>
 
       <emu-note>
-        In this version of the ECMAScript 2023 Internationalization API, the *"timeZone"* property will be the identifier of the host environment's time zone if no *"timeZone"* property was provided in the options object provided to the Intl.DateTimeFormat constructor. The first edition left the *"timeZone"* property *undefined* in this case.
+        In this version of the API, the *"timeZone"* property will be the identifier of the host environment's time zone if no *"timeZone"* property was provided in the options object provided to the Intl.DateTimeFormat constructor. The first edition left the *"timeZone"* property *undefined* in this case.
       </emu-note>
 
       <emu-note>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -2,7 +2,7 @@
   <h1>Locale Sensitive Functions of the ECMAScript Language Specification</h1>
 
   <p>
-    The ECMAScript Language Specification, edition 10 or successor, describes several locale-sensitive functions. An ECMAScript implementation that implements this Internationalization API Specification shall implement these functions as described here.
+    The ECMAScript Language Specification, edition 10 or successor, describes several locale-sensitive functions. An ECMAScript implementation that implements this specification shall implement these functions as described here.
   </p>
 
   <emu-note>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -29,7 +29,7 @@
     <h1>Language Tags</h1>
 
     <p>
-      The ECMAScript 2023 Internationalization API Specification identifies locales using Unicode BCP 47 locale identifiers as defined by <a href="https://unicode.org/reports/tr35/#Identifiers">Unicode Technical Standard #35 LDML § 3 Unicode Language and Locale Identifiers</a>, which may include extensions such as the <a href="https://unicode.org/reports/tr35/#Locale_Extension_Key_and_Type_Data">Unicode BCP 47 U Extension</a>. Their canonical form is specified in <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>.
+      This specification identifies locales using Unicode BCP 47 locale identifiers as defined by <a href="https://unicode.org/reports/tr35/#Identifiers">Unicode Technical Standard #35 LDML § 3 Unicode Language and Locale Identifiers</a>, which may include extensions such as the <a href="https://unicode.org/reports/tr35/#Locale_Extension_Key_and_Type_Data">Unicode BCP 47 U Extension</a>. Their canonical form is specified in <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers</a>.
     </p>
 
     <p>
@@ -136,7 +136,7 @@
     <h1>Currency Codes</h1>
 
     <p>
-      The ECMAScript 2023 Internationalization API Specification identifies currencies using 3-letter currency codes as defined by ISO 4217. Their canonical form is uppercase.
+      This specification identifies currencies using 3-letter currency codes as defined by ISO 4217. Their canonical form is uppercase.
     </p>
 
     <p>
@@ -172,7 +172,7 @@
     <h1>Time Zone Names</h1>
 
     <p>
-      The ECMAScript 2023 Internationalization API Specification identifies time zones using the Zone and Link names of the IANA Time Zone Database. Their canonical form is the corresponding Zone name in the casing used in the IANA Time Zone Database except as specifically overridden by CanonicalizeTimeZoneName.
+      This specification identifies time zones using the Zone and Link names of the IANA Time Zone Database. Their canonical form is the corresponding Zone name in the casing used in the IANA Time Zone Database except as specifically overridden by CanonicalizeTimeZoneName.
     </p>
 
     <p>
@@ -256,7 +256,7 @@
     <h1>Measurement Unit Identifiers</h1>
 
     <p>
-      The ECMAScript 2023 Internationalization API Specification identifies measurement units using a <dfn variants="core unit identifiers,core unit ID,core unit IDs">core unit identifier</dfn> (or equivalently <em>core unit ID</em>) as defined by <a href="https://unicode.org/reports/tr35/tr35-general.html#Unit_Identifiers">Unicode Technical Standard #35 Part 2 General, Section 6.2 Unit Identifiers</a>. Their canonical form is a string containing only Unicode Basic Latin lowercase letters (U+0061 LATIN SMALL LETTER A through U+007A LATIN SMALL LETTER Z) with zero or more medial hyphens (U+002D HYPHEN-MINUS).
+      This specification identifies measurement units using a <dfn variants="core unit identifiers,core unit ID,core unit IDs">core unit identifier</dfn> (or equivalently <em>core unit ID</em>) as defined by <a href="https://unicode.org/reports/tr35/tr35-general.html#Unit_Identifiers">Unicode Technical Standard #35 Part 2 General, Section 6.2 Unit Identifiers</a>. Their canonical form is a string containing only Unicode Basic Latin lowercase letters (U+0061 LATIN SMALL LETTER A through U+007A LATIN SMALL LETTER Z) with zero or more medial hyphens (U+002D HYPHEN-MINUS).
     </p>
 
     <p>
@@ -290,7 +290,7 @@
       <h1>IsSanctionedSingleUnitIdentifier ( _unitIdentifier_ )</h1>
 
       <p>
-        The IsSanctionedSingleUnitIdentifier abstract operation verifies that the _unitIdentifier_ argument (which must be a String value) is among the single unit identifiers sanctioned in the current version of the ECMAScript Internationalization API Specification, which are a subset of the Common Locale Data Repository <a href="https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/unit.xml">release 38 unit validity data</a>; the list may grow over time. As discussed in <a href="https://unicode.org/reports/tr35/tr35-general.html#Unit_Identifiers">Unicode Technical Standard #35 Part 2 General, Section 6.2 Unit Identifiers</a>, a single unit identifier is a core unit identifier that is not composed of multiplication or division of other unit identifiers. The following steps are taken:
+        The IsSanctionedSingleUnitIdentifier abstract operation verifies that the _unitIdentifier_ argument (which must be a String value) is among the single unit identifiers sanctioned in the current version of this specification, which are a subset of the Common Locale Data Repository <a href="https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/unit.xml">release 38 unit validity data</a>; the list may grow over time. As discussed in <a href="https://unicode.org/reports/tr35/tr35-general.html#Unit_Identifiers">Unicode Technical Standard #35 Part 2 General, Section 6.2 Unit Identifiers</a>, a single unit identifier is a core unit identifier that is not composed of multiplication or division of other unit identifiers. The following steps are taken:
       </p>
 
       <emu-alg>

--- a/spec/overview.html
+++ b/spec/overview.html
@@ -12,7 +12,7 @@
       Internationalization of software means designing it such that it supports or can be easily adapted to support the needs of users speaking different languages and having different cultural expectations, and enables worldwide communication between them. Localization then is the actual adaptation to a specific language and culture. Globalization of software is commonly understood to be the combination of internationalization and localization. Globalization starts at the lowest level by using a text representation that supports all languages in the world, and using standard identifiers to identify languages, countries, time zones, and other relevant parameters. It continues with using a user interface language and data presentation that the user understands, and finally often requires product-specific adaptations to the user's language, culture, and environment.
     </p>
     <p>
-      The ECMAScript 2023 Language Specification lays the foundation by using Unicode for text representation and by providing a few language-sensitive functions, but gives applications little control over the behaviour of these functions. The ECMAScript 2023 Internationalization API Specification builds on this by providing a set of customizable language-sensitive functionality. The API is useful even for applications that themselves are not internationalized, as even applications targeting only one language and one region need to properly support that one language and region. However, the API also enables applications that support multiple languages and regions, even concurrently, as may be needed in server environments.
+      The ECMAScript 2023 Language Specification lays the foundation by using Unicode for text representation and by providing a few language-sensitive functions, but gives applications little control over the behaviour of these functions. This specification builds on that foundation by providing a set of customizable language-sensitive functionality. The API is useful even for applications that themselves are not internationalized, as even applications targeting only one language and one region need to properly support that one language and region. However, the API also enables applications that support multiple languages and regions, even concurrently, as may be needed in server environments.
     </p>
   </emu-clause>
 
@@ -20,10 +20,10 @@
     <h1>API Overview</h1>
 
     <p>
-      The ECMAScript 2023 Internationalization API Specification is designed to complement the ECMAScript 2023 Language Specification by providing key language-sensitive functionality. The API can be added to an implementation of the ECMAScript 2023 Language Specification (ECMA-262 14<sup>th</sup> Edition, or successor) in whole or in part. This specification introduces new language values observable to ECMAScript code (such as the value of a [[FallbackSymbol]] internal slot and the set of values transitively reachable from %Intl% by <emu-xref href="#sec-property-accessors">property access</emu-xref>), and also refines the definition of some functions specified in ECMA-262 (as described below). Neither category prohibits behaviour that is otherwise permitted for values and interfaces defined in ECMA-262, in order to support adoption of this specification by any implementation of ECMA-262.
+      This specification is designed to complement the ECMAScript 2023 Language Specification by providing key language-sensitive functionality. The API can be added to an implementation of the ECMAScript 2023 Language Specification (ECMA-262 14<sup>th</sup> Edition, or successor) in whole or in part. This specification introduces new language values observable to ECMAScript code (such as the value of a [[FallbackSymbol]] internal slot and the set of values transitively reachable from %Intl% by <emu-xref href="#sec-property-accessors">property access</emu-xref>), and also refines the definition of some functions specified in ECMA-262 (as described below). Neither category prohibits behaviour that is otherwise permitted for values and interfaces defined in ECMA-262, in order to support adoption of this specification by any implementation of ECMA-262.
     </p>
     <p>
-      The ECMAScript 2023 Internationalization API Specification provides several key pieces of language-sensitive functionality that are required in most applications: String comparison (collation), number formatting, date and time formatting, relative time formatting, display names, list formatting, locale selection and operation, pluralization rules, case conversion, and text segmentation. While the ECMAScript 2023 Language Specification provides functions for this basic functionality (on <emu-xref href="#sec-array.prototype">Array.prototype</emu-xref>: `toLocaleString`; on <emu-xref href="#sec-string.prototype">String.prototype</emu-xref>: `localeCompare`, `toLocaleLowerCase`, `toLocaleUpperCase`; on <emu-xref href="#sec-number.prototype">Number.prototype</emu-xref>: `toLocaleString`; on <emu-xref href="#sec-date.prototype">Date.prototype</emu-xref>: `toLocaleString`, `toLocaleDateString`, and `toLocaleTimeString`), their actual behaviour is left largely implemenation-defined. The ECMAScript 2023 Internationalization API Specification provides additional functionality, control over the language and over details of the behaviour to be used, and a more complete specification of required functionality.
+      This specification provides several key pieces of language-sensitive functionality that are required in most applications: String comparison (collation), number formatting, date and time formatting, relative time formatting, display names, list formatting, locale selection and operation, pluralization rules, case conversion, and text segmentation. While the ECMAScript 2023 Language Specification provides functions for this basic functionality (on <emu-xref href="#sec-array.prototype">Array.prototype</emu-xref>: `toLocaleString`; on <emu-xref href="#sec-string.prototype">String.prototype</emu-xref>: `localeCompare`, `toLocaleLowerCase`, `toLocaleUpperCase`; on <emu-xref href="#sec-number.prototype">Number.prototype</emu-xref>: `toLocaleString`; on <emu-xref href="#sec-date.prototype">Date.prototype</emu-xref>: `toLocaleString`, `toLocaleDateString`, and `toLocaleTimeString`), their actual behaviour is left largely implemenation-defined. This specification provides additional functionality, control over the language and over details of the behaviour to be used, and a more complete specification of required functionality.
     </p>
 
     <p>Applications can use the API in two ways:</p>
@@ -37,7 +37,7 @@
     </ol>
 
     <p>
-      The Intl object is used to package all functionality defined in the ECMAScript 2023 Internationalization API Specification to avoid name collisions.
+      The Intl object is used to package all functionality defined in this specification in order to avoid name collisions.
     </p>
 
     <emu-note>While the API includes a variety of formatters, it does not provide any parsing facilities. This is intentional, has been discussed extensively, and concluded after weighing in all the benefits and drawbacks of including said functionality. See the discussion on the <a href="https://github.com/tc39/ecma402/issues/342">issue tracker</a>.</emu-note>
@@ -59,7 +59,7 @@
     <h1>Implementation Dependencies</h1>
 
     <p>
-      Due to the nature of internationalization, the API specification has to leave several details implementation dependent:
+      Due to the nature of internationalization, this specification has to leave several details implementation dependent:
     </p>
     <ul>
       <li>


### PR DESCRIPTION
fix #641 

Replaced phrases like "current version of the ECMAScript Internationalization API Specification" with "this specification" where appropriate, with some edits to wording of surrounding sentences to avoid ambiguity between references to _this_ specification and references to ECMA-262. 

Thought: ECMA-419 introduces 262 with this sentence:

> This Standard does not make any changes to the ECMAScript language as defined by ECMAScript Language Specification (ECMA-262)

and then subsequently refers to it as ECMA-262. Given how often references to 262 appear in 402, I'm tempted to follow their lead.
