### PR TITLE
Normative: Allow UTC offset time zones

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -16,9 +16,6 @@
           The default locale (<emu-xref href="#sec-defaultlocale"></emu-xref>)
         </li>
         <li>
-          The default time zone (<emu-xref href="#sup-defaulttimezone"></emu-xref>)
-        </li>
-        <li>
           The set of available locales for each constructor (<emu-xref href="#sec-internal-slots"></emu-xref>)
         </li>
         <li>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -679,7 +679,7 @@
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
       <li>[[Calendar]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeCalendarIdentifier">Unicode Calendar Identifier</a> used for formatting.</li>
       <li>[[NumberingSystem]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> used for formatting.</li>
-      <li>[[TimeZone]] is a String value that is a time zone identifier from the IANA Time Zone Database used for formatting.</li>
+      <li>[[TimeZone]] is a String value used for formatting that is either a time zone identifier from the IANA Time Zone Database or a UTC offset in ISO 8601 extended format.</li>
       <li>[[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]] are each either *undefined*, indicating that the component is not used for formatting, or one of the String values given in <emu-xref href="#table-datetimeformat-components"></emu-xref>, indicating how the component should be presented in the formatted output.</li>
       <li>[[FractionalSecondDigits]] is either *undefined* or a positive, non-zero integer Number value indicating the fraction digits to be used for fractional seconds. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
       <li>[[HourCycle]] is a String value indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[Hour]] is not *undefined*.</li>
@@ -1150,7 +1150,11 @@
       </dl>
 
       <emu-alg>
-        1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_timeZoneIdentifier_, _epochNs_).
+        1. If IsTimeZoneOffsetString(_timeZoneIdentifier_) is *true*, then
+          1. Let _offsetNs_ be ParseTimeZoneOffsetString(_timeZoneIdentifier_).
+        1. Else,
+          1. Assert: IsValidTimeZoneName(_timeZoneIdentifier_) is *true*.
+          1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_timeZoneIdentifier_, _epochNs_).
         1. Let _tz_ be ℝ(_epochNs_) + _offsetNs_.
         1. If _calendar_ is *"gregory"*, then
           1. Return a record with fields calculated from _tz_ according to <emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref>.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -94,9 +94,13 @@
           1. Set _timeZone_ to DefaultTimeZone().
         1. Else,
           1. Set _timeZone_ to ? ToString(_timeZone_).
-          1. If the result of IsValidTimeZoneName(_timeZone_) is *false*, then
-            1. Throw a *RangeError* exception.
+        1. If IsTimeZoneOffsetString(_timeZone_) is *true*, then
+          1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_timeZone_).
+          1. Set _timeZone_ to FormatTimeZoneOffsetString(_offsetNanoseconds_).
+        1. Else if IsValidTimeZoneName(_timeZone_) is *true*, then
           1. Set _timeZone_ to CanonicalizeTimeZoneName(_timeZone_).
+        1. Else,
+          1. Throw a *RangeError* exception.
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
         1. Let _formatOptions_ be a new Record.
         1. Set _formatOptions_.[[hourCycle]] to _hc_.
@@ -162,6 +166,31 @@
         1. Set _dateTimeFormat_.[[Pattern]] to _pattern_.
         1. Set _dateTimeFormat_.[[RangePatterns]] to _rangePatterns_.
         1. Return _dateTimeFormat_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-formattimezoneoffsetstring" aoid="FormatTimeZoneOffsetString">
+      <h1>FormatTimeZoneOffsetString ( _offsetNanoseconds_ )</h1>
+      <emu-alg>
+        1. Assert: _offsetNanoseconds_ is an integer.
+        1. If _offsetNanoseconds_ &ge; 0, let _sign_ be the code unit 0x002B (PLUS SIGN); otherwise, let _sign_ be the code unit 0x002D (HYPHEN-MINUS).
+        1. Set _offsetNanoseconds_ to abs(_offsetNanoseconds_).
+        1. Let _nanoseconds_ be _offsetNanoseconds_ modulo 10<sup>9</sup>.
+        1. Let _seconds_ be floor(_offsetNanoseconds_ / 10<sup>9</sup>) modulo 60.
+        1. Let _minutes_ be floor(_offsetNanoseconds_ / (6 &times; 10<sup>10</sup>)) modulo 60.
+        1. Let _hours_ be floor(_offsetNanoseconds_ / (3.6 &times; 10<sup>12</sup>)).
+        1. Let _h_ be ToZeroPaddedDecimalString(_hours_, 2).
+        1. Let _m_ be ToZeroPaddedDecimalString(_minutes_, 2).
+        1. Let _s_ be ToZeroPaddedDecimalString(_seconds_, 2).
+        1. If _nanoseconds_ &ne; 0, then
+          1. Let _fraction_ be ToZeroPaddedDecimalString(_nanoseconds_, 9).
+          1. Set _fraction_ to the longest possible substring of _fraction_ starting at position 0 and not ending with the code unit 0x0030 (DIGIT ZERO).
+          1. Let _post_ be the string-concatenation of the code unit 0x003A (COLON), _s_, the code unit 0x002E (FULL STOP), and _fraction_.
+        1. Else if seconds &ne; 0, then
+          1. Let _post_ be the string-concatenation of the code unit 0x003A (COLON) and _s_.
+        1. Else,
+          1. Let _post_ be the empty String.
+        1. Return the string-concatenation of _sign_, _h_, the code unit 0x003A (COLON), _m_, and _post_.
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -95,8 +95,13 @@
         1. Else,
           1. Set _timeZone_ to ? ToString(_timeZone_).
         1. If IsTimeZoneOffsetString(_timeZone_) is *true*, then
+          1. Let _parseResult_ be ParseText(StringToCodePoints(_timeZone_), |UTCOffset|).
+          1. Assert: _parseResult_ is a Parse Node.
+          1. If _parseResult_ contains more than one |MinuteSecond| Parse Node, throw a *RangeError* exception.
           1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_timeZone_).
-          1. Set _timeZone_ to FormatTimeZoneOffsetString(_offsetNanoseconds_).
+          1. Let _offsetMinutes_ be _offsetNanoseconds_ / (6 × 10<sup>10</sup>).
+          1. Assert: _offsetMinutes_ is an integer.
+          1. Set _timeZone_ to FormatOffsetTimeZoneIdentifier(_offsetMinutes_).
         1. Else if IsValidTimeZoneName(_timeZone_) is *true*, then
           1. Set _timeZone_ to CanonicalizeTimeZoneName(_timeZone_).
         1. Else,
@@ -169,28 +174,24 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-formattimezoneoffsetstring" aoid="FormatTimeZoneOffsetString">
-      <h1>FormatTimeZoneOffsetString ( _offsetNanoseconds_ )</h1>
+    <emu-clause id="sec-formatoffsettimezoneidentifier" type="abstract operation">
+      <h1>
+        FormatOffsetTimeZoneIdentifier (
+          _offsetMinutes_: an integer,
+        ): a String
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It formats a UTC offset, in minutes, into a UTC offset string formatted like ±HH:MM.
+        </dd>
+      </dl>
       <emu-alg>
-        1. Assert: _offsetNanoseconds_ is an integer.
-        1. If _offsetNanoseconds_ &ge; 0, let _sign_ be the code unit 0x002B (PLUS SIGN); otherwise, let _sign_ be the code unit 0x002D (HYPHEN-MINUS).
-        1. Set _offsetNanoseconds_ to abs(_offsetNanoseconds_).
-        1. Let _nanoseconds_ be _offsetNanoseconds_ modulo 10<sup>9</sup>.
-        1. Let _seconds_ be floor(_offsetNanoseconds_ / 10<sup>9</sup>) modulo 60.
-        1. Let _minutes_ be floor(_offsetNanoseconds_ / (6 &times; 10<sup>10</sup>)) modulo 60.
-        1. Let _hours_ be floor(_offsetNanoseconds_ / (3.6 &times; 10<sup>12</sup>)).
-        1. Let _h_ be ToZeroPaddedDecimalString(_hours_, 2).
-        1. Let _m_ be ToZeroPaddedDecimalString(_minutes_, 2).
-        1. Let _s_ be ToZeroPaddedDecimalString(_seconds_, 2).
-        1. If _nanoseconds_ &ne; 0, then
-          1. Let _fraction_ be ToZeroPaddedDecimalString(_nanoseconds_, 9).
-          1. Set _fraction_ to the longest possible substring of _fraction_ starting at position 0 and not ending with the code unit 0x0030 (DIGIT ZERO).
-          1. Let _post_ be the string-concatenation of the code unit 0x003A (COLON), _s_, the code unit 0x002E (FULL STOP), and _fraction_.
-        1. Else if seconds &ne; 0, then
-          1. Let _post_ be the string-concatenation of the code unit 0x003A (COLON) and _s_.
-        1. Else,
-          1. Let _post_ be the empty String.
-        1. Return the string-concatenation of _sign_, _h_, the code unit 0x003A (COLON), _m_, and _post_.
+        1. If _offsetMinutes_ &ge; 0, let _sign_ be the code unit 0x002B (PLUS SIGN); otherwise, let _sign_ be the code unit 0x002D (HYPHEN-MINUS).
+        1. Let _absoluteMinutes_ be abs(_offsetMinutes_).
+        1. Let _hours_ be floor(_absoluteMinutes_ / 60).
+        1. Let _minutes_ be _absoluteMinutes_ modulo 60.
+        1. Return the string-concatenation of _sign_, ToZeroPaddedDecimalString(_hours_, 2), the code unit 0x003A (COLON), and ToZeroPaddedDecimalString(_minutes_, 2).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -182,7 +182,7 @@
     </emu-clause>
 
     <emu-note>
-      Any value returned from DefaultTimeZone must be recognized as valid.
+      Any value returned from DefaultTimeZone that is not recognized as valid by IsTimeZoneOffsetString must be recognized as valid by IsValidTimeZoneName.
     </emu-note>
 
     <emu-clause id="sec-canonicalizetimezonename" type="abstract operation">
@@ -201,19 +201,6 @@
         1. If _ianaTimeZone_ is one of *"Etc/UTC"*, *"Etc/GMT"*, or *"GMT"*, return *"UTC"*.
         1. Return _ianaTimeZone_.
       </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sup-defaulttimezone" oldids="sec-defaulttimezone" type="implementation-defined abstract operation">
-      <h1>DefaultTimeZone ( ): a String</h1>
-
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns a String value representing the host environment's current time zone, which is a valid (<emu-xref href="#sec-isvalidtimezonename"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizetimezonename"></emu-xref>) time zone name.</dd>
-      </dl>
-
-      <p>
-        This definition supersedes the definition provided in es2024, <emu-xref href="#sec-defaulttimezone"></emu-xref>.
-      </p>
     </emu-clause>
 
     <emu-clause id="sec-availablecanonicaltimezones" type="implementation-defined abstract operation">


### PR DESCRIPTION
Fixes #683

This aligns with ECMA-262, and therefore removes the DefaultTimeZone override.

Example time zones that will now be accepted: [Temporal |TimeZoneUTCOffsetName|](https://tc39.es/proposal-temporal/#prod-TimeZoneUTCOffsetName)
* "+00"
* "-00"
* "−00"
* "+0000"
* "-0000"
* "−0000"
* "+00:00"
* "-00:00"
* "−00:00"
* "+2359"
* "+23:59"
* "-2359"
* "-23:59"
* "−2359"
* "−23:59"