### PR TITLE
Editorial: added explanatory note on appropriate usage of `search` collation

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -80,7 +80,7 @@
     </emu-clause>
 
     <emu-note>
-      The collation activated by the `search` value for the `usage` option should only be used to find matching strings, since this collation is not guaranteed to be in any particular order.
+      The collation associated with the *"search"* value for the *"usage"* option should only be used to find matching strings, since this collation is not guaranteed to be in any particular order (as described in [Unicode Technical Standard #35 Part 1 Core, Unicode Collation Identifier](https://unicode.org/reports/tr35/#UnicodeCollationIdentifier) and [Unicode Technical Standard #10 Unicode Collation Algorithm, Searching and Matching](https://unicode.org/reports/tr10/#Searching)).
     </emu-note>
   </emu-clause>
 

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -78,6 +78,10 @@
         1. Return _collator_.
       </emu-alg>
     </emu-clause>
+
+    <emu-note>
+      The collation activated by the `search` value for the `usage` option should only be used to find matching strings, since this collation is not guaranteed to be in any particular order.
+    </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-properties-of-the-intl-collator-constructor">


### PR DESCRIPTION
Fix #256 

(see also corresponding MDN PR: https://github.com/mdn/content/pull/27274)