### PR TITLE
Editorial: Removed several unnecessary double negatives

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -130,16 +130,7 @@
         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.
         1. Let _timeStyle_ be ? GetOption(_options_, *"timeStyle"*, ~string~, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[TimeStyle]] to _timeStyle_.
-        1. If _dateStyle_ is not *undefined* or _timeStyle_ is not *undefined*, then
-          1. If _hasExplicitFormatComponents_ is *true*, then
-            1. Throw a *TypeError* exception.
-          1. If _required_ is ~date~ and _timeStyle_ is not *undefined*, then
-            1. Throw a *TypeError* exception.
-          1. If _required_ is ~time~ and _dateStyle_ is not *undefined*, then
-            1. Throw a *TypeError* exception.
-          1. Let _styles_ be _resolvedLocaleData_.[[styles]].[[&lt;_resolvedCalendar_&gt;]].
-          1. Let _bestFormat_ be DateTimeStyleFormat(_dateStyle_, _timeStyle_, _styles_).
-        1. Else,
+        1. If _dateStyle_ is *undefined* and _timeStyle_ is *undefined*, then
           1. Let _needDefaults_ be *true*.
           1. If _required_ is ~date~ or ~any~, then
             1. For each property name _prop_ of &laquo; *"weekday"*, *"year"*, *"month"*, *"day"* &raquo;, do
@@ -160,6 +151,15 @@
             1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
           1. Else,
             1. Let _bestFormat_ be BestFitFormatMatcher(_formatOptions_, _formats_).
+        1. Else,
+            1. If _hasExplicitFormatComponents_ is *true*, then
+              1. Throw a *TypeError* exception.
+            1. If _required_ is ~date~ and _timeStyle_ is not *undefined*, then
+              1. Throw a *TypeError* exception.
+            1. If _required_ is ~time~ and _dateStyle_ is not *undefined*, then
+              1. Throw a *TypeError* exception.
+            1. Let _styles_ be _resolvedLocaleData_.[[styles]].[[&lt;_resolvedCalendar_&gt;]].
+            1. Let _bestFormat_ be DateTimeStyleFormat(_dateStyle_, _timeStyle_, _styles_).
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
           1. Let _prop_ be the name given in the Property column of the current row.
           1. If _bestFormat_ has a field [[&lt;_prop_&gt;]], then

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -135,14 +135,8 @@
         1. Set _intlObj_.[[RoundingIncrement]] to _roundingIncrement_.
         1. Set _intlObj_.[[RoundingMode]] to _roundingMode_.
         1. Set _intlObj_.[[TrailingZeroDisplay]] to _trailingZeroDisplay_.
-        1. If _mnsd_ is not *undefined* or _mxsd_ is not *undefined*, then
-          1. Let _hasSd_ be *true*.
-        1. Else,
-          1. Let _hasSd_ be *false*.
-        1. If _mnfd_ is not *undefined* or _mxfd_ is not *undefined*, then
-          1. Let _hasFd_ be *true*.
-        1. Else,
-          1. Let _hasFd_ be *false*.
+        1. If _mnsd_ is *undefined* and _mxsd_ is *undefined*, let _hasSd_ be *false*. Otherwise, let _hasSd_ be *true*.
+        1. If _mnfd_ is *undefined* and _mxsd_ is *undefined*, let _hasFd_ be *false*. Otherwise, let _hasFd_ be *true*.
         1. Let _needSd_ be *true*.
         1. Let _needFd_ be *true*.
         1. If _roundingPriority_ is *"auto"*, then


### PR DESCRIPTION
Rebased 3-1-24, and updated to include @gibson042 suggestion to improve readability of `SetNumberFormatDigitOptions` AO in `Intl.NumberFormat`
Fix #458 

Refactored several cases from  

1. If not *undefined*, then 
  a. X
2 Else,
  a. Y

with

1. If *undefined*, then 
  a. Y
2. Else,
  a. X

and 

1. If not *undefined*, then
  a. Return X.
2. Return Y.

to 
1. If *undefined*, then
  a. Return Y.
2. Return X. 
