### PR TITLE
Editorial: Two links were in Markdown syntax rather than actual HTML

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -80,7 +80,7 @@
     </emu-clause>
 
     <emu-note>
-      The collation associated with the *"search"* value for the *"usage"* option should only be used to find matching strings, since this collation is not guaranteed to be in any particular order. This behaviour is described in <a href="https://unicode.org/reports/tr35/#UnicodeCollationIdentifier">Unicode Technical Standard #35 Part 1 Core, Unicode Collation Identifier</a> and <a href="https://unicode.org/reports/tr10/#Searching">Unicode Technical Standard #10 Unicode Collation Algorithm, Searching and Matching</a>
+      The collation associated with the *"search"* value for the *"usage"* option should only be used to find matching strings, since this collation is not guaranteed to be in any particular order. This behaviour is described in <a href="https://unicode.org/reports/tr35/#UnicodeCollationIdentifier">Unicode Technical Standard #35 Part 1 Core, Unicode Collation Identifier</a> and <a href="https://unicode.org/reports/tr10/#Searching">Unicode Technical Standard #10 Unicode Collation Algorithm, Searching and Matching</a>.
     </emu-note>
   </emu-clause>
 

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -80,7 +80,7 @@
     </emu-clause>
 
     <emu-note>
-      The collation associated with the *"search"* value for the *"usage"* option should only be used to find matching strings, since this collation is not guaranteed to be in any particular order (as described in [Unicode Technical Standard #35 Part 1 Core, Unicode Collation Identifier](https://unicode.org/reports/tr35/#UnicodeCollationIdentifier) and [Unicode Technical Standard #10 Unicode Collation Algorithm, Searching and Matching](https://unicode.org/reports/tr10/#Searching)).
+      The collation associated with the *"search"* value for the *"usage"* option should only be used to find matching strings, since this collation is not guaranteed to be in any particular order. This behaviour is described in <a href="https://unicode.org/reports/tr35/#UnicodeCollationIdentifier">Unicode Technical Standard #35 Part 1 Core, Unicode Collation Identifier</a> and <a href="https://unicode.org/reports/tr10/#Searching">Unicode Technical Standard #10 Unicode Collation Algorithm, Searching and Matching</a>
     </emu-note>
   </emu-clause>
 


### PR DESCRIPTION
Corrects a recent botch in collator spec.