### PR TITLE
Editorial: Added %SegmentIteratorPrototype% and %SegmentsPrototype% to the well-known intrinsics table

### DIFF
--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -94,7 +94,7 @@
         <tr>
           <td>%SegmentIteratorPrototype%</td>
           <td></td>
-          <td>The prototype of Segments iterator objects(<emu-xref href="#sec-%segmentiteratorprototype%-object"></emu-xref>)</td>
+          <td>The prototype of Segment Iterator objects (<emu-xref href="#sec-%segmentiteratorprototype%-object"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%SegmentsPrototype%</td>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -89,7 +89,17 @@
         <tr>
           <td>%Segmenter%</td>
           <td>`Intl.Segmenter`</td>
-          <td>The `Intl.Segmenter` constructor (<emu-xref href="#sec-intl-segmenter-constructor"></emu-xref>).</td>
+          <td>The `Intl.Segmenter` constructor (<emu-xref href="#sec-intl-segmenter-constructor"></emu-xref>)</td>
+        </tr>
+        <tr>
+          <td>%SegmentIteratorPrototype%</td>
+          <td></td>
+          <td>The prototype of Segments iterator objects(<emu-xref href="#sec-%segmentiteratorprototype%-object"></emu-xref>)</td>
+        </tr>
+        <tr>
+          <td>%SegmentsPrototype%</td>
+          <td></td>
+          <td>The prototype of Segments objects (<emu-xref href="#sec-%segmentsprototype%-object"></emu-xref>)</td>
         </tr>
       </table>
     </emu-table>


### PR DESCRIPTION
fix #655 

Added %SegmentIteratorPrototype% and %SegmentsPrototype% to the well-known intrinsics table, giving them no global name (as with analogous-seeming intrinsics in ECMA-262, i.e. %StringIteratorPrototype%, %RegExpStringIteratorPrototype%, etc.)

Let me know if this one should be considered normative.