### PR TITLE
Editorial: Replaced all non-standard 'increase _x_ by _y_' and 'decrease _x_ by …' statements 

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -823,24 +823,24 @@
           1. For each property name _property_ shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, do
             1. If _options_ has a field [[&lt;_property_&gt;]], let _optionsProp_ be _options_.[[&lt;_property_&gt;]]; else let _optionsProp_ be *undefined*.
             1. If _format_ has a field [[&lt;_property_&gt;]], let _formatProp_ be _format_.[[&lt;_property_&gt;]]; else let _formatProp_ be *undefined*.
-            1. If _optionsProp_ is *undefined* and _formatProp_ is not *undefined*, decrease _score_ by _additionPenalty_.
-            1. Else if _optionsProp_ is not *undefined* and _formatProp_ is *undefined*, decrease _score_ by _removalPenalty_.
+            1. If _optionsProp_ is *undefined* and _formatProp_ is not *undefined*, set _score_ to _score_ - _additionPenalty_.
+            1. Else if _optionsProp_ is not *undefined* and _formatProp_ is *undefined*, set _score_ to _score_ - _removalPenalty_.
             1. Else if _property_ is *"timeZoneName"*, then
               1. If _optionsProp_ is *"short"* or *"shortGeneric"*, then
-                1. If _formatProp_ is *"shortOffset"*, decrease _score_ by _offsetPenalty_.
-                1. Else if _formatProp_ is *"longOffset"*, decrease _score_ by (_offsetPenalty_ + _shortMorePenalty_).
-                1. Else if _optionsProp_ is *"short"* and _formatProp_ is *"long"*, decrease _score_ by _shortMorePenalty_.
-                1. Else if _optionsProp_ is *"shortGeneric"* and _formatProp_ is *"longGeneric"*, decrease _score_ by _shortMorePenalty_.
-                1. Else if _optionsProp_ &ne; _formatProp_, decrease _score_ by _removalPenalty_.
-              1. Else if _optionsProp_ is *"shortOffset"* and _formatProp_ is *"longOffset"*, decrease _score_ by _shortMorePenalty_.
+                1. If _formatProp_ is *"shortOffset"*, set _score_ to _score_ - _offsetPenalty_.
+                1. Else if _formatProp_ is *"longOffset"*, set _score_ to _score_ - (_offsetPenalty_ + _shortMorePenalty_).
+                1. Else if _optionsProp_ is *"short"* and _formatProp_ is *"long"*, set _score_ to _score_ - _shortMorePenalty_.
+                1. Else if _optionsProp_ is *"shortGeneric"* and _formatProp_ is *"longGeneric"*, set _score_ to _score - _shortMorePenalty_.
+                1. Else if _optionsProp_ &ne; _formatProp_, set _score_ to _score_ - _removalPenalty_.
+              1. Else if _optionsProp_ is *"shortOffset"* and _formatProp_ is *"longOffset"*, set _score_ to _score_ - _shortMorePenalty_.
               1. Else if _optionsProp_ is *"long"* or *"longGeneric"*, then
-                1. If _formatProp_ is *"longOffset"*, decrease _score_ by _offsetPenalty_.
-                1. Else if _formatProp_ is *"shortOffset"*, decrease _score_ by (_offsetPenalty_ + _longLessPenalty_).
-                1. Else if _optionsProp_ is *"long"* and _formatProp_ is *"short"*, decrease _score_ by _longLessPenalty_.
-                1. Else if _optionsProp_ is *"longGeneric"* and _formatProp_ is *"shortGeneric"*, decrease _score_ by _longLessPenalty_.
-                1. Else if _optionsProp_ &ne; _formatProp_, decrease _score_ by _removalPenalty_.
-              1. Else if _optionsProp_ is *"longOffset"* and _formatProp_ is *"shortOffset"*, decrease _score_ by _longLessPenalty_.
-              1. Else if _optionsProp_ &ne; _formatProp_, decrease _score_ by _removalPenalty_.
+                1. If _formatProp_ is *"longOffset"*, set _score_ to _score_ - _offsetPenalty_.
+                1. Else if _formatProp_ is *"shortOffset"*, set _score_ to _score_ - (_offsetPenalty_ + _longLessPenalty_).
+                1. Else if _optionsProp_ is *"long"* and _formatProp_ is *"short"*, set _score_ to _score_ - _longLessPenalty_.
+                1. Else if _optionsProp_ is *"longGeneric"* and _formatProp_ is *"shortGeneric"*, set _score_ to _score - _longLessPenalty_.
+                1. Else if _optionsProp_ &ne; _formatProp_, set _score_ to _score_ - _removalPenalty_.
+              1. Else if _optionsProp_ is *"longOffset"* and _formatProp_ is *"shortOffset"*, set _score_ to _score_ - _longLessPenalty_.
+              1. Else if _optionsProp_ &ne; _formatProp_, set _score_ to _score_ - _removalPenalty_.
             1. Else if _optionsProp_ &ne; _formatProp_, then
               1. If _property_ is *"fractionalSecondDigits"*, then
                 1. Let _values_ be &laquo; *1*<sub>𝔽</sub>, *2*<sub>𝔽</sub>, *3*<sub>𝔽</sub> &raquo;.
@@ -849,10 +849,10 @@
               1. Let _optionsPropIndex_ be the index of _optionsProp_ within _values_.
               1. Let _formatPropIndex_ be the index of _formatProp_ within _values_.
               1. Let _delta_ be max(min(_formatPropIndex_ - _optionsPropIndex_, 2), -2).
-              1. If _delta_ = 2, decrease _score_ by _longMorePenalty_.
-              1. Else if _delta_ = 1, decrease _score_ by _shortMorePenalty_.
-              1. Else if _delta_ = -1, decrease _score_ by _shortLessPenalty_.
-              1. Else if _delta_ = -2, decrease _score_ by _longLessPenalty_.
+              1. If _delta_ = 2, set _score_ to _score_ - _longMorePenalty_.
+              1. Else if _delta_ = 1, set _score_ to _score_ - _shortMorePenalty_.
+              1. Else if _delta_ = -1, set _score_ to _score_ - _shortLessPenalty_.
+              1. Else if _delta_ = -2, set _score_ to _score_ - _longLessPenalty_.
           1. If _score_ > _bestScore_, then
             1. Let _bestScore_ be _score_.
             1. Let _bestFormat_ be _format_.
@@ -938,7 +938,7 @@
             1. Else, let _f_ be the value of _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the matching row.
             1. Let _v_ be the value of _tm_'s field whose name is the Internal Slot column of the matching row.
             1. If _p_ is *"year"* and _v_ &le; 0, let _v_ be 1 - _v_.
-            1. If _p_ is *"month"*, increase _v_ by 1.
+            1. If _p_ is *"month"*, set _v_ to _v_ + 1.
             1. If _p_ is *"hour"* and _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
               1. Let _v_ be _v_ modulo 12.
               1. If _v_ is 0 and _dateTimeFormat_.[[HourCycle]] is *"h12"*, let _v_ be 12.

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -273,7 +273,7 @@
           1. If _nextElement_ is not *undefined* or *null*, then
             1. Let _S_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*, &laquo; _locales_, _options_ &raquo;)).
             1. Set _R_ to the string-concatenation of _R_ and _S_.
-          1. Increase _k_ by 1.
+          1. Set _k_ to _k_ + 1.
         1. Return _R_.
       </emu-alg>
 

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -62,7 +62,7 @@
             1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
             1. Let _canonicalizedTag_ be CanonicalizeUnicodeLocaleId(_tag_).
             1. If _canonicalizedTag_ is not an element of _seen_, append _canonicalizedTag_ as the last element of _seen_.
-          1. Increase _k_ by 1.
+          1. Set _k_ to _k_ + 1.
         1. Return _seen_.
       </emu-alg>
 
@@ -91,7 +91,7 @@
         1. Repeat,
           1. If _availableLocales_ contains _candidate_, return _candidate_.
           1. Let _pos_ be the character index of the last occurrence of *"-"* (U+002D) within _candidate_. If that character does not occur, return *undefined*.
-          1. If _pos_ &ge; 2 and the character *"-"* occurs at index _pos_ - 2 of candidate, decrease _pos_ by 2.
+          1. If _pos_ &ge; 2 and the character *"-"* occurs at index _pos_ - 2 of candidate, set _pos_ to _pos_ - 2.
           1. Let _candidate_ be the substring of _candidate_ from position 0, inclusive, to position _pos_, exclusive.
       </emu-alg>
     </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1287,7 +1287,7 @@
           1. Let _cut_ be _maxPrecision_ - _minPrecision_.
           1. Repeat, while _cut_ &gt; 0 and the last code unit of _m_ is 0x0030 (DIGIT ZERO),
             1. Remove the last code unit from _m_.
-            1. Decrease _cut_ by 1.
+            1. Set _cut_ to _cut_ - 1.
           1. If the last code unit of _m_ is 0x002E (FULL STOP), then
             1. Remove the last code unit from _m_.
         1. Return the Record { [[FormattedString]]: _m_, [[RoundedNumber]]: _xFinal_, [[IntegerDigitsCount]]: _int_, [[RoundingMagnitude]]: _e_–_p_+1 }.
@@ -1334,7 +1334,7 @@
         1. Let _cut_ be _maxFraction_ - _minFraction_.
         1. Repeat, while _cut_ &gt; 0 and the last code unit of _m_ is 0x0030 (DIGIT ZERO),
           1. Remove the last code unit from _m_.
-          1. Decrease _cut_ by 1.
+          1. Set _cut_ to _cut_ - 1.
         1. If the last code unit of _m_ is 0x002E (FULL STOP), then
           1. Remove the last code unit from _m_.
         1. Return the Record { [[FormattedString]]: _m_, [[RoundedNumber]]: _xFinal_, [[IntegerDigitsCount]]: _int_, [[RoundingMagnitude]]: –_f_ }.


### PR DESCRIPTION
Replaced all non-standard 'increase _x_ by _y_' and 'decrease _x_ by …' statements with standard 'Set _x_ to _x_ + _y_' and 'set _x_ to _x_ - _y_' statements. fix #677.