### PR TITLE
Editorial: Remove extraneous periods

### DIFF
--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -49,27 +49,27 @@
         <tr>
           <td>%DateTimeFormat%</td>
           <td>`Intl.DateTimeFormat`</td>
-          <td>The `Intl.DateTimeFormat` constructor (<emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref>).</td>
+          <td>The `Intl.DateTimeFormat` constructor (<emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%DisplayNames%</td>
           <td>`Intl.DisplayNames`</td>
-          <td>The `Intl.DisplayNames` constructor (<emu-xref href="#sec-intl-displaynames-constructor"></emu-xref>).</td>
+          <td>The `Intl.DisplayNames` constructor (<emu-xref href="#sec-intl-displaynames-constructor"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%Intl%</td>
           <td>`Intl`</td>
-          <td>The `Intl` object (<emu-xref href="#intl-object"></emu-xref>).</td>
+          <td>The `Intl` object (<emu-xref href="#intl-object"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%ListFormat%</td>
           <td>`Intl.ListFormat`</td>
-          <td>The `Intl.ListFormat` constructor (<emu-xref href="#sec-intl-listformat-constructor"></emu-xref>).</td>
+          <td>The `Intl.ListFormat` constructor (<emu-xref href="#sec-intl-listformat-constructor"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%Locale%</td>
           <td>`Intl.Locale`</td>
-          <td>The `Intl.Locale` constructor (<emu-xref href="#sec-intl-locale-constructor"></emu-xref>).</td>
+          <td>The `Intl.Locale` constructor (<emu-xref href="#sec-intl-locale-constructor"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%NumberFormat%</td>
@@ -79,12 +79,12 @@
         <tr>
           <td>%PluralRules%</td>
           <td>`Intl.PluralRules`</td>
-          <td>The `Intl.PluralRules` constructor (<emu-xref href="#sec-intl-pluralrules-constructor"></emu-xref>).</td>
+          <td>The `Intl.PluralRules` constructor (<emu-xref href="#sec-intl-pluralrules-constructor"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%RelativeTimeFormat%</td>
           <td>`Intl.RelativeTimeFormat`</td>
-          <td>The `Intl.RelativeTimeFormat` constructor (<emu-xref href="#sec-intl-relativetimeformat-constructor"></emu-xref>).</td>
+          <td>The `Intl.RelativeTimeFormat` constructor (<emu-xref href="#sec-intl-relativetimeformat-constructor"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%Segmenter%</td>


### PR DESCRIPTION
Better aligns the [ECMA-402 Well-Known Intrinsic Objects table](https://tc39.es/ecma402/#sec-402-well-known-intrinsic-objects) with its [referent in ECMA-262](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-well-known-intrinsic-objects).