### PR TITLE
Normative: BestAvailableLocale AO now removes extensions before setting initial value of candidate locale.

### DIFF
--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -83,9 +83,8 @@
             1. Let _requestedLocale_ be _requestedLocales_[0].
           1. Else,
             1. Let _requestedLocale_ be ! DefaultLocale().
-          1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with any Unicode locale extension sequences removed.
           1. Let _availableLocales_ be a List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
-          1. Let _locale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
+          1. Let _locale_ be BestAvailableLocale(_availableLocales_, _requestedLocale_).
           1. If _locale_ is *undefined*, set _locale_ to *"und"*.
           1. Let _codePoints_ be StringToCodePoints(_S_).
           1. If _targetCase_ is ~lower~, then

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -88,10 +88,15 @@
       </dl>
       <emu-alg>
         1. Let _candidate_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
+        1. Let _xTagIndex be StringIndexOf(_locale_, *"-x-"*, 0).
+        1. If _xTagIndex_ is equal to -1, let _xTagIndex_ be the length of _candidate_.
         1. Repeat,
           1. If _availableLocales_ contains _candidate_, return _candidate_.
           1. Let _pos_ be the character index of the last occurrence of *"-"* (U+002D) within _candidate_. If that character does not occur, return *undefined*.
-          1. If _pos_ &ge; 2 and the character *"-"* occurs at index _pos_ - 2 of candidate, decrease _pos_ by 2.
+          1. If _pos_ &ge; 3 and the character *"-"* occurs at index _pos_ - 2 of _candidate_, then
+            1. Let _t_ be the substring of _locale_ from position _pos_ - 2, inclusive, to position _pos_, exclusive.
+            1. If _pos_ &lt; _xTagIndex_ and _t_ can be matched by the <code>tkey</code> Unicode locale nonterminal, decrease _pos_ by 3.
+          1. If _pos_ &ge; 2 and the character *"-"* occurs at index _pos_ - 2 of _candidate_, decrease _pos_ by 2.
           1. Let _candidate_ be the substring of _candidate_ from position 0, inclusive, to position _pos_, exclusive.
       </emu-alg>
     </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -93,7 +93,7 @@
         1. Repeat,
           1. If _availableLocales_ contains _candidate_, return _candidate_.
           1. Let _pos_ be the character index of the last occurrence of *"-"* (U+002D) within _candidate_. If that character does not occur, return *undefined*.
-          1. If _pos_ &ge; 3 and the character *"-"* occurs at index _pos_ - 2 of _candidate_, then
+          1. If _pos_ &ge; 3 and the character *"-"* occurs at index _pos_ - 3 of _candidate_, then
             1. Let _t_ be the substring of _locale_ from position _pos_ - 2, inclusive, to position _pos_, exclusive.
             1. If _pos_ &lt; _xTagIndex_ and _t_ can be matched by the <code>tkey</code> Unicode locale nonterminal, decrease _pos_ by 3.
           1. If _pos_ &ge; 2 and the character *"-"* occurs at index _pos_ - 2 of _candidate_, decrease _pos_ by 2.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -106,7 +106,7 @@
       <emu-alg>
         1. Let _result_ be a new Record.
         1. For each element _locale_ of _requestedLocales_, do
-        1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
+          1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
           1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
           1. If _availableLocale_ is not *undefined*, then
             1. Set _result_.[[locale]] to _availableLocale_.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -87,7 +87,7 @@
         <dd>It compares _locale_ against the locales in _availableLocales_ and returns either the longest non-empty prefix of _locale_ that is an element of _availableLocales_, or *undefined* if there is no such element. It uses the fallback mechanism of RFC 4647, section 3.4.</dd>
       </dl>
       <emu-alg>
-        1. Let _candidate_ be _locale_.
+        1. Let _candidate_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
         1. Repeat,
           1. If _availableLocales_ contains _candidate_, return _candidate_.
           1. Let _pos_ be the character index of the last occurrence of *"-"* (U+002D) within _candidate_. If that character does not occur, return *undefined*.
@@ -106,7 +106,7 @@
       <emu-alg>
         1. Let _result_ be a new Record.
         1. For each element _locale_ of _requestedLocales_, do
-          1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
+        1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
           1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
           1. If _availableLocale_ is not *undefined*, then
             1. Set _result_.[[locale]] to _availableLocale_.
@@ -274,8 +274,7 @@
       <emu-alg>
         1. Let _subset_ be a new empty List.
         1. For each element _locale_ of _requestedLocales_, do
-          1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
-          1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
+          1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _locale_).
           1. If _availableLocale_ is not *undefined*, append _locale_ to the end of _subset_.
         1. Return _subset_.
       </emu-alg>


### PR DESCRIPTION
BestAvailableLocale AO now removes extensions before setting initial value of `candidate` locale. Ensures that attempts to match invalid locales (i.e. ending in extension keys without associated types)  don't occur. fix #685.