### PR TITLE
Meta: Update BestFitFormatMatcher's reference to DateTimeFormat

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -55,7 +55,7 @@
     <li>In DateTimeFormat:
       <ul>
         <li>
-          The BestFitFormatMatcher algorithm (<emu-xref href="#sec-initializedatetimeformat"></emu-xref>)
+          The BestFitFormatMatcher algorithm (<emu-xref href="#sec-createdatetimeformat"></emu-xref>)
         </li>
         <li>
           The set of supported *"ca"* key values (calendars) per locale (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)


### PR DESCRIPTION
The master branch otherwise fails to build with the following error:
```
[2023-07-22T12:29:55.132Z] Completed with errors.
error: can't find clause, production, note or example with id "sec-initializedatetimeformat" (xref-not-found) at spec/annexes.html:58:63:
  56 |       <ul>
  57 |         <li>
> 58 |           The BestFitFormatMatcher algorithm (<emu-xref href="#sec-initializedatetimeformat"></emu-xref>)
     |                                                               ^
  59 |         </li>
  60 |         <li>
  61 |           The set of supported *"ca"* key values (calendars) per locale (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
```