### PR TITLE
Normative: Consistently remove u- extensions from values in Intl object [[Locale]] slots

### DIFF
--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -253,8 +253,6 @@
               1. Let _supportedExtensionAddition_ be *""*.
           1. Set _result_.[[&lt;_key_&gt;]] to _value_.
           1. Set _supportedExtension_ to the string-concatenation of _supportedExtension_ and _supportedExtensionAddition_.
-        1. If _supportedExtension_ is not *"-u"*, then
-          1. Set _foundLocale_ to InsertUnicodeExtensionAndCanonicalize(_foundLocale_, _supportedExtension_).
         1. Set _result_.[[locale]] to _foundLocale_.
         1. Return _result_.
       </emu-alg>


### PR DESCRIPTION
fix #311 

Currently,  u- tags are included in the strings store in the  **"locale"** property of Intl objects (other than Intl.Locale) if the following conditions are met:

1. The tag was part of the original _locale_ string passed in when the object was created.
2. There is no conflict between the value as set by the tag and the value as set through an option. 

This results in inconsistent-seeming and somewhat confusing output from resolvedOptions(). Here's the output, which appears to adhere to the spec, from all engines I've tested this on. Note particularly the case where the tag specifies an "h11" hour cycle while the option specifies "h23", which results in the u- extension tag being stripped from the locale string.

```js

> new Intl.DateTimeFormat("en-u-hc-h11", {hour: "numeric"}).resolvedOptions().locale
'en-u-hc-h11'

> new Intl.DateTimeFormat("en-u-hc-h11", {hour: "numeric", hourCycle: "h11"}).resolvedOptions().locale;
'en-u-hc-h11'

> new Intl.DateTimeFormat("en-u-hc-h11", {hour: "numeric", hourCycle: "h23"}).resolvedOptions().locale;
'en'

> new Intl.DateTimeFormat("en", {hour: "numeric", hourCycle: "h23"}).resolvedOptions().locale;
'en'
>
```

It is worth noting that there is no situation in which the u- extensions in **"locale"** reveals locale settings that are not already captured in the other properties of the object. The only u- tags that can appear in the locale string are the ones present in `[[RelevantExtensionKeys]]`, and these all get used to set the object's corresponding properties. 

Once the locale string has been stored, no part of the spec depends on the presence or absence of the u- extensions in the value stored in the object's `[[Locale]]` slot. 


This PR, following @FrankYFTang's idea in #311, changes the ResolveLocale AO to _always_ omit u- extension tags from the value stored in the `[[locale]]` field of the Record that ResolveLocale returns, much like it omits extension tags that conflict with a value set via the options bag. After this change, all of the statements given above would produce "en", with no extension tags. 
 
