### PR TITLE
Editorial: Use named records for DateTimeFormat format records

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -67,10 +67,10 @@
           The set of supported date-time formats per locale beyond a core set, including the representations used for each component and the associated patterns (<emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>)
         </li>
         <li>
-          Localized weekday names, era names, month names, day period names, am/pm indicators, and time zone names (<emu-xref href="#sec-formatdatetime"></emu-xref>)
+          Localized weekday names, era names, month names, day period names, am/pm indicators, and time zone names (<emu-xref href="#sec-formatdatetimepattern"></emu-xref>)
         </li>
         <li>
-          The calendric calculations used for calendars other than *"gregory"*, and adjustments for local time zones and daylight saving time (<emu-xref href="#sec-formatdatetime"></emu-xref>)
+          The calendric calculations used for calendars other than *"gregory"*, and adjustments for local time zones and daylight saving time (<emu-xref href="#sec-tolocaltime"></emu-xref>)
         </li>
         <li>
           The set of all known registered Zone and Link names of the IANA Time Zone Database and the information about their offsets from UTC and their daylight saving time rules (<emu-xref href="#sec-time-zone-names"></emu-xref>)

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -95,7 +95,6 @@
           1. Assert: _hour12_ is *undefined*.
           1. Let _hc_ be _r_.[[hc]].
           1. If _hc_ is *null*, set _hc_ to _dataLocaleData_.[[hourCycle]].
-        1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then
           1. Set _timeZone_ to SystemTimeZoneIdentifier().
@@ -162,9 +161,9 @@
             1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
           1. Else,
             1. Let _bestFormat_ be BestFitFormatMatcher(_formatOptions_, _formats_).
-        1. If _bestFormat_ doesn't have a field [[hour]], then
-          1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
         1. Set _dateTimeFormat_.[[DateTimeFormat]] to _bestFormat_.
+        1. If _bestFormat_ has a field [[hour]], then
+          1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Return _dateTimeFormat_.
       </emu-alg>
     </emu-clause>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -879,48 +879,37 @@
           <thead>
             <tr>
               <th>Range Pattern Field</th>
-              <th>Pattern String Field</th>
             </tr>
           </thead>
           <tr>
             <td>[[Era]]</td>
-            <td>*"era"*</td>
           </tr>
           <tr>
             <td>[[Year]]</td>
-            <td>*"year"*</td>
           </tr>
           <tr>
             <td>[[Month]]</td>
-            <td>*"month"*</td>
           </tr>
           <tr>
             <td>[[Day]]</td>
-            <td>*"day"*</td>
           </tr>
           <tr>
             <td>[[AmPm]]</td>
-            <td>*"ampm"*</td>
           </tr>
           <tr>
             <td>[[DayPeriod]]</td>
-            <td>*"dayPeriod"*</td>
           </tr>
           <tr>
             <td>[[Hour]]</td>
-            <td>*"hour"*</td>
           </tr>
           <tr>
             <td>[[Minute]]</td>
-            <td>*"minute"*</td>
           </tr>
           <tr>
             <td>[[Second]]</td>
-            <td>*"second"*</td>
           </tr>
           <tr>
             <td>[[FractionalSecondDigits]]</td>
-            <td>*"fractionalSecondDigits"*</td>
           </tr>
         </table>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1446,14 +1446,14 @@
       <h1>
         FormatDateTimePattern (
           _dateTimeFormat_: an Intl.DateTimeFormat,
-          _patternParts_: a List of Records as returned by PartitionPattern,
+          _pattern_: a Pattern String,
           _x_: a Number,
           _rangeFormatOptions_: a DateTime Range Pattern Format Record or *undefined*,
         ): either a normal completion containing a List of Records with fields [[Type]] (a String) and [[Value]] (a String), or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It interprets _x_ as a time value as specified in es2024, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according _pattern_ and to the effective locale and the formatting options of _dateTimeFormat_ and _rangeFormatOptions_.</dd>
+        <dd>It interprets _x_ as a time value as specified in es2024, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according to _pattern_ and to the effective locale and the formatting options of _dateTimeFormat_ and _rangeFormatOptions_.</dd>
       </dl>
       <emu-alg>
         1. Let _x_ be TimeClip(_x_).
@@ -1473,6 +1473,7 @@
         1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
         1. Let _nf3_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
         1. Let _tm_ be ToLocalTime(ℤ(ℝ(_x_) &times; 10<sup>6</sup>), _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
+        1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. Let _result_ be a new empty List.
         1. For each Record { [[Type]], [[Value]] } _patternPart_ of _patternParts_, do
           1. Let _p_ be _patternPart_.[[Type]].
@@ -1556,8 +1557,7 @@
           1. Let _pattern_ be _format_.[[pattern12]].
         1. Else,
           1. Let _pattern_ be _format_.[[pattern]].
-        1. Let _patternParts_ be PartitionPattern(_pattern_).
-        1. Let _result_ be ? FormatDateTimePattern(_dateTimeFormat_, _patternParts_, _x_, *undefined*).
+        1. Let _result_ be ? FormatDateTimePattern(_dateTimeFormat_, _pattern_, _x_, *undefined*).
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -1660,8 +1660,7 @@
               1. Set _relevantFieldsEqual_ to *false*.
         1. If _relevantFieldsEqual_ is *true*, then
           1. Let _collapsedResult_ be a new empty List.
-          1. Let _patternParts_ be PartitionPattern(_pattern_).
-          1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _patternParts_, _x_, *undefined*).
+          1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _pattern_, _x_, *undefined*).
           1. For each Record { [[Type]], [[Value]] } _r_ of _resultParts_, do
             1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: *"shared"* } to _collapsedResult_.
           1. Return _collapsedResult_.
@@ -1675,8 +1674,7 @@
             1. Let _z_ be _x_.
           1. Else,
             1. Let _z_ be _y_.
-          1. Let _patternParts_ be PartitionPattern(_pattern_).
-          1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _patternParts_, _z_, _selectedRangePattern_).
+          1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _pattern_, _z_, _selectedRangePattern_).
           1. For each Record { [[Type]], [[Value]] } _r_ of _resultParts_, do
             1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: _source_ } to _rangeResult_.
         1. Return _rangeResult_.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -60,7 +60,7 @@
       </dl>
 
       <emu-alg>
-        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%DateTimeFormat.prototype%"*, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]], [[TimeZoneName]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[DateTimeFormat]], [[BoundFormat]] &raquo;).
+        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%DateTimeFormat.prototype%"*, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[DateTimeFormat]], [[BoundFormat]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
@@ -162,12 +162,7 @@
             1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
           1. Else,
             1. Let _bestFormat_ be BestFitFormatMatcher(_formatOptions_, _formats_).
-        1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
-          1. Let _prop_ be the name given in the Property column of the row.
-          1. If _bestFormat_ has a field [[&lt;_prop_&gt;]], then
-            1. Let _p_ be _bestFormat_.[[&lt;_prop_&gt;]].
-            1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
-        1. If _dateTimeFormat_.[[Hour]] is *undefined*, then
+        1. If _bestFormat_ doesn't have a field [[hour]], then
           1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
         1. Set _dateTimeFormat_.[[DateTimeFormat]] to _bestFormat_.
         1. Return _dateTimeFormat_.
@@ -1215,9 +1210,7 @@
       <li>[[Calendar]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeCalendarIdentifier">Unicode Calendar Identifier</a> used for formatting.</li>
       <li>[[NumberingSystem]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> used for formatting.</li>
       <li>[[TimeZone]] is a String value used for formatting that is either a time zone identifier from the IANA Time Zone Database or a UTC offset in ISO 8601 extended format.</li>
-      <li>[[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]] are each either *undefined*, indicating that the component is not used for formatting, or one of the String values given in <emu-xref href="#table-datetimeformat-components"></emu-xref>, indicating how the component should be presented in the formatted output.</li>
-      <li>[[FractionalSecondDigits]] is either *undefined* or a positive, non-zero integer indicating the fraction digits to be used for fractional seconds. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
-      <li>[[HourCycle]] is a String value indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[Hour]] is not *undefined*.</li>
+      <li>[[HourCycle]] is a String value indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[DateTimeFormat]] has an [[hour]] field.</li>
       <li>[[DateStyle]], [[TimeStyle]] are each either *undefined*, or a String value with values *"full"*, *"long"*, *"medium"*, or *"short"*.</li>
       <li>[[DateTimeFormat]] is a DateTime Format Record.</li>
     </ul>
@@ -1239,7 +1232,7 @@
       <table class="real-table">
         <thead>
           <tr>
-            <th>Internal Slot</th>
+            <th>Field Name</th>
             <th>Property</th>
             <th>Values</th>
           </tr>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1475,11 +1475,11 @@
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"useGrouping"*, *false*).
         1. Let _nf2_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nf2Options_ &raquo;).
         1. Let _fractionalSecondDigits_ be _dateTimeFormat_.[[FractionalSecondDigits]].
-        1. If _fractionalSecondDigits_ is not *undefined*, then
-          1. Let _nf3Options_ be OrdinaryObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, 𝔽(_fractionalSecondDigits_)).
-          1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
-          1. Let _nf3_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
+        1. If _fractionalSecondDigits_ is *undefined*, set _fractionalSecondDigits_ to 1.
+        1. Let _nf3Options_ be OrdinaryObjectCreate(*null*).
+        1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, 𝔽(_fractionalSecondDigits_)).
+        1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
+        1. Let _nf3_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
         1. Let _tm_ be ToLocalTime(ℤ(ℝ(_x_) &times; 10<sup>6</sup>), _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _result_ be a new empty List.
         1. For each Record { [[Type]], [[Value]] } _patternPart_ of _patternParts_, do
@@ -1487,7 +1487,6 @@
           1. If _p_ is *"literal"*, then
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
           1. Else if _p_ is equal to *"fractionalSecondDigits"*, then
-            1. Assert: _fractionalSecondDigits_ is not *undefined*.
             1. Let _v_ be _tm_.[[Millisecond]].
             1. Set _v_ to floor(_v_ &times; 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
             1. Let _fv_ be FormatNumeric(_nf3_, _v_).

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1223,7 +1223,7 @@
       <li>[[HourCycle]] is a String value indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[Hour]] is not *undefined*.</li>
       <li>[[DateStyle]], [[TimeStyle]] are each either *undefined*, or a String value with values *"full"*, *"long"*, *"medium"*, or *"short"*.</li>
       <li>[[Pattern]] is a String value as described in <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>.</li>
-      <li>[[RangePatterns]] is a Record as described in <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>.</li>
+      <li>[[RangePatterns]] is a DateTime Range Pattern Record.</li>
     </ul>
 
     <p>
@@ -1311,8 +1311,8 @@
         DateTimeStyleFormat (
           _dateStyle_: *"full"*, *"long"*, *"medium"*, *"short"*, or *undefined*,
           _timeStyle_: *"full"*, *"long"*, *"medium"*, *"short"*, or *undefined*,
-          _styles_: a Record,
-        ): a Record
+          _styles_: a DateTime Calendar Style Record,
+        ): a DateTime Format Record
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1327,7 +1327,7 @@
           1. Assert: _dateStyle_ is one of *"full"*, *"long"*, *"medium"*, or *"short"*.
           1. Let _dateFormat_ be _styles_.[[DateFormat]].[[&lt;_dateStyle_&gt;]].
         1. If _dateStyle_ is not *undefined* and _timeStyle_ is not *undefined*, then
-          1. Let _format_ be a new Record.
+          1. Let _format_ be a new DateTime Format Record.
           1. Add to _format_ all fields from _dateFormat_ except [[pattern]] and [[rangePatterns]].
           1. Add to _format_ all fields from _timeFormat_ except [[pattern]], [[rangePatterns]], [[pattern12]], and [[rangePatterns12]], if present.
           1. Let _connector_ be _styles_.[[DateTimeFormat]].[[&lt;_dateStyle_&gt;]].
@@ -1352,8 +1352,8 @@
       <h1>
         BasicFormatMatcher (
           _options_: a Record,
-          _formats_: a List of Records,
-        ): a Record
+          _formats_: a List of DateTime Format Records,
+        ): a DateTime Format Record
       </h1>
       <dl class="header">
       </dl>
@@ -1420,8 +1420,8 @@
       <h1>
         BestFitFormatMatcher (
           _options_: a Record,
-          _formats_: a List of Records,
-        ): a Record
+          _formats_: a List of DateTime Format Records,
+        ): a DateTime Format Record
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1456,7 +1456,7 @@
           _dateTimeFormat_: an Intl.DateTimeFormat,
           _patternParts_: a List of Records as returned by PartitionPattern,
           _x_: a Number,
-          _rangeFormatOptions_: a range pattern Record as used in [[rangePattern]], or *undefined*,
+          _rangeFormatOptions_: a DateTime Range Pattern Format Record or *undefined*,
         ): either a normal completion containing a List of Records with fields [[Type]] (a String) and [[Value]] (a String), or a throw completion
       </h1>
       <dl class="header">

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1301,7 +1301,6 @@
         1. Let _offsetPenalty_ be 1.
         1. Let _bestScore_ be -∞.
         1. Let _bestFormat_ be *undefined*.
-        1. Assert: Type(_formats_) is List.
         1. For each element _format_ of _formats_, do
           1. Let _score_ be 0.
           1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -60,7 +60,7 @@
       </dl>
 
       <emu-alg>
-        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%DateTimeFormat.prototype%"*, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]], [[TimeZoneName]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[Pattern]], [[RangePatterns]], [[BoundFormat]] &raquo;).
+        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%DateTimeFormat.prototype%"*, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]], [[TimeZoneName]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[DateTimeFormat]], [[BoundFormat]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
@@ -169,14 +169,7 @@
             1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
         1. If _dateTimeFormat_.[[Hour]] is *undefined*, then
           1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
-        1. If _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
-          1. Let _pattern_ be _bestFormat_.[[pattern12]].
-          1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns12]].
-        1. Else,
-          1. Let _pattern_ be _bestFormat_.[[pattern]].
-          1. Let _rangePatterns_ be _bestFormat_.[[rangePatterns]].
-        1. Set _dateTimeFormat_.[[Pattern]] to _pattern_.
-        1. Set _dateTimeFormat_.[[RangePatterns]] to _rangePatterns_.
+        1. Set _dateTimeFormat_.[[DateTimeFormat]] to _bestFormat_.
         1. Return _dateTimeFormat_.
       </emu-alg>
     </emu-clause>
@@ -1222,8 +1215,7 @@
       <li>[[FractionalSecondDigits]] is either *undefined* or a positive, non-zero integer indicating the fraction digits to be used for fractional seconds. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
       <li>[[HourCycle]] is a String value indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[Hour]] is not *undefined*.</li>
       <li>[[DateStyle]], [[TimeStyle]] are each either *undefined*, or a String value with values *"full"*, *"long"*, *"medium"*, or *"short"*.</li>
-      <li>[[Pattern]] is a String value as described in <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>.</li>
-      <li>[[RangePatterns]] is a DateTime Range Pattern Record.</li>
+      <li>[[DateTimeFormat]] is a DateTime Format Record.</li>
     </ul>
 
     <p>
@@ -1559,7 +1551,12 @@
         <dd>It interprets _x_ as a time value as specified in es2024, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according to the effective locale and the formatting options of _dateTimeFormat_.</dd>
       </dl>
       <emu-alg>
-        1. Let _patternParts_ be PartitionPattern(_dateTimeFormat_.[[Pattern]]).
+        1. Let _format_ be _dateTimeFormat_.[[DateTimeFormat]].
+        1. If _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
+          1. Let _pattern_ be _format_.[[pattern12]].
+        1. Else,
+          1. Let _pattern_ be _format_.[[pattern]].
+        1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. Let _result_ be ? FormatDateTimePattern(_dateTimeFormat_, _patternParts_, _x_, *undefined*).
         1. Return _result_.
       </emu-alg>
@@ -1625,7 +1622,13 @@
         1. If _y_ is *NaN*, throw a *RangeError* exception.
         1. Let _tm1_ be ToLocalTime(ℤ(ℝ(_x_) &times; 10<sup>6</sup>), _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _tm2_ be ToLocalTime(ℤ(ℝ(_y_) &times; 10<sup>6</sup>), _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
-        1. Let _rangePatterns_ be _dateTimeFormat_.[[RangePatterns]].
+        1. Let _format_ be _dateTimeFormat_.[[DateTimeFormat]].
+        1. If _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
+          1. Let _pattern_ be _format_.[[pattern12]].
+          1. Let _rangePatterns_ be _format_.[[rangePatterns12]].
+        1. Else,
+          1. Let _pattern_ be _format_.[[pattern]].
+          1. Let _rangePatterns_ be _format_.[[rangePatterns]].
         1. Let _selectedRangePattern_ be *undefined*.
         1. Let _relevantFieldsEqual_ be *true*.
         1. Let _checkMoreFields_ be *true*.
@@ -1657,7 +1660,6 @@
               1. Set _relevantFieldsEqual_ to *false*.
         1. If _relevantFieldsEqual_ is *true*, then
           1. Let _collapsedResult_ be a new empty List.
-          1. Let _pattern_ be _dateTimeFormat_.[[Pattern]].
           1. Let _patternParts_ be PartitionPattern(_pattern_).
           1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _patternParts_, _x_, *undefined*).
           1. For each Record { [[Type]], [[Value]] } _r_ of _resultParts_, do

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -161,7 +161,7 @@
             1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
           1. Else,
             1. Let _bestFormat_ be BestFitFormatMatcher(_formatOptions_, _formats_).
-        1. Set _dateTimeFormat_.[[DateTimeFormat]] to _bestFormat_.
+        1. Set _dateTimeFormat_.[[Patterns]] to _bestFormat_.
         1. If _bestFormat_ has a field [[hour]], then
           1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Return _dateTimeFormat_.
@@ -258,7 +258,7 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle24]] must be a String value equal to *"h23"* or *"h24"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. This [[formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a List of DateTime Format Records. Multiple Records in a List may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. The value of this [[formats]] field must be a Record with a [[&lt;_calendar_&gt;]] field for each calendar value _calendar_. The value of each [[&lt;_calendar_&gt;]] field must be a List of DateTimeFormat Patterns Record. Multiple Records in such a List may use the same subset of the fields as long as the corresponding values differ for at least one field. The following subsets must be available for each locale:
           <ul>
             <li>weekday, year, month, day, hour, minute, second, fractionalSecondDigits</li>
             <li>weekday, year, month, day, hour, minute, second</li>
@@ -275,18 +275,18 @@
           </ul>
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[styles]] field. The [[styles]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field is a DateTime Calendar Style Record.
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[styles]] field. The value of this [[styles]] field must be a Record with a [[&lt;_calendar_&gt;]] field for each calendar value _calendar_. The value of each [[&lt;_calendar_&gt;]] field must be a DateTimeFormat Styles Record.
          </li>
       </ul>
 
-      <emu-clause id="sec-datetimeformat-format-record">
-        <h1>DateTime Format Records</h1>
+      <emu-clause id="sec-datetimeformat-patterns-record">
+        <h1>DateTimeFormat Patterns Records</h1>
 
         <p>
-          Each <dfn id="datetimeformat-format-record" variants="DateTime Format Records">DateTime Format Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-format-record"></emu-xref>.
+          Each <dfn id="datetimeformat-patterns-record" variants="DateTimeFormat Patterns Records">DateTimeFormat Patterns Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-patterns-record"></emu-xref>.
         </p>
-        <emu-table id="table-datetimeformat-format-record">
-          <emu-caption>DateTime Time Range Record</emu-caption>
+        <emu-table id="table-datetimeformat-patterns-record">
+          <emu-caption>DateTimeFormat Patterns Record</emu-caption>
           <table class="real-table">
             <thead>
               <tr>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -871,49 +871,6 @@
       <emu-note>
         It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="https://cldr.unicode.org/">https://cldr.unicode.org/</a>).
       </emu-note>
-
-      <emu-table id="table-datetimeformat-rangepatternfields">
-        <emu-caption>Range pattern fields</emu-caption>
-
-        <table class="real-table">
-          <thead>
-            <tr>
-              <th>Range Pattern Field</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>[[Era]]</td>
-          </tr>
-          <tr>
-            <td>[[Year]]</td>
-          </tr>
-          <tr>
-            <td>[[Month]]</td>
-          </tr>
-          <tr>
-            <td>[[Day]]</td>
-          </tr>
-          <tr>
-            <td>[[AmPm]]</td>
-          </tr>
-          <tr>
-            <td>[[DayPeriod]]</td>
-          </tr>
-          <tr>
-            <td>[[Hour]]</td>
-          </tr>
-          <tr>
-            <td>[[Minute]]</td>
-          </tr>
-          <tr>
-            <td>[[Second]]</td>
-          </tr>
-          <tr>
-            <td>[[FractionalSecondDigits]]</td>
-          </tr>
-        </table>
-
-      </emu-table>
     </emu-clause>
   </emu-clause>
 
@@ -1618,13 +1575,13 @@
         1. Let _selectedRangePattern_ be *undefined*.
         1. Let _relevantFieldsEqual_ be *true*.
         1. Let _checkMoreFields_ be *true*.
-        1. For each row of <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref>, except the header row, in table order, do
-          1. Let _fieldName_ be the name given in the Range Pattern Field column of the row.
+        1. For each row of <emu-xref href="#table-datetimeformat-range-pattern-record"></emu-xref>, except the header row, in table order, do
+          1. Let _fieldName_ be the name given in the Field Name column of the row.
           1. If _rangePatterns_ has a field whose name is _fieldName_, let _rangePattern_ be _rangePatterns_' field whose name is _fieldName_; else let _rangePattern_ be *undefined*.
           1. If _selectedRangePattern_ is not *undefined* and _rangePattern_ is *undefined*, then
             1. NOTE: Because there is no range pattern for differences at or below this field, no further checks will be performed.
             1. Set _checkMoreFields_ to *false*.
-          1. If _relevantFieldsEqual_ is *true* and _checkMoreFields_ is *true*, then
+          1. If _fieldName_ is not equal to [[Default]] and _relevantFieldsEqual_ is *true* and _checkMoreFields_ is *true*, then
             1. Set _selectedRangePattern_ to _rangePattern_.
             1. If _fieldName_ is equal to [[AmPm]], then
               1. If _tm1_.[[Hour]] is less than 12, let _v1_ be *"am"*; else let _v1_ be *"pm"*.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1492,11 +1492,13 @@
             1. Let _fv_ be FormatNumeric(_nf3_, _v_).
             1. Append the Record { [[Type]]: *"fractionalSecond"*, [[Value]]: _fv_ } to _result_.
           1. Else if _p_ is equal to *"dayPeriod"*, then
-            1. Let _f_ be _dateTimeFormat_.[[DayPeriod]].
+            1. If _rangeFormatOptions_ is not *undefined*, let _f_ be _rangeFormatOptions_.[[dayPeriod]].
+            1. Else, let _f_ be _dateTimeFormat_.[[DayPeriod]].
             1. Let _fv_ be a String value representing the day period of _tm_ in the form given by _f_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
           1. Else if _p_ is equal to *"timeZoneName"*, then
-            1. Let _f_ be _dateTimeFormat_.[[TimeZoneName]].
+            1. If _rangeFormatOptions_ is not *undefined*, let _f_ be _rangeFormatOptions_.[[timeZoneName]].
+            1. Else, let _f_ be _dateTimeFormat_.[[TimeZoneName]].
             1. Let _v_ be _dateTimeFormat_.[[TimeZone]].
             1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_. The String value may also depend on the value of the [[InDST]] field of _tm_ if _f_ is *"short"*, *"long"*, *"shortOffset"*, or *"longOffset"*. If the implementation does not have such a localized representation of _v_, then use the String value of _v_ itself.
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1052,11 +1052,15 @@
         1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. For each row of <emu-xref href="#table-datetimeformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _v_ be the value of _dtf_'s internal slot whose name is the Internal Slot value of the current row.
           1. Let _p_ be the Property value of the current row.
-          1. If the Internal Slot value of the current row is an Internal Slot value in <emu-xref href="#table-datetimeformat-components"></emu-xref>, then
-            1. If _dtf_.[[DateStyle]] is not *undefined* or _dtf_.[[TimeStyle]] is not *undefined*, then
-              1. Set _v_ to *undefined*.
+          1. If there is an Internal Slot value in the current row, then
+            1. Let _v_ be the value of _dtf_'s internal slot whose name is the Internal Slot value of the current row.
+          1. Else,
+            1. Let _format_ be _dtf_.[[DateTimeFormat]].
+            1. If _format_ has a field [[&lt;_p_&gt;]] and _dtf_.[[DateStyle]] is *undefined* and _dtf_.[[TimeStyle]] is *undefined*, then
+              1. Let _v_ be _format_.[[&lt;_p_&gt;]].
+            1. Else,
+              1. Let _v_ be *undefined*.
           1. If _v_ is not *undefined*, then
             1. If there is a Conversion value in the current row, then
               1. Let _conversion_ be the Conversion value of the current row.
@@ -1110,57 +1114,57 @@
             <td>~hour12~</td>
           </tr>
           <tr>
-            <td>[[Weekday]]</td>
+            <td></td>
             <td>*"weekday"*</td>
             <td></td>
           </tr>
           <tr>
-            <td>[[Era]]</td>
+            <td></td>
             <td>*"era"*</td>
             <td></td>
           </tr>
           <tr>
-            <td>[[Year]]</td>
+            <td></td>
             <td>*"year"*</td>
             <td></td>
           </tr>
           <tr>
-            <td>[[Month]]</td>
+            <td></td>
             <td>*"month"*</td>
             <td></td>
           </tr>
           <tr>
-            <td>[[Day]]</td>
+            <td></td>
             <td>*"day"*</td>
             <td></td>
           </tr>
           <tr>
-            <td>[[DayPeriod]]</td>
+            <td></td>
             <td>*"dayPeriod"*</td>
             <td></td>
           </tr>
           <tr>
-            <td>[[Hour]]</td>
+            <td></td>
             <td>*"hour"*</td>
             <td></td>
           </tr>
           <tr>
-            <td>[[Minute]]</td>
+            <td></td>
             <td>*"minute"*</td>
             <td></td>
           </tr>
           <tr>
-            <td>[[Second]]</td>
+            <td></td>
             <td>*"second"*</td>
             <td></td>
           </tr>
           <tr>
-            <td>[[FractionalSecondDigits]]</td>
+            <td></td>
             <td>*"fractionalSecondDigits"*</td>
             <td>~number~</td>
           </tr>
           <tr>
-            <td>[[TimeZoneName]]</td>
+            <td></td>
             <td>*"timeZoneName"*</td>
             <td></td>
           </tr>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -271,7 +271,7 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle24]] must be a String value equal to *"h23"* or *"h24"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. This [[formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a list of records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. This [[formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a List of DateTime Format Records. Multiple Records in a List may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
           <ul>
             <li>weekday, year, month, day, hour, minute, second, fractionalSecondDigits</li>
             <li>weekday, year, month, day, hour, minute, second</li>
@@ -286,42 +286,516 @@
             <li>dayPeriod, hour, minute, second</li>
             <li>dayPeriod, hour, minute</li>
           </ul>
-          Each of the records must also have the following fields:
-          <ol>
-            <li>A [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*.</li>
-            <li>If the record has an [[hour]] field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the [[pattern]] field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</li>
-            <li>If the record has a [[year]] field, the [[pattern]] and [[pattern12]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</li>
-            <li>
-              A [[rangePatterns]] field with a Record value:
-                <ul>
-                  <li>The [[rangePatterns]] record may have any of the fields in <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref>, where each field represents a range pattern and its value is a Record.
-                    <ul>
-                      <li>The name of the field indicates the largest calendar element that must be different between the start and end dates in order to use this range pattern. For example, if the field name is [[Month]], it contains the range pattern that should be used to format a date range where the era and year values are the same, but the month value is different.</li>
-                      <li>The record will contain the following fields:</li>
-                        <ul>
-                          <li>A subset of the fields shown in the Property column of <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for that field in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref>. All fields required to format a date for any of the [[PatternParts]] records must be present.</li>
-                          <li>A [[PatternParts]] field whose value is a list of Records each representing a part of the range pattern. Each record contains a [[Pattern]] field and a [[Source]] field. The [[Pattern]] field's value is a String of the same format as the regular date pattern String. The [[Source]] field is one of the String values *"shared"*, *"startRange"*, or *"endRange"*. It indicates which of the range's dates should be formatted using the value of the [[Pattern]] field.</li>
-                        </ul>
-                    </ul>
-                  </li>
-                  <li>The [[rangePatterns]] record must have a [[Default]] field which contains the default range pattern used when the specific range pattern is not available. Its value is a list of records with the same structure as the other fields in the [[rangePatterns]] record.</li>
-                </ul>
-            </li>
-            <li>If the record has an [[hour]] field, it must also have a [[rangePatterns12]] field. Its value is similar to the Record in [[rangePatterns]], but it uses a String similar to [[pattern12]] for each part of the range pattern.</li>
-            <li>If the record has a [[year]] field, the [[rangePatterns]] and [[rangePatterns12]] fields may contain range patterns where the [[Pattern]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</li>
-          </ol>
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[styles]] field. The [[styles]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The calendar records must contain [[DateFormat]], [[TimeFormat]], [[DateTimeFormat]] and [[DateTimeRangeFormat]] fields, the value of these fields are Records, where each of which has [[full]], [[long]], [[medium]] and [[short]] fields. For [[DateFormat]] and [[TimeFormat]], the value of these fields must be a record, which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Each of the records must also have the following fields:
-          <ol>
-            <li>A [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*.</li>
-            <li>If the record has an [[hour]] field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the pattern field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</li>
-            <li>A [[rangePatterns]] field that contains a record similar to the one described in the [[formats]] field.</li>
-            <li>If the record has an [[hour]] field, it must also have a [[rangePatterns12]] field. Its value is similar to the record in [[rangePatterns]] but it uses a string similar to [[pattern12]] for each range pattern.</li>
-          </ol>
-          For [[DateTimeFormat]], the field value must be a string pattern which contains the strings *"{0}"* and *"{1}"*. For [[DateTimeRangeFormat]] the value of these fields must be a nested record which also has [[full]], [[long]], [[medium]] and [[short]] fields. The [[full]], [[long]], [[medium]] and [[short]] fields in the enclosing record refer to the date style of the range pattern, while the fields in the nested record refers to the time style of the range pattern. The value of these fields in the nested record is a record with a [[rangePatterns]] field and a [[rangePatterns12]] field which are similar to the [[rangePatterns]] and [rangePatterns12]] fields in [[DateFormat]] and [[TimeFormat]].
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[styles]] field. The [[styles]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field is a DateTime Calendar Style Record.
          </li>
       </ul>
+
+      <emu-clause id="sec-datetimeformat-format-record">
+        <h1>DateTime Format Records</h1>
+
+        <p>
+          Each <dfn id="datetimeformat-format-record" variants="DateTime Format Records">DateTime Format Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-format-record"></emu-xref>.
+        </p>
+        <emu-table id="table-datetimeformat-format-record">
+          <emu-caption>DateTime Time Range Record</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>Field Name</th>
+                <th>Value Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>[[weekday]]</td>
+              <td>[[Weekday]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains the substring *"{weekday}"*.</td>
+            </tr>
+            <tr>
+              <td>[[era]]</td>
+              <td>[[Era]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains the substring *"{era}"*.</td>
+            </tr>
+            <tr>
+              <td>[[year]]</td>
+              <td>[[Year]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains at least one of the substrings *"{year}"*, *"{yearName}"*, or *"{relatedYear}"*.</td>
+            </tr>
+            <tr>
+              <td>[[month]]</td>
+              <td>[[Month]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains the substring *"{month}"*.</td>
+            </tr>
+            <tr>
+              <td>[[day]]</td>
+              <td>[[Day]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains the substring *"{day}"*.</td>
+            </tr>
+            <tr>
+              <td>[[dayPeriod]]</td>
+              <td>[[DayPeriod]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains the substring *"{dayPeriod}"*.</td>
+            </tr>
+            <tr>
+              <td>[[hour]]</td>
+              <td>[[Hour]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains the substring *"{hour}"*.</td>
+            </tr>
+            <tr>
+              <td>[[minute]]</td>
+              <td>[[Minute]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains the substring *"{minute}"*.</td>
+            </tr>
+            <tr>
+              <td>[[second]]</td>
+              <td>[[Second]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains the substring *"{second}"*.</td>
+            </tr>
+            <tr>
+              <td>[[fractionalSecondDigits]]</td>
+              <td>[[FractionalSecondDigits]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains the substring *"{fractionalSecondDigits}"*.</td>
+            </tr>
+            <tr>
+              <td>[[timeZoneName]]</td>
+              <td>[[TimeZoneName]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if [[pattern]] contains the substring *"{timeZoneName}"*.</td>
+            </tr>
+            <tr>
+              <td>[[pattern]]</td>
+              <td>a Pattern String</td>
+              <td><emu-not-ref>Contains</emu-not-ref> for each of the date and time format component fields of the record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*. If the record has a [[year]] field, the string may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</td>
+            </tr>
+            <tr>
+              <td>[[pattern12]]</td>
+              <td>a Pattern String</td>
+              <td>Optional field. Present if the [[hour]] field is present. In addition to the substrings of the [[pattern]] field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</td>
+            </tr>
+            <tr>
+              <td>[[rangePatterns]]</td>
+              <td>a DateTime Range Pattern Record</td>
+              <td>Pattern strings in this field are similar to [[pattern]].</td>
+            </tr>
+            <tr>
+              <td>[[rangePatterns12]]</td>
+              <td>a DateTime Range Pattern Record</td>
+              <td>Optional field. Present if the [[hour]] field is present. Pattern strings in this field are similar to [[pattern12]].</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-datetimeformat-range-pattern-record">
+        <h1>DateTime Range Pattern Records</h1>
+
+        <p>
+          Each <dfn id="datetimeformat-range-pattern-record">DateTime Range Pattern Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-range-pattern-record"></emu-xref>.
+        </p>
+        <emu-table id="table-datetimeformat-range-pattern-record">
+          <emu-caption>DateTime Range Pattern Record</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>Field Name</th>
+                <th>Value Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>[[Default]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>It contains the default range pattern used when a more specific range pattern is not available.</td>
+            </tr>
+            <tr>
+              <td>[[Era]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>Optional field. Used when <em>era</em> is the largest calendar element that is different between the start and end dates.</td>
+            </tr>
+            <tr>
+              <td>[[Year]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>Optional field. Used when <em>year</em> is the largest calendar element that is different between the start and end dates.</td>
+            </tr>
+            <tr>
+              <td>[[Month]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>Optional field. Used when <em>month</em> is the largest calendar element that is different between the start and end dates.</td>
+            </tr>
+            <tr>
+              <td>[[Day]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>Optional field. Used when <em>day</em> is the largest calendar element that is different between the start and end dates.</td>
+            </tr>
+            <tr>
+              <td>[[AmPm]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>Optional field. Used when <em>ante</em> or <em>post meridiem</em> is the largest calendar element that is different between the start and end dates.</td>
+            </tr>
+            <tr>
+              <td>[[DayPeriod]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>Optional field. Used when <em>day period</em> is the largest calendar element that is different between the start and end dates.</td>
+            </tr>
+            <tr>
+              <td>[[Hour]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>Optional field. Used when <em>hour</em> is the largest calendar element that is different between the start and end dates.</td>
+            </tr>
+            <tr>
+              <td>[[Minute]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>Optional field. Used when <em>minute</em> is the largest calendar element that is different between the start and end dates.</td>
+            </tr>
+            <tr>
+              <td>[[Second]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>Optional field. Used when <em>second</em> is the largest calendar element that is different between the start and end dates.</td>
+            </tr>
+            <tr>
+              <td>[[FractionalSecondDigits]]</td>
+              <td>a DateTime Range Pattern Format Record</td>
+              <td>Optional field. Used when <em>fractional seconds</em> are the largest calendar element that is different between the start and end dates.</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-datetimeformat-range-pattern-format-record">
+        <h1>DateTime Range Pattern Format Records</h1>
+
+        <p>
+          Each <dfn id="datetimeformat-range-pattern-format-record">DateTime Range Pattern Format Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-range-pattern-format-record"></emu-xref>.
+        </p>
+        <emu-table id="table-datetimeformat-range-pattern-format-record">
+          <emu-caption>DateTime Range Pattern Format Record</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>Field Name</th>
+                <th>Value Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>[[weekday]]</td>
+              <td>[[Weekday]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains the substring *"{weekday}"*.</td>
+            </tr>
+            <tr>
+              <td>[[era]]</td>
+              <td>[[Era]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains the substring *"{era}"*.</td>
+            </tr>
+            <tr>
+              <td>[[year]]</td>
+              <td>[[Year]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains at least one of the substrings *"{year}"*, *"{yearName}"*, or *"{relatedYear}"*.</td>
+            </tr>
+            <tr>
+              <td>[[month]]</td>
+              <td>[[Month]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains the substring *"{month}"*.</td>
+            </tr>
+            <tr>
+              <td>[[day]]</td>
+              <td>[[Day]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains the substring *"{day}"*.</td>
+            </tr>
+            <tr>
+              <td>[[dayPeriod]]</td>
+              <td>[[DayPeriod]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains the substring *"{dayPeriod}"*.</td>
+            </tr>
+            <tr>
+              <td>[[hour]]</td>
+              <td>[[Hour]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains the substring *"{hour}"*.</td>
+            </tr>
+            <tr>
+              <td>[[minute]]</td>
+              <td>[[Minute]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains the substring *"{minute}"*.</td>
+            </tr>
+            <tr>
+              <td>[[second]]</td>
+              <td>[[Second]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains the substring *"{second}"*.</td>
+            </tr>
+            <tr>
+              <td>[[fractionalSecondDigits]]</td>
+              <td>[[FractionalSecondDigits]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains the substring *"{fractionalSecondDigits}"*.</td>
+            </tr>
+            <tr>
+              <td>[[timeZoneName]]</td>
+              <td>[[TimeZoneName]] values in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref></td>
+              <td>Optional field. Present if a Pattern String in [[PatternParts]] contains the substring *"{timeZoneName}"*.</td>
+            </tr>
+            <tr>
+              <td>[[PatternParts]]</td>
+              <td>a List of DateTime Range Pattern Part Records</td>
+              <td>Each record represents a part of the range pattern.</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-datetimeformat-range-pattern-part-record">
+        <h1>DateTime Range Pattern Part Records</h1>
+
+        <p>
+          Each <dfn id="datetimeformat-range-pattern-part-record" variants="DateTime Range Pattern Part Records">DateTime Range Pattern Part Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-range-pattern-part-record"></emu-xref>.
+        </p>
+        <emu-table id="table-datetimeformat-range-pattern-part-record">
+          <emu-caption>DateTime Range Pattern Part Record</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>Field Name</th>
+                <th>Value Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>[[Source]]</td>
+              <td>*"shared"*, *"startRange"*, or *"endRange"*</td>
+              <td>It indicates which of the range's dates should be formatted using the value of the [[Pattern]] field.</td>
+            </tr>
+            <tr>
+              <td>[[Pattern]]</td>
+              <td>a Pattern String</td>
+              <td>A String of the same format as the regular date pattern String.</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-datetimeformat-calendar-style-record">
+        <h1>DateTime Calendar Style Records</h1>
+
+        <p>
+          Each <dfn id="datetimeformat-calendar-style-record">DateTime Calendar Style Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-calendar-style-record"></emu-xref>.
+        </p>
+        <emu-table id="table-datetimeformat-calendar-style-record">
+          <emu-caption>DateTime Calendar Style Record</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>Field Name</th>
+                <th>Value Type</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>[[DateFormat]]</td>
+              <td>a DateTime Style Record</td>
+            </tr>
+            <tr>
+              <td>[[TimeFormat]]</td>
+              <td>a DateTime Style Record</td>
+            </tr>
+            <tr>
+              <td>[[DateTimeFormat]]</td>
+              <td>a DateTime Connector Record</td>
+            </tr>
+            <tr>
+              <td>[[DateTimeRangeFormat]]</td>
+              <td>a DateTime Date Range Record</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-datetimeformat-style-record">
+        <h1>DateTime Style Records</h1>
+
+        <p>
+          Each <dfn id="datetimeformat-style-record">DateTime Style Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-style-record"></emu-xref>.
+        </p>
+        <emu-table id="table-datetimeformat-style-record">
+          <emu-caption>DateTime Style Record</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>Field Name</th>
+                <th>Value Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>[[full]]</td>
+              <td>a DateTime Format Record</td>
+              <td>Format record for the *"full"* style.</td>
+            </tr>
+            <tr>
+              <td>[[long]]</td>
+              <td>a DateTime Format Record</td>
+              <td>Format record for the *"long"* style.</td>
+            </tr>
+            <tr>
+              <td>[[medium]]</td>
+              <td>a DateTime Format Record</td>
+              <td>Format record for the *"medium"* style.</td>
+            </tr>
+            <tr>
+              <td>[[short]]</td>
+              <td>a DateTime Format Record</td>
+              <td>Format record for the *"short"* style.</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-datetimeformat-connector-record">
+        <h1>DateTime Connector Records</h1>
+
+        <p>
+          Each <dfn id="datetimeformat-connector-record">DateTime Connector Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-connector-record"></emu-xref>. All connector pattern strings must contain the strings *"{0}"* and *"{1}"*.
+        </p>
+        <emu-table id="table-datetimeformat-connector-record">
+          <emu-caption>DateTime Connector Record</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>Field Name</th>
+                <th>Value Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>[[full]]</td>
+              <td>a Pattern String</td>
+              <td>Connector pattern when the date style is *"full"*.</td>
+            </tr>
+            <tr>
+              <td>[[long]]</td>
+              <td>a Pattern String</td>
+              <td>Connector pattern when the date style is *"long"*.</td>
+            </tr>
+            <tr>
+              <td>[[medium]]</td>
+              <td>a Pattern String</td>
+              <td>Connector pattern when the date style is *"medium"*.</td>
+            </tr>
+            <tr>
+              <td>[[short]]</td>
+              <td>a Pattern String</td>
+              <td>Connector pattern when the date style is *"short"*.</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-datetimeformat-date-range-record">
+        <h1>DateTime Date Range Records</h1>
+
+        <p>
+          Each <dfn id="datetimeformat-date-range-record">DateTime Date Range Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-date-range-record"></emu-xref>.
+        </p>
+        <emu-table id="table-datetimeformat-date-range-record">
+          <emu-caption>DateTime Date Range Record</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>Field Name</th>
+                <th>Value Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>[[full]]</td>
+              <td>a DateTime Time Range Record</td>
+              <td>Used when date style is *"full"*.</td>
+            </tr>
+            <tr>
+              <td>[[long]]</td>
+              <td>a DateTime Time Range Record</td>
+              <td>Used when date style is *"long"*.</td>
+            </tr>
+            <tr>
+              <td>[[medium]]</td>
+              <td>a DateTime Time Range Record</td>
+              <td>Used when date style is *"medium"*.</td>
+            </tr>
+            <tr>
+              <td>[[short]]</td>
+              <td>a DateTime Time Range Record</td>
+              <td>Used when date style is *"short"*.</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-datetimeformat-time-range-record">
+        <h1>DateTime Time Range Records</h1>
+
+        <p>
+          Each <dfn id="datetimeformat-time-range-record">DateTime Time Range Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-time-range-record"></emu-xref>.
+        </p>
+        <emu-table id="table-datetimeformat-time-range-record">
+          <emu-caption>DateTime Time Range Record</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>Field Name</th>
+                <th>Value Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>[[full]]</td>
+              <td>a DateTime Style Range Record</td>
+              <td>Used when time style is *"full"*.</td>
+            </tr>
+            <tr>
+              <td>[[long]]</td>
+              <td>a DateTime Style Range Record</td>
+              <td>Used when time style is *"long"*.</td>
+            </tr>
+            <tr>
+              <td>[[medium]]</td>
+              <td>a DateTime Style Range Record</td>
+              <td>Used when time style is *"medium"*.</td>
+            </tr>
+            <tr>
+              <td>[[short]]</td>
+              <td>a DateTime Style Range Record</td>
+              <td>Used when time style is *"short"*.</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-datetimeformat-style-range-record">
+        <h1>DateTime Style Range Records</h1>
+
+        <p>
+          Each <dfn id="datetimeformat-style-range-record">DateTime Style Range Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-style-range-record"></emu-xref>.
+        </p>
+        <emu-table id="table-datetimeformat-style-range-record">
+          <emu-caption>DateTime Style Range Record</emu-caption>
+          <table class="real-table">
+            <thead>
+              <tr>
+                <th>Field Name</th>
+                <th>Value Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>[[rangePatterns]]</td>
+              <td>a DateTime Range Pattern Record</td>
+              <td>Range patterns to combine date and time styles.</td>
+            </tr>
+            <tr>
+              <td>[[rangePatterns12]]</td>
+              <td>a DateTime Range Pattern Record</td>
+              <td>Optional Field. Range patterns to combine date and time styles for 12-hour formats.</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
 
       <emu-note>
         For example, an implementation might include the following record as part of its English locale data:

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1446,14 +1446,14 @@
       <h1>
         FormatDateTimePattern (
           _dateTimeFormat_: an Intl.DateTimeFormat,
+          _format_: a DateTime Format Record or a DateTime Range Pattern Format Record,
           _pattern_: a Pattern String,
           _x_: a Number,
-          _rangeFormatOptions_: a DateTime Range Pattern Format Record or *undefined*,
         ): either a normal completion containing a List of Records with fields [[Type]] (a String) and [[Value]] (a String), or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It interprets _x_ as a time value as specified in es2024, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according to _pattern_ and to the effective locale and the formatting options of _dateTimeFormat_ and _rangeFormatOptions_.</dd>
+        <dd>It interprets _x_ as a time value as specified in es2024, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according to _pattern_ and to the effective locale and the formatting options of _dateTimeFormat_ and _format_.</dd>
       </dl>
       <emu-alg>
         1. Let _x_ be TimeClip(_x_).
@@ -1466,12 +1466,12 @@
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"minimumIntegerDigits"*, *2*<sub>𝔽</sub>).
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"useGrouping"*, *false*).
         1. Let _nf2_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nf2Options_ &raquo;).
-        1. Let _fractionalSecondDigits_ be _dateTimeFormat_.[[FractionalSecondDigits]].
-        1. If _fractionalSecondDigits_ is *undefined*, set _fractionalSecondDigits_ to 1.
-        1. Let _nf3Options_ be OrdinaryObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, 𝔽(_fractionalSecondDigits_)).
-        1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
-        1. Let _nf3_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
+        1. If _format_ has a field [[fractionalSecondDigits]], then
+          1. Let _fractionalSecondDigits_ be _format_.[[fractionalSecondDigits]].
+          1. Let _nf3Options_ be OrdinaryObjectCreate(*null*).
+          1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, 𝔽(_fractionalSecondDigits_)).
+          1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
+          1. Let _nf3_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
         1. Let _tm_ be ToLocalTime(ℤ(ℝ(_x_) &times; 10<sup>6</sup>), _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. Let _result_ be a new empty List.
@@ -1480,24 +1480,25 @@
           1. If _p_ is *"literal"*, then
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
           1. Else if _p_ is equal to *"fractionalSecondDigits"*, then
+            1. Assert: _format_ has a field [[fractionalSecondDigits]].
             1. Let _v_ be _tm_.[[Millisecond]].
             1. Set _v_ to floor(_v_ &times; 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
             1. Let _fv_ be FormatNumeric(_nf3_, _v_).
             1. Append the Record { [[Type]]: *"fractionalSecond"*, [[Value]]: _fv_ } to _result_.
           1. Else if _p_ is equal to *"dayPeriod"*, then
-            1. If _rangeFormatOptions_ is not *undefined*, let _f_ be _rangeFormatOptions_.[[dayPeriod]].
-            1. Else, let _f_ be _dateTimeFormat_.[[DayPeriod]].
+            1. Assert: _format_ has a field [[dayPeriod]].
+            1. Let _f_ be _format_.[[dayPeriod]].
             1. Let _fv_ be a String value representing the day period of _tm_ in the form given by _f_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
           1. Else if _p_ is equal to *"timeZoneName"*, then
-            1. If _rangeFormatOptions_ is not *undefined*, let _f_ be _rangeFormatOptions_.[[timeZoneName]].
-            1. Else, let _f_ be _dateTimeFormat_.[[TimeZoneName]].
+            1. Assert: _format_ has a field [[timeZoneName]].
+            1. Let _f_ be _format_.[[timeZoneName]].
             1. Let _v_ be _dateTimeFormat_.[[TimeZone]].
             1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_. The String value may also depend on the value of the [[InDST]] field of _tm_ if _f_ is *"short"*, *"long"*, *"shortOffset"*, or *"longOffset"*. If the implementation does not have such a localized representation of _v_, then use the String value of _v_ itself.
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
           1. Else if _p_ matches a Property column of the row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, then
-            1. If _rangeFormatOptions_ is not *undefined*, let _f_ be the value of _rangeFormatOptions_'s field whose name matches _p_.
-            1. Else, let _f_ be the value of _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the matching row.
+            1. Assert: _format_ has a field [[&lt;_p_&gt;]].
+            1. Let _f_ be _format_.[[&lt;_p_&gt;]].
             1. Let _v_ be the value of _tm_'s field whose name is the Internal Slot column of the matching row.
             1. If _p_ is *"year"* and _v_ &le; 0, set _v_ to 1 - _v_.
             1. If _p_ is *"month"*, set _v_ to _v_ + 1.
@@ -1512,7 +1513,7 @@
               1. Let _fv_ be FormatNumeric(_nf2_, _v_).
               1. If the *"length"* property of _fv_ is greater than 2, set _fv_ to the substring of _fv_ containing the last two characters.
             1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then
-              1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether _dateTimeFormat_.[[Day]] is *undefined*. If _p_ is *"month"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[day]] is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether _dateTimeFormat_.[[Era]] is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[era]] is *undefined*. If the implementation does not have such a localized representation of _v_, then use ! ToString(_v_).
+              1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _format_.[[day]] is present. If _p_ is *"era"*, then the String value may also depend on whether _format_.[[era]] is present. If the implementation does not have a localized representation of _f_, then use ! ToString(_v_).
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
           1. Else if _p_ is equal to *"ampm"*, then
             1. Let _v_ be _tm_.[[Hour]].
@@ -1557,7 +1558,7 @@
           1. Let _pattern_ be _format_.[[pattern12]].
         1. Else,
           1. Let _pattern_ be _format_.[[pattern]].
-        1. Let _result_ be ? FormatDateTimePattern(_dateTimeFormat_, _pattern_, _x_, *undefined*).
+        1. Let _result_ be ? FormatDateTimePattern(_dateTimeFormat_, _format_, _pattern_, _x_).
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -1660,7 +1661,7 @@
               1. Set _relevantFieldsEqual_ to *false*.
         1. If _relevantFieldsEqual_ is *true*, then
           1. Let _collapsedResult_ be a new empty List.
-          1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _pattern_, _x_, *undefined*).
+          1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _format_, _pattern_, _x_).
           1. For each Record { [[Type]], [[Value]] } _r_ of _resultParts_, do
             1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: *"shared"* } to _collapsedResult_.
           1. Return _collapsedResult_.
@@ -1674,7 +1675,7 @@
             1. Let _z_ be _x_.
           1. Else,
             1. Let _z_ be _y_.
-          1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _pattern_, _z_, _selectedRangePattern_).
+          1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _selectedRangePattern_, _pattern_, _z_).
           1. For each Record { [[Type]], [[Value]] } _r_ of _resultParts_, do
             1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: _source_ } to _rangeResult_.
         1. Return _rangeResult_.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1513,7 +1513,7 @@
               1. Let _fv_ be FormatNumeric(_nf2_, _v_).
               1. If the *"length"* property of _fv_ is greater than 2, set _fv_ to the substring of _fv_ containing the last two characters.
             1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then
-              1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _format_.[[day]] is present. If _p_ is *"era"*, then the String value may also depend on whether _format_.[[era]] is present. If the implementation does not have a localized representation of _f_, then use ! ToString(_v_).
+              1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _format_.[[day]] is present. If the implementation does not have a localized representation of _f_, then use ! ToString(_v_).
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
           1. Else if _p_ is equal to *"ampm"*, then
             1. Let _v_ be _tm_.[[Hour]].

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1631,7 +1631,7 @@
         1. Let _checkMoreFields_ be *true*.
         1. For each row of <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref>, except the header row, in table order, do
           1. Let _fieldName_ be the name given in the Range Pattern Field column of the row.
-          1. If _rangePatterns_ has a field [[&lt;_fieldName_&gt;]], let _rangePattern_ be _rangePatterns_.[[&lt;_fieldName_&gt;]]; else let _rangePattern_ be *undefined*.
+          1. If _rangePatterns_ has a field whose name is _fieldName_, let _rangePattern_ be _rangePatterns_' field whose name is _fieldName_; else let _rangePattern_ be *undefined*.
           1. If _selectedRangePattern_ is not *undefined* and _rangePattern_ is *undefined*, then
             1. NOTE: Because there is no range pattern for differences at or below this field, no further checks will be performed.
             1. Set _checkMoreFields_ to *false*.
@@ -1651,8 +1651,8 @@
               1. Let _v1_ be floor(_tm1_.[[Millisecond]] &times; 10<sup>_exp_</sup>).
               1. Let _v2_ be floor(_tm2_.[[Millisecond]] &times; 10<sup>_exp_</sup>).
             1. Else,
-              1. Let _v1_ be _tm1_.[[&lt;_fieldName_&gt;]].
-              1. Let _v2_ be _tm2_.[[&lt;_fieldName_&gt;]].
+              1. Let _v1_ be _tm1_'s field whose name is _fieldName_.
+              1. Let _v2_ be _tm2_'s field whose name is _fieldName_.
             1. If _v1_ is not equal to _v2_, then
               1. Set _relevantFieldsEqual_ to *false*.
         1. If _relevantFieldsEqual_ is *true*, then

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -235,7 +235,7 @@
     <emu-clause id="sec-deconstructpattern" type="abstract operation">
       <h1>
         DeconstructPattern (
-          _pattern_: a String,
+          _pattern_: a Pattern String,
           _placeables_: a Record,
         ): a List
       </h1>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -2,7 +2,7 @@
   <h1>Identification of Locales, Currencies, Time Zones, Measurement Units, Numbering Systems, Collations, and Calendars</h1>
 
   <p>
-    This clause describes the String values used in this specification to identify locales, currencies, time zones, measurement units, numbering systems, collations, and calendars.
+    This clause describes the String values used in this specification to identify locales, currencies, time zones, measurement units, numbering systems, collations, calendars, and pattern strings.
   </p>
 
   <emu-clause id="sec-case-sensitivity-and-case-mapping">
@@ -413,5 +413,12 @@
         <dd>The returned List is ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_, and contains unique canonical calendar types identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects. The list must include *"iso8601"*.</dd>
       </dl>
     </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-pattern-string-types">
+    <h1>Pattern String Types</h1>
+    <p>
+      <dfn>Pattern String</dfn> is a String value which contains zero or more substrings of the form *"{name}"*. The syntax of the abstract pattern strings is an implementation detail and is not exposed to users of ECMA-402.
+    </p>
   </emu-clause>
 </emu-clause>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -418,7 +418,7 @@
   <emu-clause id="sec-pattern-string-types">
     <h1>Pattern String Types</h1>
     <p>
-      <dfn>Pattern String</dfn> is a String value which contains zero or more substrings of the form *"{name}"*. The syntax of the abstract pattern strings is an implementation detail and is not exposed to users of ECMA-402.
+      <dfn>Pattern String</dfn> is a String value which contains zero or more substrings of the form *"{key}"*, where key can be any nonempty sequence consisting only of elements from the ASCII word characters. The syntax of the abstract pattern strings is an implementation detail and is not exposed to users of ECMA-402.
     </p>
   </emu-clause>
 </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -471,14 +471,13 @@
     <emu-clause id="sec-partitionpattern" type="abstract operation">
       <h1>
         PartitionPattern (
-          _pattern_: a String,
+          _pattern_: a Pattern String,
         ): a List of Records with fields [[Type]] (a String) and [[Value]] (a String or *undefined*)
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
           The [[Value]] field will be a String value if [[Type]] is *"literal"*, and *undefined* otherwise.
-          The syntax of the abstract pattern strings is an implementation detail and is not exposed to users of ECMA-402.
         </dd>
       </dl>
       <emu-alg>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -343,7 +343,7 @@
     <emu-clause id="sec-makepartslist" type="abstract operation">
       <h1>
         MakePartsList (
-          _pattern_: a pattern String,
+          _pattern_: a Pattern String,
           _unit_: a String,
           _parts_: a List of Records representing a formatted Number,
         ): a List of Records with fields [[Type]] (a String), [[Value]] (a String), and [[Unit]] (a String or ~empty~)


### PR DESCRIPTION
This PR aims to restructure [Intl.DateTimeFormat Constructor - Internal Slots](https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots) to use named Record types instead of ad-hoc records. In the process of this clean-up, some editorial bugs were found and fixed, see the commit messages for details.

In addition to providing a more _type-safe_ approach when compared to using ad-hoc records, these changes should also help with the Temporal integration, see <https://tc39.es/proposal-temporal/#sec-temporal-intl>.

---

The PR applies on top of #822.
