### PR TITLE
Normative: Allow locale based ignorePunctuation default

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -48,6 +48,9 @@
           The default search sensitivity per locale (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
         </li>
         <li>
+          The default ignore punctuation value per locale (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>) 
+        </li>
+        <li>
           The sort order for each supported locale and options combination (<emu-xref href="#sec-collator-compare-functions"></emu-xref>)
         </li>
       </ul>

--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -48,7 +48,7 @@
           The default search sensitivity per locale (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
         </li>
         <li>
-          The default ignore punctuation value per locale (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>) 
+          The default ignore punctuation value per locale (<emu-xref href="#sec-intl-collator-internal-slots"></emu-xref>)
         </li>
         <li>
           The sort order for each supported locale and options combination (<emu-xref href="#sec-collator-compare-functions"></emu-xref>)

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -137,7 +137,7 @@
         <li>The first element of [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] must be *null*.</li>
         <li>The values *"standard"* and *"search"* must not be used as elements in any [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] list.</li>
         <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] must have a [[sensitivity]] field with a String value equal to *"base"*, *"accent"*, *"case"*, or *"variant"*.</li>
-        <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] and [[SortLocaleData]].[[&lt;_locale_&gt;]] must have a [[ignorePunctuation]] field with a Boolean value.</li>
+        <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] and [[SortLocaleData]].[[&lt;_locale_&gt;]] must have an [[ignorePunctuation]] field with a Boolean value.</li>
       </ul>
     </emu-clause>
   </emu-clause>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -64,16 +64,17 @@
           1. Set _collator_.[[Numeric]] to SameValue(_r_.[[kn]], *"true"*).
         1. If _relevantExtensionKeys_ contains *"kf"*, then
           1. Set _collator_.[[CaseFirst]] to _r_.[[kf]].
+        1. Let _dataLocale_ be _r_.[[dataLocale]].
+        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, ~string~, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
         1. If _sensitivity_ is *undefined*, then
           1. If _usage_ is *"sort"*, then
             1. Let _sensitivity_ be *"variant"*.
           1. Else,
-            1. Let _dataLocale_ be _r_.[[dataLocale]].
-            1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
             1. Let _sensitivity_ be _dataLocaleData_.[[sensitivity]].
         1. Set _collator_.[[Sensitivity]] to _sensitivity_.
-        1. Let _ignorePunctuation_ be ? GetOption(_options_, *"ignorePunctuation"*, ~boolean~, ~empty~, *false*).
+        1. Let _defaultIgnorePunctuation_ be _dataLocaleData_.[[ignorePunctuation]].
+        1. Let _ignorePunctuation_ be ? GetOption(_options_, *"ignorePunctuation"*, ~boolean~, ~empty~, _defaultIgnorePunctuation_).
         1. Set _collator_.[[IgnorePunctuation]] to _ignorePunctuation_.
         1. Return _collator_.
       </emu-alg>
@@ -136,6 +137,7 @@
         <li>The first element of [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] must be *null*.</li>
         <li>The values *"standard"* and *"search"* must not be used as elements in any [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] list.</li>
         <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] must have a [[sensitivity]] field with a String value equal to *"base"*, *"accent"*, *"case"*, or *"variant"*.</li>
+        <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] and [[SortLocaleData]].[[&lt;_locale_&gt;]] must have a [[ignorePunctuation]] field with a Boolean value.</li>
       </ul>
     </emu-clause>
   </emu-clause>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -76,8 +76,6 @@
           1. If _usage_ is *"sort"*, then
             1. Set _sensitivity_ to *"variant"*.
           1. Else,
-            1. Let _dataLocale_ be _r_.[[dataLocale]].
-            1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
             1. Set _sensitivity_ to _dataLocaleData_.[[sensitivity]].
         1. Set _collator_.[[Sensitivity]] to _sensitivity_.
         1. Let _defaultIgnorePunctuation_ be _dataLocaleData_.[[ignorePunctuation]].


### PR DESCRIPTION
"th" locale in CLDR collation rule default ignorePunctuation to true instead of false so we need to get tht default value from the locale data instead of always false.
Address https://github.com/tc39/ecma402/issues/832

th CLDR rule is in 
https://github.com/unicode-org/cldr/blob/main/common/collation/th.xml#L17
```
				[alternate shifted]

```

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
@anba @sffc @ben-allen  @gibson042