### PR TITLE
Normative: Allow users to specify rounding based on cash denominations in common use

### DIFF
--- a/spec/normative-references.html
+++ b/spec/normative-references.html
@@ -32,9 +32,6 @@
       <a href="https://www.iana.org/time-zones/">IANA Time Zone Database</a>
     </li>
     <li>
-      <a href="https://cldr.unicode.org/">The Unicode Common Locale Data Repository</a>
-    </li>
-    <li>
       <a href="https://unicode.org/versions/latest">The Unicode Standard</a>
     </li>
     <li>

--- a/spec/normative-references.html
+++ b/spec/normative-references.html
@@ -32,6 +32,9 @@
       <a href="https://www.iana.org/time-zones/">IANA Time Zone Database</a>
     </li>
     <li>
+      <a href="https://cldr.unicode.org/">The Unicode Common Locale Data Repository</a>
+    </li>
+    <li>
       <a href="https://unicode.org/versions/latest">The Unicode Standard</a>
     </li>
     <li>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -734,10 +734,14 @@
       <emu-alg>
         1. Assert: IsWellFormedCurrencyCode(_currency_) is *true*.
         1. Assert: _currency_ is equal to the ASCII-uppercase of _currency_.
-        1. If the Common Locale Data Repository supplemental data pertaining to fractional currency values contains an element with _currency_ as the value of its iso4217 attribute, then
-          1. If _currencyPrecision_ is *"cash"* and the element with _currency_ as the value of its iso4217 attribute has a cashDigits attribute, return the value of that attribute; otherwise, return the value of that element's digits attribute.
+        1. If _currencyPrecision_ is *"cash"*, then
+          1. If there is available locale data that specifies the number of fractional digits to be used when dealing with cash values, return that number.
+        1. If there is available locale data that specifies the number of fractional digits to be used when dealing with non-cash values, return that number.
         1. Return 2.
       </emu-alg>
+      <emu-note>
+        It is recommended that implementations use the Common Locale Data Repository supplemental data on currencies. In this case, if _currencyPrecison_ is *"cash"* and the element with _currency_ as the value of its iso4217 attribute has a cashDigits attribute, return the value of that attribute, otherwise, return the value of that element's digits attribute.
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-currencyrounding" type="abstract operation">
@@ -752,10 +756,13 @@
       <emu-alg>
         1. Assert: IsWellFormedCurrencyCode(_currency_) is *true*.
         1. Assert: _currency_ is equal to the ASCII-uppercase of _currency_.
-        1. If the Common Locale Repository supplemental data pertaining to fractional currency values contains an element with _currency_ as the value of its iso4217 attribute, then
-          1. If _currencyPrecision_ is *"cash"* and the element with _currency_ as the value of its iso4217 attribute has a cashRounding attribute, return the value of that attribute.
+        1. If _currencyPrecision_ is *"cash"*, then
+          1. If there is available locale data that specifies the number to which cash values should be rounded, return that number.
         1. Return 1.
       </emu-alg>
+        <emu-note>
+          It is recommended that implementations use the Common Locale Data Repository supplemental data on currencies. In this case, if _currencyRounding_ is *"cash"* and the element with _currency_ as the value of its iso4217 attribute has a cashRounding attribute, return the value of that attribute,
+        </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-number-format-functions">

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -79,7 +79,7 @@
           1. Let _currency_ be _numberFormat_.[[Currency]].
           1. Let _currencyPrecision_ be _numberFormat_.[[CurrencyPrecision]].
           1. Let _cDigits_ be CurrencyDigits(_currency_, _currencyPrecision_).
-          1. Let _defaultRoundingIncrement_ be CurrencyRounding(_currency_, _currencyPrecision_).
+          1. Let _defaultRoundingIncrement_ be CurrencyRoundingIncrement(_currency_, _currencyPrecision_).
           1. Let _mnfdDefault_ be _cDigits_.
           1. Let _mxfdDefault_ be _cDigits_.
         1. Else,
@@ -741,7 +741,7 @@
 
     <emu-clause id="sec-currencyrounding" type="abstract operation">
       <h1>
-        CurrencyRounding (
+        CurrencyRoundingIncrement (
           _currency_: a String,
           _currencyPrecision_: a String,
         ): a non-negative integer

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -17,7 +17,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
+        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencyPrecision]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
         1. Perform ? InitializeNumberFormat(_numberFormat_, _locales_, _options_).
         1. If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then
           1. Let _this_ be the *this* value.
@@ -77,7 +77,8 @@
         1. Let _style_ be _numberFormat_.[[Style]].
         1. If _style_ is *"currency"*, then
           1. Let _currency_ be _numberFormat_.[[Currency]].
-          1. Let _cDigits_ be CurrencyDigits(_currency_).
+          1. Let _currencyPrecision_ be _numberFormat_.[[CurrencyPrecision]].
+          1. Let _cDigits_ be CurrencyDigits(_currency_, _currencyPrecision_).
           1. Let _mnfdDefault_ be _cDigits_.
           1. Let _mxfdDefault_ be _cDigits_.
         1. Else,
@@ -215,6 +216,7 @@
         1. Else,
           1. If IsWellFormedCurrencyCode(_currency_) is *false*, throw a *RangeError* exception.
         1. Let _currencyDisplay_ be ? GetOption(_options_, *"currencyDisplay"*, ~string~, &laquo; *"code"*, *"symbol"*, *"narrowSymbol"*, *"name"* &raquo;, *"symbol"*).
+        1. Let _currencyPrecision_ be ? GetOption(_options_, *"currencyPrecision"*, ~string~, &laquo; *"cash"*, *"financial"* &raquo;, *"financial"*).
         1. Let _currencySign_ be ? GetOption(_options_, *"currencySign"*, ~string~, &laquo; *"standard"*, *"accounting"* &raquo;, *"standard"*).
         1. Let _unit_ be ? GetOption(_options_, *"unit"*, ~string~, ~empty~, *undefined*).
         1. If _unit_ is *undefined*, then
@@ -225,6 +227,7 @@
         1. If _style_ is *"currency"*, then
           1. Set _intlObj_.[[Currency]] to the ASCII-uppercase of _currency_.
           1. Set _intlObj_.[[CurrencyDisplay]] to _currencyDisplay_.
+          1. Set _intlObj_.[[CurrencyPrecision]] to _currencyPrecision_.
           1. Set _intlObj_.[[CurrencySign]] to _currencySign_.
         1. If _style_ is *"unit"*, then
           1. Set _intlObj_.[[Unit]] to _unit_.
@@ -471,6 +474,11 @@
             <td></td>
           </tr>
           <tr>
+            <td>[[CurrencyPrecision]]</td>
+            <td>*"currencyPrecision"*</td>
+            <td></td>
+          </tr>
+          <tr>
             <td>[[CurrencySign]]</td>
             <td>*"currencySign"*</td>
             <td></td>
@@ -577,6 +585,7 @@
       <li>[[Style]] is one of the String values *"decimal"*, *"currency"*, *"percent"*, or *"unit"*, identifying the type of quantity being measured.</li>
       <li>[[Currency]] is a String value with the currency code identifying the currency to be used if formatting with the *"currency"* unit type. It is only used when [[Style]] has the value *"currency"*.</li>
       <li>[[CurrencyDisplay]] is one of the String values *"code"*, *"symbol"*, *"narrowSymbol"*, or *"name"*, specifying whether to display the currency as an ISO 4217 alphabetic currency code, a localized currency symbol, or a localized currency name if formatting with the *"currency"* style. It is only used when [[Style]] has the value *"currency"*.</li>
+      <li>[[CurrencyPrecision]] is one of the String values *"cash"* or *"financial"*, specifying whether to round currency values to the smallest denomination of the currency in common usage, or instead to round to the number of fractional digits used for the currency in accounting and by financial institutions. It is only used when [[Style]] has the value *"currency"*.</li>
       <li>[[CurrencySign]] is one of the String values *"standard"* or *"accounting"*, specifying whether to render negative numbers in accounting format, often signified by parenthesis. It is only used when [[Style]] has the value *"currency"* and when [[SignDisplay]] is not *"never"*.</li>
       <li>[[Unit]] is a core unit identifier. It is only used when [[Style]] has the value *"unit"*.</li>
       <li>[[UnitDisplay]] is one of the String values *"short"*, *"narrow"*, or *"long"*, specifying whether to display the unit as a symbol, narrow symbol, or localized long name if formatting with the *"unit"* style. It is only used when [[Style]] has the value *"unit"*.</li>
@@ -713,6 +722,7 @@
       <h1>
         CurrencyDigits (
           _currency_: a String,
+          _currencyPrecision_: a String,
         ): a non-negative integer
       </h1>
       <dl class="header">
@@ -720,7 +730,9 @@
       <emu-alg>
         1. Assert: IsWellFormedCurrencyCode(_currency_) is *true*.
         1. Assert: _currency_ is equal to the ASCII-uppercase of _currency_.
-        1. If the ISO 4217 currency and funds code list contains _currency_ as an alphabetic code, return the minor unit value corresponding to the _currency_ from the list; otherwise, return 2.
+        1. If the Common Locale Data Repository supplemental data pertaining to fractional currency values contains an element with _currency_ as the value of its iso4217 attribute, then
+          1. If _currencyPrecision_ is *"cash"* and the element with _currency_ as the value of its iso4217 attribute has a cashDigits attribute, return the value of that attribute; otherwise, return the value of that element's digits attribute.
+        1. Return 2.
       </emu-alg>
     </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -79,9 +79,11 @@
           1. Let _currency_ be _numberFormat_.[[Currency]].
           1. Let _currencyPrecision_ be _numberFormat_.[[CurrencyPrecision]].
           1. Let _cDigits_ be CurrencyDigits(_currency_, _currencyPrecision_).
+          1. Let _defaultRoundingIncrement_ be CurrencyRounding(_currency_, _currencyPrecision_).
           1. Let _mnfdDefault_ be _cDigits_.
           1. Let _mxfdDefault_ be _cDigits_.
         1. Else,
+          1. Let _defaultRoundingIncrement_ be 1.
           1. Let _mnfdDefault_ be 0.
           1. If _style_ is *"percent"*, then
             1. Let _mxfdDefault_ be 0.
@@ -89,7 +91,7 @@
             1. Let _mxfdDefault_ be 3.
         1. Let _notation_ be ? GetOption(_options_, *"notation"*, ~string~, &laquo; *"standard"*, *"scientific"*, *"engineering"*, *"compact"* &raquo;, *"standard"*).
         1. Set _numberFormat_.[[Notation]] to _notation_.
-        1. Perform ? SetNumberFormatDigitOptions(_numberFormat_, _options_, _mnfdDefault_, _mxfdDefault_, _notation_).
+        1. Perform ? SetNumberFormatDigitOptions(_numberFormat_, _options_, _mnfdDefault_, _mxfdDefault_, _notation_, _defaultRoundingIncrement_).
         1. Let _compactDisplay_ be ? GetOption(_options_, *"compactDisplay"*, ~string~, &laquo; *"short"*, *"long"* &raquo;, *"short"*).
         1. Let _defaultUseGrouping_ be *"auto"*.
         1. If _notation_ is *"compact"*, then
@@ -114,6 +116,7 @@
           _mnfdDefault_: an integer,
           _mxfdDefault_: an integer,
           _notation_: a String,
+          _defaultRoundingIncrement_: an integer,
         ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
@@ -127,7 +130,7 @@
         1. Let _mnsd_ be ? Get(_options_, *"minimumSignificantDigits"*).
         1. Let _mxsd_ be ? Get(_options_, *"maximumSignificantDigits"*).
         1. Set _intlObj_.[[MinimumIntegerDigits]] to _mnid_.
-        1. Let _roundingIncrement_ be ? GetNumberOption(_options_, *"roundingIncrement"*, 1, 5000, 1).
+        1. Let _roundingIncrement_ be ? GetNumberOption(_options_, *"roundingIncrement"*, 1, 5000, _defaultRoundingIncrement_).
         1. If _roundingIncrement_ is not in « 1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000 », throw a *RangeError* exception.
         1. Let _roundingMode_ be ? GetOption(_options_, *"roundingMode"*, ~string~, &laquo; *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* &raquo;, *"halfExpand"*).
         1. Let _roundingPriority_ be ? GetOption(_options_, *"roundingPriority"*, ~string~, &laquo; *"auto"*, *"morePrecision"*, *"lessPrecision"* &raquo;, *"auto"*).
@@ -733,6 +736,24 @@
         1. If the Common Locale Data Repository supplemental data pertaining to fractional currency values contains an element with _currency_ as the value of its iso4217 attribute, then
           1. If _currencyPrecision_ is *"cash"* and the element with _currency_ as the value of its iso4217 attribute has a cashDigits attribute, return the value of that attribute; otherwise, return the value of that element's digits attribute.
         1. Return 2.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-currencyrounding" type="abstract operation">
+      <h1>
+        CurrencyRounding (
+          _currency_: a String,
+          _currencyPrecision_: a String,
+        ): a non-negative integer
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Assert: IsWellFormedCurrencyCode(_currency_) is *true*.
+        1. Assert: _currency_ is equal to the ASCII-uppercase of _currency_.
+        1. If the Common Locale Repository supplemental data pertaining to fractional currency values contains an element with _currency_ as the value of its iso4217 attribute, then
+          1. If _currencyPrecision_ is *"cash"* and the element with _currency_ as the value of its iso4217 attribute has a cashRounding attribute, return the value of that attribute.
+        1. Return 1.
       </emu-alg>
     </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -130,7 +130,7 @@
         1. Let _mnsd_ be ? Get(_options_, *"minimumSignificantDigits"*).
         1. Let _mxsd_ be ? Get(_options_, *"maximumSignificantDigits"*).
         1. Set _intlObj_.[[MinimumIntegerDigits]] to _mnid_.
-        1. Let _roundingIncrement_ be ? GetNumberOption(_options_, *"roundingIncrement"*, 1, 5000, _defaultRoundingIncrement_).
+        1. Let _roundingIncrement_ be ? GetNumberOption(_options_, *"roundingIncrement"*, 1, 5000, 1).
         1. If _roundingIncrement_ is not in « 1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000 », throw a *RangeError* exception.
         1. Let _roundingMode_ be ? GetOption(_options_, *"roundingMode"*, ~string~, &laquo; *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* &raquo;, *"halfExpand"*).
         1. Let _roundingPriority_ be ? GetOption(_options_, *"roundingPriority"*, ~string~, &laquo; *"auto"*, *"morePrecision"*, *"lessPrecision"* &raquo;, *"auto"*).
@@ -173,6 +173,7 @@
           1. Else,
             1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfdDefault_.
             1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfdDefault_.
+            1. Set _intlObj_.[[RoundingIncrement]] to _defaultRoundingIncrement_.
         1. If _needSd_ is *false* and _needFd_ is *false*, then
           1. Set _intlObj_.[[MinimumFractionDigits]] to 0.
           1. Set _intlObj_.[[MaximumFractionDigits]] to 0.

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -42,7 +42,7 @@
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _t_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
-        1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, 0, 3, *"standard"*).
+        1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, 0, 3, *"standard"*, 1).
         1. Let _localeData_ be %PluralRules%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %PluralRules%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _pluralRules_.[[Locale]] to _r_.[[locale]].


### PR DESCRIPTION
fix #134 
fix #835 

For some currencies, the number of fractional digits and rounding increment used when dealing with cash values differs from the fractional digits/rounding increments used in financial contexts, with the cash contexts being limited to what's allowed for by the smallest currency denominations in actual circulation. ISO 4217 data uses the values for financial rounding, which is often inappropriate for common usage, while CLDR's currency data has separate attributes for: 

1. cash fractional digits and financial fractional digits
2. cash rounding and financial rounding

This PR allows users to specify a new "currencyPrecision" attribute, which can be set to either "cash" (using CLDR's cash data) or "financial" (using CLDR's financial data, which is almost identical to ISO 4217's values). 

This PR makes CLDR normative.

Note 1: I'm not confident about the wording used in CurrencyDigits and the new CurrencyRounding AOs to describe the CLDR data pulled in -- this is to be taken as a best first guess rather than a definitive attempt.
Note 2: Current version shows whether "cash" or "financial" rounding has been set in resolvedOptions, which may not be necessary, as the actual values used for fractional digits and rounding increment are already visible elsewhere in resolvedOptions.