### PR TITLE
Editorial: Refactor PartitionPattern for simplicity and comprehensibility

### DIFF
--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -435,29 +435,26 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          The [[Value]] field will be a String value if [[Type]] is *"literal"*, and *undefined* otherwise.
+          It interprets _pattern_ as containing an arbitrary number of brace-wrapped "placeholder" <emu-not-ref>substrings</emu-not-ref> and returns a List in which each such placeholder is represented as a Record with [[Type]] equal to the unwrapped <emu-not-ref>substring</emu-not-ref> and [[Value]] equal to *undefined*, and each non-empty <emu-not-ref>substring</emu-not-ref> adjacent to or between such placeholders is represented as a Record with [[Type]] equal to *"literal"* and [[Value]] equal to the <emu-not-ref>substring</emu-not-ref>, preserving the relative order of appearance such that _pattern_ could be recovered by concatenating the value from the appropriate field of each Record in turn.
           The syntax of the abstract pattern strings is an implementation detail and is not exposed to users of ECMA-402.
         </dd>
       </dl>
       <emu-alg>
         1. Let _result_ be a new empty List.
-        1. Let _beginIndex_ be StringIndexOf(_pattern_, *"{"*, 0).
-        1. Let _endIndex_ be 0.
-        1. Let _nextIndex_ be 0.
-        1. Let _length_ be the number of code units in _pattern_.
-        1. Repeat, while _beginIndex_ is an integer index into _pattern_,
-          1. Set _endIndex_ to StringIndexOf(_pattern_, *"}"*, _beginIndex_).
-          1. Assert: _endIndex_ is greater than _beginIndex_.
-          1. If _beginIndex_ is greater than _nextIndex_, then
-            1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
+        1. Let _placeholderEnd_ be -1.
+        1. Let _placeholderStart_ be StringIndexOf(_pattern_, *"{"*, 0).
+        1. Repeat, while _placeholderEnd_ < _placeholderStart_,
+          1. Let _literal_ be the substring of _pattern_ from _placeholderEnd_ + 1 to _placeholderStart_.
+          1. If _literal_ is not the empty String, then
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _literal_ } to _result_.
-          1. Let _p_ be the substring of _pattern_ from position _beginIndex_, exclusive, to position _endIndex_, exclusive.
-          1. Append the Record { [[Type]]: _p_, [[Value]]: *undefined* } to _result_.
-          1. Set _nextIndex_ to _endIndex_ + 1.
-          1. Set _beginIndex_ to StringIndexOf(_pattern_, *"{"*, _nextIndex_).
-        1. If _nextIndex_ is less than _length_, then
-          1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, inclusive, to position _length_, exclusive.
-          1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _literal_ } to _result_.
+          1. Set _placeholderEnd_ to StringIndexOf(_pattern_, *"}"*, _placeholderStart_).
+          1. Assert: _placeholderStart_ < _placeholderEnd_.
+          1. Let _placeholderName_ be the substring of _pattern_ from _placeholderStart_ + 1 to _placeholderEnd_.
+          1. Append the Record { [[Type]]: _placeholderName_, [[Value]]: *undefined* } to _result_.
+          1. Set _placeholderStart_ to StringIndexOf(_pattern_, *"{"*, _placeholderEnd_).
+        1. Let _tail_ be the substring of _pattern_ from _placeholderEnd_ + 1.
+        1. If _tail_ is not the empty String, then
+          1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _tail_ } to _result_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
* Adds a prose description explaining treatment of brace-wrapped placeholders and adjacent literal text in converting a String pattern into an equivalent List of Records.
* Renames spec aliases (_beginIndex_ → _placeholderStart_, _endIndex_ → _placeholderEnd_, _p_ → _placeholderName_).
* Adopts ECMA-262 phrasing conventions (e.g., "the [substring](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#substring) of _S_ from _inclusiveStart_ [to _exclusiveEnd_]" and `<`/`≤`/`≥`/`>` operators).
* Reduces unnecessary repetition (e.g., "If _beginIndex_ \> _nextIndex_, then Let _literal_ be the substring of _pattern_ from _nextIndex_ to _beginIndex_ and Append the Record { [[Type]]: **"literal"**, [[Value]]: _literal_ } to _result_." → "Let _literal_ be the substring of _pattern_ from _placeholderEnd_ + 1 to _placeholderStart_ and If _literal_ is not the empty String, then Append the Record { [[Type]]: **"literal"**, [[Value]]: _literal_ } to _result_.").
* Makes more obvious the omission of zero-length literal Records.
* Increases alias reference locality (e.g., checking for a literal part between a previous _placeholderEnd_ `}` and current _placeholderStart_ `{` before advancing _placeholderEnd_ for the current placeholder part).