### PR TITLE
Editorial: Prefix names of intrinsics

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -4,7 +4,7 @@
   <emu-clause id="sec-the-intl-collator-constructor">
     <h1>The Intl.Collator Constructor</h1>
     <p>
-      The Intl.Collator constructor is the <dfn>%Collator%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The Intl.Collator constructor is the <dfn>%Intl.Collator%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-intl.collator">
@@ -16,11 +16,11 @@
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
         1. Let _internalSlotsList_ be &laquo; [[InitializedCollator]], [[Locale]], [[Usage]], [[Sensitivity]], [[IgnorePunctuation]], [[Collation]], [[BoundCompare]] &raquo;.
-        1. If %Collator%.[[RelevantExtensionKeys]] contains *"kn"*, then
+        1. If %Intl.Collator%.[[RelevantExtensionKeys]] contains *"kn"*, then
           1. Append [[Numeric]] to _internalSlotsList_.
-        1. If %Collator%.[[RelevantExtensionKeys]] contains *"kf"*, then
+        1. If %Intl.Collator%.[[RelevantExtensionKeys]] contains *"kf"*, then
           1. Append [[CaseFirst]] to _internalSlotsList_.
-        1. Let _collator_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Collator.prototype%"*, _internalSlotsList_).
+        1. Let _collator_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.Collator.prototype%"*, _internalSlotsList_).
         1. Return ? InitializeCollator(_collator_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -43,9 +43,9 @@
         1. Let _usage_ be ? GetOption(_options_, *"usage"*, ~string~, &laquo; *"sort"*, *"search"* &raquo;, *"sort"*).
         1. Set _collator_.[[Usage]] to _usage_.
         1. If _usage_ is *"sort"*, then
-          1. Let _localeData_ be %Collator%.[[SortLocaleData]].
+          1. Let _localeData_ be %Intl.Collator%.[[SortLocaleData]].
         1. Else,
-          1. Let _localeData_ be %Collator%.[[SearchLocaleData]].
+          1. Let _localeData_ be %Intl.Collator%.[[SearchLocaleData]].
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
@@ -59,8 +59,8 @@
         1. Set _opt_.[[kn]] to _numeric_.
         1. Let _caseFirst_ be ? GetOption(_options_, *"caseFirst"*, ~string~, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
         1. Set _opt_.[[kf]] to _caseFirst_.
-        1. Let _relevantExtensionKeys_ be %Collator%.[[RelevantExtensionKeys]].
-        1. Let _r_ be ResolveLocale(%Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
+        1. Let _relevantExtensionKeys_ be %Intl.Collator%.[[RelevantExtensionKeys]].
+        1. Let _r_ be ResolveLocale(%Intl.Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
         1. Set _collator_.[[Locale]] to _r_.[[locale]].
         1. Set _collation_ to _r_.[[co]].
         1. If _collation_ is *null*, set _collation_ to *"default"*.
@@ -100,7 +100,7 @@
       <h1>Intl.Collator.prototype</h1>
 
       <p>
-        The value of `Intl.Collator.prototype` is %Collator.prototype%.
+        The value of `Intl.Collator.prototype` is %Intl.Collator.prototype%.
       </p>
 
       <p>
@@ -116,7 +116,7 @@
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be %Collator%.[[AvailableLocales]].
+        1. Let _availableLocales_ be %Intl.Collator%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
@@ -149,14 +149,14 @@
     <h1>Properties of the Intl.Collator Prototype Object</h1>
 
     <p>
-      The Intl.Collator prototype object is itself an ordinary object. <dfn>%Collator.prototype%</dfn> is not an Intl.Collator instance and does not have an [[InitializedCollator]] internal slot or any of the other internal slots of Intl.Collator instance objects.
+      The Intl.Collator prototype object is itself an ordinary object. <dfn>%Intl.Collator.prototype%</dfn> is not an Intl.Collator instance and does not have an [[InitializedCollator]] internal slot or any of the other internal slots of Intl.Collator instance objects.
     </p>
 
     <emu-clause id="sec-intl.collator.prototype.constructor">
       <h1>Intl.Collator.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.Collator.prototype.constructor` is %Collator%.
+        The initial value of `Intl.Collator.prototype.constructor` is %Intl.Collator%.
       </p>
     </emu-clause>
 
@@ -316,7 +316,7 @@
           1. Let _v_ be the value of _collator_'s internal slot whose name is the Internal Slot value of the current row.
           1. If the current row has an Extension Key value, then
             1. Let _extensionKey_ be the Extension Key value of the current row.
-            1. If %Collator%.[[RelevantExtensionKeys]] does not contain _extensionKey_, then
+            1. If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain _extensionKey_, then
               1. Set _v_ to *undefined*.
           1. If _v_ is not *undefined*, then
             1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
@@ -377,7 +377,7 @@
     <h1>Properties of Intl.Collator Instances</h1>
 
     <p>
-      Intl.Collator instances are ordinary objects that inherit properties from %Collator.prototype%.
+      Intl.Collator instances are ordinary objects that inherit properties from %Intl.Collator.prototype%.
     </p>
 
     <p>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -42,52 +42,52 @@
           </tr>
         </thead>
         <tr>
-          <td>%Collator%</td>
-          <td>`Intl.Collator`</td>
-          <td>The `Intl.Collator` constructor (<emu-xref href="#sec-the-intl-collator-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%DateTimeFormat%</td>
-          <td>`Intl.DateTimeFormat`</td>
-          <td>The `Intl.DateTimeFormat` constructor (<emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%DisplayNames%</td>
-          <td>`Intl.DisplayNames`</td>
-          <td>The `Intl.DisplayNames` constructor (<emu-xref href="#sec-intl-displaynames-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
           <td>%Intl%</td>
           <td>`Intl`</td>
           <td>The `Intl` object (<emu-xref href="#intl-object"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%ListFormat%</td>
+          <td>%Intl.Collator%</td>
+          <td>`Intl.Collator`</td>
+          <td>The `Intl.Collator` constructor (<emu-xref href="#sec-the-intl-collator-constructor"></emu-xref>)</td>
+        </tr>
+        <tr>
+          <td>%Intl.DateTimeFormat%</td>
+          <td>`Intl.DateTimeFormat`</td>
+          <td>The `Intl.DateTimeFormat` constructor (<emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref>)</td>
+        </tr>
+        <tr>
+          <td>%Intl.DisplayNames%</td>
+          <td>`Intl.DisplayNames`</td>
+          <td>The `Intl.DisplayNames` constructor (<emu-xref href="#sec-intl-displaynames-constructor"></emu-xref>)</td>
+        </tr>
+        <tr>
+          <td>%Intl.ListFormat%</td>
           <td>`Intl.ListFormat`</td>
           <td>The `Intl.ListFormat` constructor (<emu-xref href="#sec-intl-listformat-constructor"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%Locale%</td>
+          <td>%Intl.Locale%</td>
           <td>`Intl.Locale`</td>
           <td>The `Intl.Locale` constructor (<emu-xref href="#sec-intl-locale-constructor"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%NumberFormat%</td>
+          <td>%Intl.NumberFormat%</td>
           <td>`Intl.NumberFormat`</td>
           <td>The `Intl.NumberFormat` constructor (<emu-xref href="#sec-intl-numberformat-constructor"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%PluralRules%</td>
+          <td>%Intl.PluralRules%</td>
           <td>`Intl.PluralRules`</td>
           <td>The `Intl.PluralRules` constructor (<emu-xref href="#sec-intl-pluralrules-constructor"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%RelativeTimeFormat%</td>
+          <td>%Intl.RelativeTimeFormat%</td>
           <td>`Intl.RelativeTimeFormat`</td>
           <td>The `Intl.RelativeTimeFormat` constructor (<emu-xref href="#sec-intl-relativetimeformat-constructor"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%Segmenter%</td>
+          <td>%Intl.Segmenter%</td>
           <td>`Intl.Segmenter`</td>
           <td>The `Intl.Segmenter` constructor (<emu-xref href="#sec-intl-segmenter-constructor"></emu-xref>)</td>
         </tr>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -92,14 +92,14 @@
           <td>The `Intl.Segmenter` constructor (<emu-xref href="#sec-intl-segmenter-constructor"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%SegmentIteratorPrototype%</td>
+          <td>%IntlSegmentIteratorPrototype%</td>
           <td></td>
-          <td>The prototype of Segment Iterator objects (<emu-xref href="#sec-%segmentiteratorprototype%-object"></emu-xref>)</td>
+          <td>The prototype of Segment Iterator objects (<emu-xref href="#sec-%intlsegmentiteratorprototype%-object"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%SegmentsPrototype%</td>
+          <td>%IntlSegmentsPrototype%</td>
           <td></td>
-          <td>The prototype of Segments objects (<emu-xref href="#sec-%segmentsprototype%-object"></emu-xref>)</td>
+          <td>The prototype of Segments objects (<emu-xref href="#sec-%intlsegmentsprototype%-object"></emu-xref>)</td>
         </tr>
       </table>
     </emu-table>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -5,7 +5,7 @@
     <h1>The Intl.DateTimeFormat Constructor</h1>
 
     <p>
-      The Intl.DateTimeFormat constructor is the <dfn>%DateTimeFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The Intl.DateTimeFormat constructor is the <dfn>%Intl.DateTimeFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-intl.datetimeformat">
@@ -36,7 +36,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _newTarget_ is *undefined* and ? OrdinaryHasInstance(%DateTimeFormat%, _this_) is *true*, then
+          1. If _newTarget_ is *undefined* and ? OrdinaryHasInstance(%Intl.DateTimeFormat%, _this_) is *true*, then
             1. Perform ? DefinePropertyOrThrow(_this_, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: _dateTimeFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Return _this_.
           1. Return _dateTimeFormat_.
@@ -60,7 +60,7 @@
       </dl>
 
       <emu-alg>
-        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%DateTimeFormat.prototype%"*, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]], [[TimeZoneName]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[Pattern]], [[RangePatterns]], [[BoundFormat]] &raquo;).
+        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.DateTimeFormat.prototype%"*, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]], [[TimeZoneName]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[Pattern]], [[RangePatterns]], [[BoundFormat]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
@@ -79,8 +79,8 @@
         1. If _hour12_ is not *undefined*, then
           1. Set _hourCycle_ to *null*.
         1. Set _opt_.[[hc]] to _hourCycle_.
-        1. Let _localeData_ be %DateTimeFormat%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%DateTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %DateTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _localeData_ be %Intl.DateTimeFormat%.[[LocaleData]].
+        1. Let _r_ be ResolveLocale(%Intl.DateTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.DateTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _dateTimeFormat_.[[Locale]] to _r_.[[locale]].
         1. Let _resolvedCalendar_ be _r_.[[ca]].
         1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.
@@ -214,7 +214,7 @@
       <h1>Intl.DateTimeFormat.prototype</h1>
 
       <p>
-        The value of `Intl.DateTimeFormat.prototype` is %DateTimeFormat.prototype%.
+        The value of `Intl.DateTimeFormat.prototype` is %Intl.DateTimeFormat.prototype%.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -229,7 +229,7 @@
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be %DateTimeFormat%.[[AvailableLocales]].
+        1. Let _availableLocales_ be %Intl.DateTimeFormat%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
@@ -471,14 +471,14 @@
     <h1>Properties of the Intl.DateTimeFormat Prototype Object</h1>
 
     <p>
-      The Intl.DateTimeFormat prototype object is itself an ordinary object. <dfn>%DateTimeFormat.prototype%</dfn> is not an Intl.DateTimeFormat instance and does not have an [[InitializedDateTimeFormat]] internal slot or any of the other internal slots of Intl.DateTimeFormat instance objects.
+      The Intl.DateTimeFormat prototype object is itself an ordinary object. <dfn>%Intl.DateTimeFormat.prototype%</dfn> is not an Intl.DateTimeFormat instance and does not have an [[InitializedDateTimeFormat]] internal slot or any of the other internal slots of Intl.DateTimeFormat instance objects.
     </p>
 
     <emu-clause id="sec-intl.datetimeformat.prototype.constructor">
       <h1>Intl.DateTimeFormat.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.DateTimeFormat.prototype.constructor` is %DateTimeFormat%.
+        The initial value of `Intl.DateTimeFormat.prototype.constructor` is %Intl.DateTimeFormat%.
       </p>
     </emu-clause>
 
@@ -728,7 +728,7 @@
     <h1>Properties of Intl.DateTimeFormat Instances</h1>
 
     <p>
-      Intl.DateTimeFormat instances are ordinary objects that inherit properties from %DateTimeFormat.prototype%.
+      Intl.DateTimeFormat instances are ordinary objects that inherit properties from %Intl.DateTimeFormat.prototype%.
     </p>
 
     <p>
@@ -842,7 +842,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>_styles_ is a record from %DateTimeFormat%.[[LocaleData]].[[&lt;_locale_&gt;]].[[styles]].[[&lt;_calendar_&gt;]] for some locale _locale_ and calendar _calendar_. It returns the appropriate format record for date time formatting based on the parameters.</dd>
+        <dd>_styles_ is a record from %Intl.DateTimeFormat%.[[LocaleData]].[[&lt;_locale_&gt;]].[[styles]].[[&lt;_calendar_&gt;]] for some locale _locale_ and calendar _calendar_. It returns the appropriate format record for date time formatting based on the parameters.</dd>
       </dl>
       <emu-alg>
         1. Assert: _dateStyle_ is not *undefined* or _timeStyle_ is not *undefined*.
@@ -995,17 +995,17 @@
         1. Let _locale_ be _dateTimeFormat_.[[Locale]].
         1. Let _nfOptions_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"useGrouping"*, *false*).
-        1. Let _nf_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nfOptions_ &raquo;).
+        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, &laquo; _locale_, _nfOptions_ &raquo;).
         1. Let _nf2Options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"minimumIntegerDigits"*, *2*<sub>𝔽</sub>).
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"useGrouping"*, *false*).
-        1. Let _nf2_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nf2Options_ &raquo;).
+        1. Let _nf2_ be ! Construct(%Intl.NumberFormat%, &laquo; _locale_, _nf2Options_ &raquo;).
         1. Let _fractionalSecondDigits_ be _dateTimeFormat_.[[FractionalSecondDigits]].
         1. If _fractionalSecondDigits_ is not *undefined*, then
           1. Let _nf3Options_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, 𝔽(_fractionalSecondDigits_)).
           1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
-          1. Let _nf3_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
+          1. Let _nf3_ be ! Construct(%Intl.NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
         1. Let _tm_ be ToLocalTime(ℤ(ℝ(_x_) &times; 10<sup>6</sup>), _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _result_ be a new empty List.
         1. For each Record { [[Type]], [[Value]] } _patternPart_ of _patternParts_, do
@@ -1373,12 +1373,12 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It returns the DateTimeFormat instance of its input object, which is either the value itself or a value associated with it by %DateTimeFormat% according to the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>.
+          It returns the DateTimeFormat instance of its input object, which is either the value itself or a value associated with it by %Intl.DateTimeFormat% according to the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>.
         </dd>
       </dl>
       <emu-alg>
         1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
-        1. If _dtf_ does not have an [[InitializedDateTimeFormat]] internal slot and ? OrdinaryHasInstance(%DateTimeFormat%, _dtf_) is *true*, then
+        1. If _dtf_ does not have an [[InitializedDateTimeFormat]] internal slot and ? OrdinaryHasInstance(%Intl.DateTimeFormat%, _dtf_) is *true*, then
           1. Return ? Get(_dtf_, %Intl%.[[FallbackSymbol]]).
         1. Return _dtf_.
       </emu-alg>

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -5,7 +5,7 @@
     <h1>The Intl.DisplayNames Constructor</h1>
 
     <p>
-      The DisplayNames constructor is the <dfn>%DisplayNames%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The DisplayNames constructor is the <dfn>%Intl.DisplayNames%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-Intl.DisplayNames">
@@ -17,15 +17,15 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _displayNames_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%DisplayNames.prototype%"*, &laquo; [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], [[LanguageDisplay]], [[Fields]] &raquo;).
+        1. Let _displayNames_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.DisplayNames.prototype%"*, &laquo; [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], [[LanguageDisplay]], [[Fields]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _localeData_ be %DisplayNames%.[[LocaleData]].
+        1. Let _localeData_ be %Intl.DisplayNames%.[[LocaleData]].
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _r_ be ResolveLocale(%DisplayNames%.[[AvailableLocales]], _requestedLocales_, _opt_, %DisplayNames%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _r_ be ResolveLocale(%Intl.DisplayNames%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.DisplayNames%.[[RelevantExtensionKeys]], _localeData_).
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"narrow"*, *"short"*, *"long"* &raquo;, *"long"*).
         1. Set _displayNames_.[[Style]] to _style_.
         1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* &raquo;, *undefined*).
@@ -64,7 +64,7 @@
       <h1>Intl.DisplayNames.prototype</h1>
 
       <p>
-        The value of `Intl.DisplayNames.prototype` is %DisplayNames.prototype%.
+        The value of `Intl.DisplayNames.prototype` is %Intl.DisplayNames.prototype%.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -79,7 +79,7 @@
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be %DisplayNames%.[[AvailableLocales]].
+        1. Let _availableLocales_ be %Intl.DisplayNames%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
@@ -123,14 +123,14 @@
     <h1>Properties of the Intl.DisplayNames Prototype Object</h1>
 
     <p>
-      The Intl.DisplayNames prototype object is itself an ordinary object. <dfn>%DisplayNames.prototype%</dfn> is not an Intl.DisplayNames instance and does not have an [[InitializedDisplayNames]] internal slot or any of the other internal slots of Intl.DisplayNames instance objects.
+      The Intl.DisplayNames prototype object is itself an ordinary object. <dfn>%Intl.DisplayNames.prototype%</dfn> is not an Intl.DisplayNames instance and does not have an [[InitializedDisplayNames]] internal slot or any of the other internal slots of Intl.DisplayNames instance objects.
     </p>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype.constructor">
       <h1>Intl.DisplayNames.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.DisplayNames.prototype.constructor` is %DisplayNames%.
+        The initial value of `Intl.DisplayNames.prototype.constructor` is %Intl.DisplayNames%.
       </p>
     </emu-clause>
 
@@ -221,7 +221,7 @@
     <h1>Properties of Intl.DisplayNames Instances</h1>
 
     <p>
-      Intl.DisplayNames instances are ordinary objects that inherit properties from %DisplayNames.prototype%.
+      Intl.DisplayNames instances are ordinary objects that inherit properties from %Intl.DisplayNames.prototype%.
     </p>
 
     <p>

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -5,7 +5,7 @@
     <h1>The Intl.ListFormat Constructor</h1>
 
     <p>
-      The ListFormat constructor is the <dfn>%ListFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The ListFormat constructor is the <dfn>%Intl.ListFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-Intl.ListFormat">
@@ -17,14 +17,14 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _listFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%ListFormat.prototype%"*, &laquo; [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[Templates]] &raquo;).
+        1. Let _listFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.ListFormat.prototype%"*, &laquo; [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[Templates]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _localeData_ be %ListFormat%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %ListFormat%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _localeData_ be %Intl.ListFormat%.[[LocaleData]].
+        1. Let _r_ be ResolveLocale(%Intl.ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.ListFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _listFormat_.[[Locale]] to _r_.[[locale]].
         1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"conjunction"*, *"disjunction"*, *"unit"* &raquo;, *"conjunction"*).
         1. Set _listFormat_.[[Type]] to _type_.
@@ -50,7 +50,7 @@
       <h1>Intl.ListFormat.prototype</h1>
 
       <p>
-        The value of `Intl.ListFormat.prototype` is %ListFormat.prototype%.
+        The value of `Intl.ListFormat.prototype` is %Intl.ListFormat.prototype%.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -65,7 +65,7 @@
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be %ListFormat%.[[AvailableLocales]].
+        1. Let _availableLocales_ be %Intl.ListFormat%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
@@ -87,7 +87,7 @@
       </emu-note>
 
       <p>
-        The value of the [[LocaleData]] internal slot is implementation-defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints, for each locale value _locale_ in %ListFormat%.[[AvailableLocales]]:
+        The value of the [[LocaleData]] internal slot is implementation-defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints, for each locale value _locale_ in %Intl.ListFormat%.[[AvailableLocales]]:
       </p>
 
       <ul>
@@ -109,14 +109,14 @@
     <h1>Properties of the Intl.ListFormat Prototype Object</h1>
 
     <p>
-      The Intl.ListFormat prototype object is itself an ordinary object. <dfn>%ListFormat.prototype%</dfn> is not an Intl.ListFormat instance and does not have an [[InitializedListFormat]] internal slot or any of the other internal slots of Intl.ListFormat instance objects.
+      The Intl.ListFormat prototype object is itself an ordinary object. <dfn>%Intl.ListFormat.prototype%</dfn> is not an Intl.ListFormat instance and does not have an [[InitializedListFormat]] internal slot or any of the other internal slots of Intl.ListFormat instance objects.
     </p>
 
     <emu-clause id="sec-Intl.ListFormat.prototype.constructor">
       <h1>Intl.ListFormat.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.ListFormat.prototype.constructor` is %ListFormat%.
+        The initial value of `Intl.ListFormat.prototype.constructor` is %Intl.ListFormat%.
       </p>
     </emu-clause>
 
@@ -210,7 +210,7 @@
     <h1>Properties of Intl.ListFormat Instances</h1>
 
     <p>
-      Intl.ListFormat instances inherit properties from %ListFormat.prototype%.
+      Intl.ListFormat instances inherit properties from %Intl.ListFormat.prototype%.
     </p>
 
     <p>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -27,7 +27,7 @@
         1. Let _O_ be ? RequireObjectCoercible(*this* value).
         1. Let _S_ be ? ToString(_O_).
         1. Let _thatValue_ be ? ToString(_that_).
-        1. Let _collator_ be ? Construct(%Collator%, &laquo; _locales_, _options_ &raquo;).
+        1. Let _collator_ be ? Construct(%Intl.Collator%, &laquo; _locales_, _options_ &raquo;).
         1. Return CompareStrings(_collator_, _S_, _thatValue_).
       </emu-alg>
 
@@ -149,7 +149,7 @@
 
       <emu-alg>
         1. Let _x_ be ? ThisNumberValue(*this* value).
-        1. Let _numberFormat_ be ? Construct(%NumberFormat%, &laquo; _locales_, _options_ &raquo;).
+        1. Let _numberFormat_ be ? Construct(%Intl.NumberFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return FormatNumeric(_numberFormat_, ! ToIntlMathematicalValue(_x_)).
       </emu-alg>
     </emu-clause>
@@ -175,7 +175,7 @@
 
       <emu-alg>
         1. Let _x_ be ? ThisBigIntValue(*this* value).
-        1. Let _numberFormat_ be ? Construct(%NumberFormat%, &laquo; _locales_, _options_ &raquo;).
+        1. Let _numberFormat_ be ? Construct(%Intl.NumberFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return FormatNumeric(_numberFormat_, ℝ(_x_)).
       </emu-alg>
     </emu-clause>
@@ -204,7 +204,7 @@
         1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
         1. Let _x_ be _dateObject_.[[DateValue]].
         1. If _x_ is *NaN*, return *"Invalid Date"*.
-        1. Let _dateFormat_ be ? CreateDateTimeFormat(%DateTimeFormat%, _locales_, _options_, ~any~, ~all~).
+        1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~any~, ~all~).
         1. Return ! FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
     </emu-clause>
@@ -225,7 +225,7 @@
         1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
         1. Let _x_ be _dateObject_.[[DateValue]].
         1. If _x_ is *NaN*, return *"Invalid Date"*.
-        1. Let _dateFormat_ be ? CreateDateTimeFormat(%DateTimeFormat%, _locales_, _options_, ~date~, ~date~).
+        1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~date~, ~date~).
         1. Return ! FormatDateTime(_dateFormat_, _x_).
       </emu-alg>
     </emu-clause>
@@ -246,7 +246,7 @@
         1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
         1. Let _x_ be _dateObject_.[[DateValue]].
         1. If _x_ is *NaN*, return *"Invalid Date"*.
-        1. Let _timeFormat_ be ? CreateDateTimeFormat(%DateTimeFormat%, _locales_, _options_, ~time~, ~time~).
+        1. Let _timeFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~time~, ~time~).
         1. Return ! FormatDateTime(_timeFormat_, _x_).
       </emu-alg>
     </emu-clause>

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -5,7 +5,7 @@
     <h1>The Intl.Locale Constructor</h1>
 
     <p>
-      The Locale constructor is the <dfn>%Locale%</dfn> intrinsic object and a standard built-in property of the Intl object.
+      The Locale constructor is the <dfn>%Intl.Locale%</dfn> intrinsic object and a standard built-in property of the Intl object.
     </p>
 
     <emu-clause id="sec-Intl.Locale">
@@ -17,13 +17,13 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _relevantExtensionKeys_ be %Locale%.[[RelevantExtensionKeys]].
+        1. Let _relevantExtensionKeys_ be %Intl.Locale%.[[RelevantExtensionKeys]].
         1. Let _internalSlotsList_ be &laquo; [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[NumberingSystem]] &raquo;.
         1. If _relevantExtensionKeys_ contains *"kf"*, then
           1. Append [[CaseFirst]] to _internalSlotsList_.
         1. If _relevantExtensionKeys_ contains *"kn"*, then
           1. Append [[Numeric]] to _internalSlotsList_.
-        1. Let _locale_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Locale.prototype%"*, _internalSlotsList_).
+        1. Let _locale_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.Locale.prototype%"*, _internalSlotsList_).
         1. If Type(_tag_) is not String or Object, throw a *TypeError* exception.
         1. If Type(_tag_) is Object and _tag_ has an [[InitializedLocale]] internal slot, then
           1. Let _tag_ be _tag_.[[Locale]].
@@ -163,7 +163,7 @@
       <h1>Intl.Locale.prototype</h1>
 
       <p>
-        The value of `Intl.Locale.prototype` is %Locale.prototype%.
+        The value of `Intl.Locale.prototype` is %Intl.Locale.prototype%.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -174,7 +174,7 @@
       <h1>Internal slots</h1>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; *"ca"*, *"co"*, *"hc"*, *"kf"*, *"kn"*, *"nu"* &raquo;. If %Collator%.[[RelevantExtensionKeys]] does not contain *"kf"*, then remove *"kf"* from %Locale%.[[RelevantExtensionKeys]]. If %Collator%.[[RelevantExtensionKeys]] does not contain *"kn"*, then remove *"kn"* from %Locale%.[[RelevantExtensionKeys]].
+        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; *"ca"*, *"co"*, *"hc"*, *"kf"*, *"kn"*, *"nu"* &raquo;. If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain *"kf"*, then remove *"kf"* from %Intl.Locale%.[[RelevantExtensionKeys]]. If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain *"kn"*, then remove *"kn"* from %Intl.Locale%.[[RelevantExtensionKeys]].
       </p>
     </emu-clause>
   </emu-clause>
@@ -183,14 +183,14 @@
     <h1>Properties of the Intl.Locale Prototype Object</h1>
 
     <p>
-      The Intl.Locale prototype object is itself an ordinary object. <dfn>%Locale.prototype%</dfn> is not an Intl.Locale instance and does not have an [[InitializedLocale]] internal slot or any of the other internal slots of Intl.Locale instance objects.
+      The Intl.Locale prototype object is itself an ordinary object. <dfn>%Intl.Locale.prototype%</dfn> is not an Intl.Locale instance and does not have an [[InitializedLocale]] internal slot or any of the other internal slots of Intl.Locale instance objects.
     </p>
 
     <emu-clause id="sec-Intl.Locale.prototype.constructor">
       <h1>Intl.Locale.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.Locale.prototype.constructor` is %Locale%.
+        The initial value of `Intl.Locale.prototype.constructor` is %Intl.Locale%.
       </p>
     </emu-clause>
 
@@ -213,7 +213,7 @@
       1. Let _loc_ be the *this* value.
       1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
       1. Let _maximal_ be the result of the <a href="https://unicode.org/reports/tr35/#Likely_Subtags">Add Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _maximal_ to _loc_.[[Locale]].
-      1. Return ! Construct(%Locale%, _maximal_).
+      1. Return ! Construct(%Intl.Locale%, _maximal_).
       </emu-alg>
     </emu-clause>
 
@@ -224,7 +224,7 @@
       1. Let _loc_ be the *this* value.
       1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
       1. Let _minimal_ be the result of the <a href="https://unicode.org/reports/tr35/#Likely_Subtags">Remove Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _minimal_ to _loc_.[[Locale]].
-      1. Return ! Construct(%Locale%, _minimal_).
+      1. Return ! Construct(%Intl.Locale%, _minimal_).
       </emu-alg>
     </emu-clause>
 
@@ -261,7 +261,7 @@
 
     <emu-clause id="sec-Intl.Locale.prototype.caseFirst">
       <h1>get Intl.Locale.prototype.caseFirst</h1>
-      <p>This property only exists if %Locale%.[[RelevantExtensionKeys]] contains *"kf"*.</p>
+      <p>This property only exists if %Intl.Locale%.[[RelevantExtensionKeys]] contains *"kf"*.</p>
       <p>`Intl.Locale.prototype.caseFirst` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
@@ -292,7 +292,7 @@
 
     <emu-clause id="sec-Intl.Locale.prototype.numeric">
       <h1>get Intl.Locale.prototype.numeric</h1>
-      <p>This property only exists if %Locale%.[[RelevantExtensionKeys]] contains *"kn"*.</p>
+      <p>This property only exists if %Intl.Locale%.[[RelevantExtensionKeys]] contains *"kn"*.</p>
       <p>`Intl.Locale.prototype.numeric` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
@@ -346,7 +346,7 @@
     <h1>Properties of Intl.Locale Instances</h1>
 
     <p>
-      Intl.Locale instances are ordinary objects that inherit properties from %Locale.prototype%.
+      Intl.Locale instances are ordinary objects that inherit properties from %Intl.Locale.prototype%.
     </p>
 
     <p>
@@ -363,8 +363,8 @@
       <li>[[Collation]] is a String value that is a syntactically valid type value as given in <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">Unicode Technical Standard #35 Part 1 Core, Section 3.2 Unicode Locale Identifier</a>, or is *undefined*.</li>
       <li>[[HourCycle]] is a String value that is a syntactically valid type value as given in <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">Unicode Technical Standard #35 Part 1 Core, Section 3.2 Unicode Locale Identifier</a>, or is *undefined*.</li>
       <li>[[NumberingSystem]] is a String value that is a syntactically valid type value as given in <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">Unicode Technical Standard #35 Part 1 Core, Section 3.2 Unicode Locale Identifier</a>, or is *undefined*.</li>
-      <li>[[CaseFirst]] is a String value that is a syntactically valid type value as given in <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">Unicode Technical Standard #35 Part 1 Core, Section 3.2 Unicode Locale Identifier</a>, or is *undefined*. This internal slot only exists if the [[RelevantExtensionKeys]] internal slot of %Locale% contains *"kf"*.</li>
-      <li>[[Numeric]] is a Boolean value specifying whether numeric sorting is used by the locale, or is *undefined*. This internal slot only exists if the [[RelevantExtensionKeys]] internal slot of %Locale% contains *"kn"*.</li>
+      <li>[[CaseFirst]] is a String value that is a syntactically valid type value as given in <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">Unicode Technical Standard #35 Part 1 Core, Section 3.2 Unicode Locale Identifier</a>, or is *undefined*. This internal slot only exists if the [[RelevantExtensionKeys]] internal slot of %Intl.Locale% contains *"kf"*.</li>
+      <li>[[Numeric]] is a Boolean value specifying whether numeric sorting is used by the locale, or is *undefined*. This internal slot only exists if the [[RelevantExtensionKeys]] internal slot of %Intl.Locale% contains *"kn"*.</li>
     </ul>
   </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -5,7 +5,7 @@
     <h1>The Intl.NumberFormat Constructor</h1>
 
     <p>
-      The NumberFormat constructor is the <dfn>%NumberFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The NumberFormat constructor is the <dfn>%Intl.NumberFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-intl.numberformat">
@@ -17,7 +17,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
+        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
         1. Perform ? InitializeNumberFormat(_numberFormat_, _locales_, _options_).
         1. If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then
           1. Let _this_ be the *this* value.
@@ -37,7 +37,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _newTarget_ is *undefined* and ? OrdinaryHasInstance(%NumberFormat%, _this_) is *true*, then
+          1. If _newTarget_ is *undefined* and ? OrdinaryHasInstance(%Intl.NumberFormat%, _this_) is *true*, then
             1. Perform ? DefinePropertyOrThrow(_this_, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: _numberFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Return _this_.
           1. Return _numberFormat_.
@@ -68,8 +68,8 @@
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ cannot be matched by the <code>type</code> Unicode locale nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
-        1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %NumberFormat%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
+        1. Let _r_ be ResolveLocale(%Intl.NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.NumberFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _numberFormat_.[[Locale]] to _r_.[[locale]].
         1. Set _numberFormat_.[[DataLocale]] to _r_.[[dataLocale]].
         1. Set _numberFormat_.[[NumberingSystem]] to _r_.[[nu]].
@@ -245,7 +245,7 @@
       <h1>Intl.NumberFormat.prototype</h1>
 
       <p>
-        The value of `Intl.NumberFormat.prototype` is %NumberFormat.prototype%.
+        The value of `Intl.NumberFormat.prototype` is %Intl.NumberFormat.prototype%.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -260,7 +260,7 @@
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be %NumberFormat%.[[AvailableLocales]].
+        1. Let _availableLocales_ be %Intl.NumberFormat%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
@@ -315,14 +315,14 @@
     <h1>Properties of the Intl.NumberFormat Prototype Object</h1>
 
     <p>
-      The Intl.NumberFormat prototype object is itself an ordinary object. <dfn>%NumberFormat.prototype%</dfn> is not an Intl.NumberFormat instance and does not have an [[InitializedNumberFormat]] internal slot or any of the other internal slots of Intl.NumberFormat instance objects.
+      The Intl.NumberFormat prototype object is itself an ordinary object. <dfn>%Intl.NumberFormat.prototype%</dfn> is not an Intl.NumberFormat instance and does not have an [[InitializedNumberFormat]] internal slot or any of the other internal slots of Intl.NumberFormat instance objects.
     </p>
 
     <emu-clause id="sec-intl.numberformat.prototype.constructor">
       <h1>Intl.NumberFormat.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.NumberFormat.prototype.constructor` is %NumberFormat%.
+        The initial value of `Intl.NumberFormat.prototype.constructor` is %Intl.NumberFormat%.
       </p>
     </emu-clause>
 
@@ -559,7 +559,7 @@
     <h1>Properties of Intl.NumberFormat Instances</h1>
 
     <p>
-      Intl.NumberFormat instances are ordinary objects that inherit properties from %NumberFormat.prototype%.
+      Intl.NumberFormat instances are ordinary objects that inherit properties from %Intl.NumberFormat.prototype%.
     </p>
 
     <p>
@@ -1433,12 +1433,12 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It returns the NumberFormat instance of its input object, which is either the value itself or a value associated with it by %NumberFormat% according to the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>.
+          It returns the NumberFormat instance of its input object, which is either the value itself or a value associated with it by %Intl.NumberFormat% according to the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>.
         </dd>
       </dl>
       <emu-alg>
         1. If Type(_nf_) is not Object, throw a *TypeError* exception.
-        1. If _nf_ does not have an [[InitializedNumberFormat]] internal slot and ? OrdinaryHasInstance(%NumberFormat%, _nf_) is *true*, then
+        1. If _nf_ does not have an [[InitializedNumberFormat]] internal slot and ? OrdinaryHasInstance(%Intl.NumberFormat%, _nf_) is *true*, then
           1. Return ? Get(_nf_, %Intl%.[[FallbackSymbol]]).
         1. Return _nf_.
       </emu-alg>
@@ -1459,7 +1459,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
+        1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
         1. Let _dataLocale_ be _numberFormat_.[[DataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _patterns_ be _dataLocaleData_.[[patterns]].
@@ -1548,7 +1548,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _localeData_ be %NumberFormat%.[[LocaleData]].
+        1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
         1. Let _dataLocale_ be _numberFormat_.[[DataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _notationSubPatterns_ be _dataLocaleData_.[[notationSubPatterns]].

--- a/spec/overview.html
+++ b/spec/overview.html
@@ -47,7 +47,7 @@
     <h1>API Conventions</h1>
 
     <p>
-      Every <emu-xref href="#sec-constructor-properties-of-the-intl-object">Intl constructor</emu-xref> should behave as if defined by a class, throwing a *TypeError* exception when called as a function (without NewTarget). For backwards compatibility with past editions, this does not apply to %Collator%, %DateTimeFormat%, or %NumberFormat%, each of which construct and return a new object when called as a function.
+      Every <emu-xref href="#sec-constructor-properties-of-the-intl-object">Intl constructor</emu-xref> should behave as if defined by a class, throwing a *TypeError* exception when called as a function (without NewTarget). For backwards compatibility with past editions, this does not apply to %Intl.Collator%, %Intl.DateTimeFormat%, or %Intl.NumberFormat%, each of which construct and return a new object when called as a function.
     </p>
 
     <emu-note id="legacy-constructor">

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -5,7 +5,7 @@
     <h1>The Intl.PluralRules Constructor</h1>
 
     <p>
-      The PluralRules constructor is the <dfn>%PluralRules%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The PluralRules constructor is the <dfn>%Intl.PluralRules%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-intl.pluralrules">
@@ -17,7 +17,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%PluralRules.prototype%"*, &laquo; [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]] &raquo;).
+        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.PluralRules.prototype%"*, &laquo; [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]] &raquo;).
         1. Return ? InitializePluralRules(_pluralRules_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -43,8 +43,8 @@
         1. Let _t_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, 0, 3, *"standard"*).
-        1. Let _localeData_ be %PluralRules%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %PluralRules%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _localeData_ be %Intl.PluralRules%.[[LocaleData]].
+        1. Let _r_ be ResolveLocale(%Intl.PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.PluralRules%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _pluralRules_.[[Locale]] to _r_.[[locale]].
         1. Return _pluralRules_.
       </emu-alg>
@@ -62,7 +62,7 @@
       <h1>Intl.PluralRules.prototype</h1>
 
       <p>
-        The value of `Intl.PluralRules.prototype` is %PluralRules.prototype%.
+        The value of `Intl.PluralRules.prototype` is %Intl.PluralRules.prototype%.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -77,7 +77,7 @@
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be %PluralRules%.[[AvailableLocales]].
+        1. Let _availableLocales_ be %Intl.PluralRules%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
@@ -112,14 +112,14 @@
     <h1>Properties of the Intl.PluralRules Prototype Object</h1>
 
     <p>
-      The Intl.PluralRules prototype object is itself an ordinary object. <dfn>%PluralRules.prototype%</dfn> is not an Intl.PluralRules instance and does not have an [[InitializedPluralRules]] internal slot or any of the other internal slots of Intl.PluralRules instance objects.
+      The Intl.PluralRules prototype object is itself an ordinary object. <dfn>%Intl.PluralRules.prototype%</dfn> is not an Intl.PluralRules instance and does not have an [[InitializedPluralRules]] internal slot or any of the other internal slots of Intl.PluralRules instance objects.
     </p>
 
     <emu-clause id="sec-intl.pluralrules.prototype.constructor">
       <h1>Intl.PluralRules.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.PluralRules.prototype.constructor` is %PluralRules%.
+        The initial value of `Intl.PluralRules.prototype.constructor` is %Intl.PluralRules%.
       </p>
     </emu-clause>
 
@@ -271,7 +271,7 @@
     <h1>Properties of Intl.PluralRules Instances</h1>
 
     <p>
-      Intl.PluralRules instances are ordinary objects that inherit properties from %PluralRules.prototype%.
+      Intl.PluralRules instances are ordinary objects that inherit properties from %Intl.PluralRules.prototype%.
     </p>
 
     <p>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -5,7 +5,7 @@
     <h1>The Intl.RelativeTimeFormat Constructor</h1>
 
     <p>
-      The RelativeTimeFormat constructor is the <dfn>%RelativeTimeFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The RelativeTimeFormat constructor is the <dfn>%Intl.RelativeTimeFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat">
@@ -17,7 +17,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%RelativeTimeFormat.prototype%"*, &laquo; [[InitializedRelativeTimeFormat]], [[Locale]], [[DataLocale]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] &raquo;).
+        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.RelativeTimeFormat.prototype%"*, &laquo; [[InitializedRelativeTimeFormat]], [[Locale]], [[DataLocale]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] &raquo;).
         1. Return ? InitializeRelativeTimeFormat(_relativeTimeFormat_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -46,8 +46,8 @@
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ cannot be matched by the <code>type</code> Unicode locale nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
-        1. Let _localeData_ be %RelativeTimeFormat%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%RelativeTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %RelativeTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _localeData_ be %Intl.RelativeTimeFormat%.[[LocaleData]].
+        1. Let _r_ be ResolveLocale(%Intl.RelativeTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.RelativeTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Let _locale_ be _r_.[[locale]].
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
         1. Set _relativeTimeFormat_.[[DataLocale]] to _r_.[[dataLocale]].
@@ -56,8 +56,8 @@
         1. Set _relativeTimeFormat_.[[Style]] to _style_.
         1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, ~string~, &laquo; *"always"*, *"auto"* &raquo;, *"always"*).
         1. Set _relativeTimeFormat_.[[Numeric]] to _numeric_.
-        1. Let _relativeTimeFormat_.[[NumberFormat]] be ! Construct(%NumberFormat%, &laquo; _locale_ &raquo;).
-        1. Let _relativeTimeFormat_.[[PluralRules]] be ! Construct(%PluralRules%, &laquo; _locale_ &raquo;).
+        1. Let _relativeTimeFormat_.[[NumberFormat]] be ! Construct(%Intl.NumberFormat%, &laquo; _locale_ &raquo;).
+        1. Let _relativeTimeFormat_.[[PluralRules]] be ! Construct(%Intl.PluralRules%, &laquo; _locale_ &raquo;).
         1. Return _relativeTimeFormat_.
       </emu-alg>
     </emu-clause>
@@ -74,7 +74,7 @@
       <h1>Intl.RelativeTimeFormat.prototype</h1>
 
       <p>
-        The value of `Intl.RelativeTimeFormat.prototype` is %RelativeTimeFormat.prototype%.
+        The value of `Intl.RelativeTimeFormat.prototype` is %Intl.RelativeTimeFormat.prototype%.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -89,7 +89,7 @@
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be %RelativeTimeFormat%.[[AvailableLocales]].
+        1. Let _availableLocales_ be %Intl.RelativeTimeFormat%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
@@ -136,14 +136,14 @@
     <h1>Properties of the Intl.RelativeTimeFormat Prototype Object</h1>
 
     <p>
-      The Intl.RelativeTimeFormat prototype object is itself an ordinary object. <dfn>%RelativeTimeFormat.prototype%</dfn> is not an Intl.RelativeTimeFormat instance and does not have an [[InitializedRelativeTimeFormat]] internal slot or any of the other internal slots of Intl.RelativeTimeFormat instance objects.
+      The Intl.RelativeTimeFormat prototype object is itself an ordinary object. <dfn>%Intl.RelativeTimeFormat.prototype%</dfn> is not an Intl.RelativeTimeFormat instance and does not have an [[InitializedRelativeTimeFormat]] internal slot or any of the other internal slots of Intl.RelativeTimeFormat instance objects.
     </p>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat.prototype.constructor">
       <h1>Intl.RelativeTimeFormat.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.RelativeTimeFormat.prototype.constructor` is %RelativeTimeFormat%.
+        The initial value of `Intl.RelativeTimeFormat.prototype.constructor` is %Intl.RelativeTimeFormat%.
       </p>
     </emu-clause>
 
@@ -243,7 +243,7 @@
     <h1>Properties of Intl.RelativeTimeFormat Instances</h1>
 
     <p>
-      Intl.RelativeTimeFormat instances are ordinary objects that inherit properties from %RelativeTimeFormat.prototype%.
+      Intl.RelativeTimeFormat instances are ordinary objects that inherit properties from %Intl.RelativeTimeFormat.prototype%.
     </p>
 
     <p>
@@ -309,7 +309,7 @@
       <emu-alg>
         1. If _value_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Let _unit_ be ? SingularRelativeTimeUnit(_unit_).
-        1. Let _localeData_ be %RelativeTimeFormat%.[[LocaleData]].
+        1. Let _localeData_ be %Intl.RelativeTimeFormat%.[[LocaleData]].
         1. Let _dataLocale_ be _relativeTimeFormat_.[[DataLocale]].
         1. Let _fields_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _style_ be _relativeTimeFormat_.[[Style]].

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -209,24 +209,24 @@
       </dl>
       <emu-alg>
         1. Let _internalSlotsList_ be &laquo; [[SegmentsSegmenter]], [[SegmentsString]] &raquo;.
-        1. Let _segments_ be OrdinaryObjectCreate(%SegmentsPrototype%, _internalSlotsList_).
+        1. Let _segments_ be OrdinaryObjectCreate(%IntlSegmentsPrototype%, _internalSlotsList_).
         1. Set _segments_.[[SegmentsSegmenter]] to _segmenter_.
         1. Set _segments_.[[SegmentsString]] to _string_.
         1. Return _segments_.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-%segmentsprototype%-object">
-      <h1>The %SegmentsPrototype% Object</h1>
-      <p>The <dfn>%SegmentsPrototype%</dfn> object:</p>
+    <emu-clause id="sec-%intlsegmentsprototype%-object" oldids="sec-%segmentsprototype%-object">
+      <h1>The %IntlSegmentsPrototype% Object</h1>
+      <p>The <dfn>%IntlSegmentsPrototype%</dfn> object:</p>
       <ul>
         <li>is the prototype of all Segments objects.</li>
         <li>is an ordinary object.</li>
         <li>has the following properties:</li>
       </ul>
 
-      <emu-clause id="sec-%segmentsprototype%.containing">
-        <h1>%SegmentsPrototype%.containing ( _index_ )</h1>
+      <emu-clause id="sec-%intlsegmentsprototype%.containing" oldids="sec-%segmentsprototype%.containing">
+        <h1>%IntlSegmentsPrototype%.containing ( _index_ )</h1>
         <p>The `containing` method is called on a Segments instance with argument _index_ to return a Segment Data object describing the segment in the string including the code unit at the specified index according to the locale and options of the Segments instance's constructing Intl.Segmenter instance. The following steps are taken:</p>
         <emu-alg>
           1. Let _segments_ be the *this* value.
@@ -242,8 +242,8 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%segmentsprototype%-@@iterator">
-        <h1>%SegmentsPrototype% [ @@iterator ] ( )</h1>
+      <emu-clause id="sec-%intlsegmentsprototype%-@@iterator" oldids="sec-%segmentsprototype%-@@iterator">
+        <h1>%IntlSegmentsPrototype% [ @@iterator ] ( )</h1>
         <p>The `@@iterator` method is called on a Segments instance to create a Segment Iterator over its string using the locale and options of its constructing Intl.Segmenter instance. The following steps are taken:</p>
         <emu-alg>
           1. Let _segments_ be the *this* value.
@@ -259,7 +259,7 @@
       <h1>Properties of Segments Instances</h1>
 
       <p>
-        Segments instances are ordinary objects that inherit properties from %SegmentsPrototype%.
+        Segments instances are ordinary objects that inherit properties from %IntlSegmentsPrototype%.
       </p>
 
       <p>
@@ -292,7 +292,7 @@
       </dl>
       <emu-alg>
         1. Let _internalSlotsList_ be &laquo; [[IteratingSegmenter]], [[IteratedString]], [[IteratedStringNextSegmentCodeUnitIndex]] &raquo;.
-        1. Let _iterator_ be OrdinaryObjectCreate(%SegmentIteratorPrototype%, _internalSlotsList_).
+        1. Let _iterator_ be OrdinaryObjectCreate(%IntlSegmentIteratorPrototype%, _internalSlotsList_).
         1. Set _iterator_.[[IteratingSegmenter]] to _segmenter_.
         1. Set _iterator_.[[IteratedString]] to _string_.
         1. Set _iterator_.[[IteratedStringNextSegmentCodeUnitIndex]] to 0.
@@ -300,9 +300,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-%segmentiteratorprototype%-object">
-      <h1>The %SegmentIteratorPrototype% Object</h1>
-      <p>The <dfn>%SegmentIteratorPrototype%</dfn> object:</p>
+    <emu-clause id="sec-%intlsegmentiteratorprototype%-object" oldids="sec-%segmentiteratorprototype%-object">
+      <h1>The %IntlSegmentIteratorPrototype% Object</h1>
+      <p>The <dfn>%IntlSegmentIteratorPrototype%</dfn> object:</p>
       <ul>
         <li>is the prototype of all Segment Iterator objects.</li>
         <li>is an ordinary object.</li>
@@ -310,8 +310,8 @@
         <li>has the following properties:</li>
       </ul>
 
-      <emu-clause id="sec-%segmentiteratorprototype%.next">
-        <h1>%SegmentIteratorPrototype%.next ( )</h1>
+      <emu-clause id="sec-%intlsegmentiteratorprototype%.next" oldids="sec-%segmentiteratorprototype%.next">
+        <h1>%IntlSegmentIteratorPrototype%.next ( )</h1>
         <p>The `next` method is called on a Segment Iterator instance to advance it forward one segment and return an <i>IteratorResult</i> object either describing the new segment or declaring iteration done. The following steps are taken:</p>
         <emu-alg>
           1. Let _iterator_ be the *this* value.
@@ -328,8 +328,8 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%segmentiteratorprototype%.@@tostringtag">
-        <h1>%SegmentIteratorPrototype% [ @@toStringTag ]</h1>
+      <emu-clause id="sec-%intlsegmentiteratorprototype%.@@tostringtag" oldids="sec-%segmentiteratorprototype%.@@tostringtag">
+        <h1>%IntlSegmentIteratorPrototype% [ @@toStringTag ]</h1>
 
         <p>
           The initial value of the @@toStringTag property is the String value *"Segmenter String Iterator"*.

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -5,7 +5,7 @@
     <h1>The Intl.Segmenter Constructor</h1>
 
     <p>
-      The Segmenter constructor is the <dfn>%Segmenter%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The Segmenter constructor is the <dfn>%Intl.Segmenter%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-intl.segmenter">
@@ -18,14 +18,14 @@
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _internalSlotsList_ be &laquo; [[InitializedSegmenter]], [[Locale]], [[SegmenterGranularity]] &raquo;.
-        1. Let _segmenter_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Segmenter.prototype%"*, _internalSlotsList_).
+        1. Let _segmenter_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.Segmenter.prototype%"*, _internalSlotsList_).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _localeData_ be %Segmenter%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%Segmenter%.[[AvailableLocales]], _requestedLocales_, _opt_, %Segmenter%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _localeData_ be %Intl.Segmenter%.[[LocaleData]].
+        1. Let _r_ be ResolveLocale(%Intl.Segmenter%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.Segmenter%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _segmenter_.[[Locale]] to _r_.[[locale]].
         1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, ~string~, &laquo; *"grapheme"*, *"word"*, *"sentence"* &raquo;, *"grapheme"*).
         1. Set _segmenter_.[[SegmenterGranularity]] to _granularity_.
@@ -45,7 +45,7 @@
       <h1>Intl.Segmenter.prototype</h1>
 
       <p>
-        The value of `Intl.Segmenter.prototype` is %Segmenter.prototype%.
+        The value of `Intl.Segmenter.prototype` is %Intl.Segmenter.prototype%.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -60,7 +60,7 @@
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be %Segmenter%.[[AvailableLocales]].
+        1. Let _availableLocales_ be %Intl.Segmenter%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
@@ -90,14 +90,14 @@
     <h1>Properties of the Intl.Segmenter Prototype Object</h1>
 
     <p>
-      The Intl.Segmenter prototype object is itself an ordinary object. <dfn>%Segmenter.prototype%</dfn> is not an Intl.Segmenter instance and does not have an [[InitializedSegmenter]] internal slot or any of the other internal slots of Intl.Segmenter instance objects.
+      The Intl.Segmenter prototype object is itself an ordinary object. <dfn>%Intl.Segmenter.prototype%</dfn> is not an Intl.Segmenter instance and does not have an [[InitializedSegmenter]] internal slot or any of the other internal slots of Intl.Segmenter instance objects.
     </p>
 
     <emu-clause id="sec-intl.segmenter.prototype.constructor">
       <h1>Intl.Segmenter.prototype.constructor</h1>
 
       <p>
-        The initial value of `Intl.Segmenter.prototype.constructor` is %Segmenter%.
+        The initial value of `Intl.Segmenter.prototype.constructor` is %Intl.Segmenter%.
       </p>
     </emu-clause>
 
@@ -172,7 +172,7 @@
     <h1>Properties of Intl.Segmenter Instances</h1>
 
     <p>
-      Intl.Segmenter instances are ordinary objects that inherit properties from %Segmenter.prototype%.
+      Intl.Segmenter instances are ordinary objects that inherit properties from %Intl.Segmenter.prototype%.
     </p>
 
     <p>


### PR DESCRIPTION
Closes #842.

Not sure if the same naming scheme is appropriate for `%SegmentIteratorPrototype%` and `%SegmentsPrototype%`, but happy update those as well if wanted.