### PR TITLE
Editorial: Remove a paragraph for the length property of String.prototype.localeCompare

### DIFF
--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -31,10 +31,6 @@
         1. Return CompareStrings(_collator_, _S_, _thatValue_).
       </emu-alg>
 
-      <p>
-        The value of the *"length"* property of the `localeCompare` method is 1.
-      </p>
-
       <emu-note>
         The `localeCompare` method itself is not directly suitable as an argument to `Array.prototype.sort` because the latter requires a function of two arguments.
       </emu-note>


### PR DESCRIPTION
This style follows other "length" properties in this spec and the ECMAScript spec.
