### PR TITLE
Editorial: Remove unnecessary lowercase conversion of key

### DIFF
--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -253,9 +253,9 @@
             1. Let _optionsValue_ be _options_.[[&lt;_key_&gt;]].
             1. Assert: Type(_optionsValue_) is either String, Undefined, or Null.
             1. If Type(_optionsValue_) is String, then
-              1. Let _ukey_ be the ASCII-lowercase of _key_.
+              1. Assert: The ASCII-lowercase of _key_ is _key_.
               1. Let _optionsUValue_ be the ASCII-lowercase of _optionsValue_.
-              1. Set _optionsValue_ to the String value resulting from canonicalizing _optionsUValue_ as a value of key _ukey_ per <a href="https://unicode.org/reports/tr35/#processing-localeids">Unicode Technical Standard #35 Part 1 Core, Annex C LocaleId Canonicalization Section 5 Canonicalizing Syntax, Processing LocaleIds</a>.
+              1. Set _optionsValue_ to the String value resulting from canonicalizing _optionsUValue_ as a value of key _key_ per <a href="https://unicode.org/reports/tr35/#processing-localeids">Unicode Technical Standard #35 Part 1 Core, Annex C LocaleId Canonicalization Section 5 Canonicalizing Syntax, Processing LocaleIds</a>.
               1. NOTE: It is recommended that implementations use the 'u' extension data in <code>common/bcp47</code> provided by the Common Locale Data Repository (available at <a href="https://cldr.unicode.org/">https://cldr.unicode.org/</a>).
               1. If _optionsValue_ is the empty String, then
                 1. Set _optionsValue_ to *"true"*.


### PR DESCRIPTION
Replaced with assertion since all the key come from internal slots that are already all in lowercase ASCII.

This issue is mentioned by @anba in https://github.com/tc39/ecma402/pull/846#r1428263375
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
