### PR TITLE
Editorial: Refactor ResolveLocale to simplify calls

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -70,15 +70,15 @@
         1. If _relevantExtensionKeys_ contains *"kf"*, then
           1. Set _collator_.[[CaseFirst]] to _r_.[[kf]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, ~string~, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
         1. If _sensitivity_ is *undefined*, then
           1. If _usage_ is *"sort"*, then
             1. Set _sensitivity_ to *"variant"*.
           1. Else,
-            1. Set _sensitivity_ to _dataLocaleData_.[[sensitivity]].
+            1. Set _sensitivity_ to _resolvedLocaleData_.[[sensitivity]].
         1. Set _collator_.[[Sensitivity]] to _sensitivity_.
-        1. Let _defaultIgnorePunctuation_ be _dataLocaleData_.[[ignorePunctuation]].
+        1. Let _defaultIgnorePunctuation_ be _resolvedLocaleData_.[[ignorePunctuation]].
         1. Let _ignorePunctuation_ be ? GetOption(_options_, *"ignorePunctuation"*, ~boolean~, ~empty~, _defaultIgnorePunctuation_).
         1. Set _collator_.[[IgnorePunctuation]] to _ignorePunctuation_.
         1. Return _collator_.

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -69,8 +69,7 @@
           1. Set _collator_.[[Numeric]] to SameValue(_r_.[[kn]], *"true"*).
         1. If _relevantExtensionKeys_ contains *"kf"*, then
           1. Set _collator_.[[CaseFirst]] to _r_.[[kf]].
-        1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _resolvedLocaleData_ be _r_.[[localeData]].
         1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, ~string~, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
         1. If _sensitivity_ is *undefined*, then
           1. If _usage_ is *"sort"*, then

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -61,7 +61,7 @@
         1. Set _opt_.[[kf]] to _caseFirst_.
         1. Let _relevantExtensionKeys_ be %Intl.Collator%.[[RelevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(%Intl.Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
-        1. Set _collator_.[[Locale]] to _r_.[[locale]].
+        1. Set _collator_.[[Locale]] to _r_.[[Locale]].
         1. Set _collation_ to _r_.[[co]].
         1. If _collation_ is *null*, set _collation_ to *"default"*.
         1. Set _collator_.[[Collation]] to _collation_.
@@ -69,7 +69,7 @@
           1. Set _collator_.[[Numeric]] to SameValue(_r_.[[kn]], *"true"*).
         1. If _relevantExtensionKeys_ contains *"kf"*, then
           1. Set _collator_.[[CaseFirst]] to _r_.[[kf]].
-        1. Let _resolvedLocaleData_ be _r_.[[localeData]].
+        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
         1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, ~string~, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
         1. If _sensitivity_ is *undefined*, then
           1. If _usage_ is *"sort"*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -85,8 +85,7 @@
         1. Let _resolvedCalendar_ be _r_.[[ca]].
         1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _resolvedLocaleData_ be _r_.[[localeData]].
         1. If _hour12_ is *true*, then
           1. Let _hc_ be _resolvedLocaleData_.[[hourCycle12]].
         1. Else if _hour12_ is *false*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -81,11 +81,11 @@
         1. Set _opt_.[[hc]] to _hourCycle_.
         1. Let _localeData_ be %Intl.DateTimeFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Intl.DateTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.DateTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _dateTimeFormat_.[[Locale]] to _r_.[[locale]].
+        1. Set _dateTimeFormat_.[[Locale]] to _r_.[[Locale]].
         1. Let _resolvedCalendar_ be _r_.[[ca]].
         1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _resolvedLocaleData_ be _r_.[[localeData]].
+        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
         1. If _hour12_ is *true*, then
           1. Let _hc_ be _resolvedLocaleData_.[[hourCycle12]].
         1. Else if _hour12_ is *false*, then

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -86,15 +86,15 @@
         1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. If _hour12_ is *true*, then
-          1. Let _hc_ be _dataLocaleData_.[[hourCycle12]].
+          1. Let _hc_ be _resolvedLocaleData_.[[hourCycle12]].
         1. Else if _hour12_ is *false*, then
-          1. Let _hc_ be _dataLocaleData_.[[hourCycle24]].
+          1. Let _hc_ be _resolvedLocaleData_.[[hourCycle24]].
         1. Else,
           1. Assert: _hour12_ is *undefined*.
           1. Let _hc_ be _r_.[[hc]].
-          1. If _hc_ is *null*, set _hc_ to _dataLocaleData_.[[hourCycle]].
+          1. If _hc_ is *null*, set _hc_ to _resolvedLocaleData_.[[hourCycle]].
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then
@@ -139,7 +139,7 @@
             1. Throw a *TypeError* exception.
           1. If _required_ is ~time~ and _dateStyle_ is not *undefined*, then
             1. Throw a *TypeError* exception.
-          1. Let _styles_ be _dataLocaleData_.[[styles]].[[&lt;_resolvedCalendar_&gt;]].
+          1. Let _styles_ be _resolvedLocaleData_.[[styles]].[[&lt;_resolvedCalendar_&gt;]].
           1. Let _bestFormat_ be DateTimeStyleFormat(_dateStyle_, _timeStyle_, _styles_).
         1. Else,
           1. Let _needDefaults_ be *true*.
@@ -157,7 +157,7 @@
           1. If _needDefaults_ is *true* and _defaults_ is either ~time~ or ~all~, then
             1. For each property name _prop_ of &laquo; *"hour"*, *"minute"*, *"second"* &raquo;, do
               1. Set _formatOptions_.[[&lt;_prop_&gt;]] to *"numeric"*.
-          1. Let _formats_ be _dataLocaleData_.[[formats]].[[&lt;_resolvedCalendar_&gt;]].
+          1. Let _formats_ be _resolvedLocaleData_.[[formats]].[[&lt;_resolvedCalendar_&gt;]].
           1. If _formatMatcher_ is *"basic"*, then
             1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
           1. Else,

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -79,8 +79,7 @@
         1. If _hour12_ is not *undefined*, then
           1. Set _hourCycle_ to *null*.
         1. Set _opt_.[[hc]] to _hourCycle_.
-        1. Let _localeData_ be %Intl.DateTimeFormat%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%Intl.DateTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.DateTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _r_ be ResolveLocale(%Intl.DateTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.DateTimeFormat%.[[RelevantExtensionKeys]], %Intl.DateTimeFormat%.[[LocaleData]]).
         1. Set _dateTimeFormat_.[[Locale]] to _r_.[[Locale]].
         1. Let _resolvedCalendar_ be _r_.[[ca]].
         1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -33,8 +33,8 @@
         1. Set _displayNames_.[[Type]] to _type_.
         1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, &laquo; *"code"*, *"none"* &raquo;, *"code"*).
         1. Set _displayNames_.[[Fallback]] to _fallback_.
-        1. Set _displayNames_.[[Locale]] to _r_.[[locale]].
-        1. Let _resolvedLocaleData_ be _r_.[[localeData]].
+        1. Set _displayNames_.[[Locale]] to _r_.[[Locale]].
+        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
         1. Let _types_ be _resolvedLocaleData_.[[types]].
         1. Assert: _types_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, ~string~, &laquo; *"dialect"*, *"standard"* &raquo;, *"dialect"*).

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -35,8 +35,8 @@
         1. Set _displayNames_.[[Fallback]] to _fallback_.
         1. Set _displayNames_.[[Locale]] to _r_.[[locale]].
         1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _types_ be _dataLocaleData_.[[types]].
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _types_ be _resolvedLocaleData_.[[types]].
         1. Assert: _types_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, ~string~, &laquo; *"dialect"*, *"standard"* &raquo;, *"dialect"*).
         1. Let _typeFields_ be _types_.[[&lt;_type_&gt;]].

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -22,10 +22,9 @@
         1. If _options_ is *undefined*, throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _localeData_ be %Intl.DisplayNames%.[[LocaleData]].
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _r_ be ResolveLocale(%Intl.DisplayNames%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.DisplayNames%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _r_ be ResolveLocale(%Intl.DisplayNames%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.DisplayNames%.[[RelevantExtensionKeys]], %Intl.DisplayNames%.[[LocaleData]]).
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"narrow"*, *"short"*, *"long"* &raquo;, *"long"*).
         1. Set _displayNames_.[[Style]] to _style_.
         1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* &raquo;, *undefined*).

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -34,8 +34,7 @@
         1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, &laquo; *"code"*, *"none"* &raquo;, *"code"*).
         1. Set _displayNames_.[[Fallback]] to _fallback_.
         1. Set _displayNames_.[[Locale]] to _r_.[[locale]].
-        1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _resolvedLocaleData_ be _r_.[[localeData]].
         1. Let _types_ be _resolvedLocaleData_.[[types]].
         1. Assert: _types_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, ~string~, &laquo; *"dialect"*, *"standard"* &raquo;, *"dialect"*).

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -25,12 +25,12 @@
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be %Intl.ListFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Intl.ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.ListFormat%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _listFormat_.[[Locale]] to _r_.[[locale]].
+        1. Set _listFormat_.[[Locale]] to _r_.[[Locale]].
         1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"conjunction"*, *"disjunction"*, *"unit"* &raquo;, *"conjunction"*).
         1. Set _listFormat_.[[Type]] to _type_.
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _listFormat_.[[Style]] to _style_.
-        1. Let _resolvedLocaleData_ be _r_.[[localeData]].
+        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
         1. Let _dataLocaleTypes_ be _resolvedLocaleData_.[[&lt;_type_&gt;]].
         1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[&lt;_style_&gt;]].
         1. Return _listFormat_.

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -31,8 +31,8 @@
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _listFormat_.[[Style]] to _style_.
         1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _dataLocaleTypes_ be _dataLocaleData_.[[&lt;_type_&gt;]].
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _dataLocaleTypes_ be _resolvedLocaleData_.[[&lt;_type_&gt;]].
         1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[&lt;_style_&gt;]].
         1. Return _listFormat_.
       </emu-alg>

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -30,8 +30,7 @@
         1. Set _listFormat_.[[Type]] to _type_.
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _listFormat_.[[Style]] to _style_.
-        1. Let _dataLocale_ be _r_.[[dataLocale]].
-        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _resolvedLocaleData_ be _r_.[[localeData]].
         1. Let _dataLocaleTypes_ be _resolvedLocaleData_.[[&lt;_type_&gt;]].
         1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[&lt;_style_&gt;]].
         1. Return _listFormat_.

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -23,8 +23,7 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _localeData_ be %Intl.ListFormat%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%Intl.ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.ListFormat%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _r_ be ResolveLocale(%Intl.ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.ListFormat%.[[RelevantExtensionKeys]], %Intl.ListFormat%.[[LocaleData]]).
         1. Set _listFormat_.[[Locale]] to _r_.[[Locale]].
         1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"conjunction"*, *"disjunction"*, *"unit"* &raquo;, *"conjunction"*).
         1. Set _listFormat_.[[Type]] to _type_.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -227,7 +227,7 @@
         1. Let _foundLocaleData_ be _localeData_.[[&lt;_foundLocale_&gt;]].
         1. Assert: Type(_foundLocaleData_) is Record.
         1. Let _result_ be a new Record.
-        1. Set _result_.[[localeData]] to _foundLocaleData_.
+        1. Set _result_.[[LocaleData]] to _foundLocaleData_.
         1. If _r_.[[extension]] is not ~empty~, then
           1. Let _components_ be UnicodeExtensionComponents(_r_.[[extension]]).
           1. Let _keywords_ be _components_.[[Keywords]].
@@ -265,9 +265,9 @@
           1. Set _result_.[[&lt;_key_&gt;]] to _value_.
           1. Set _supportedExtension_ to the string-concatenation of _supportedExtension_ and _supportedExtensionAddition_.
         1. If _supportedExtension_ is *"-u"*, then
-          1. Set _result_.[[locale]] to _foundLocale_.
+          1. Set _result_.[[Locale]] to _foundLocale_.
         1. Else,
-          1. Set _result_.[[locale]] to InsertUnicodeExtensionAndCanonicalize(_foundLocale_, _supportedExtension_).
+          1. Set _result_.[[Locale]] to InsertUnicodeExtensionAndCanonicalize(_foundLocale_, _supportedExtension_).
         1. Return _result_.
       </emu-alg>
 

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -224,15 +224,15 @@
         1. Else,
           1. Let _r_ be BestFitMatcher(_availableLocales_, _requestedLocales_).
         1. Let _foundLocale_ be _r_.[[locale]].
+        1. Let _foundLocaleData_ be _localeData_.[[&lt;_foundLocale_&gt;]].
+        1. Assert: Type(_foundLocaleData_) is Record.
         1. Let _result_ be a new Record.
-        1. Set _result_.[[dataLocale]] to _foundLocale_.
+        1. Set _result_.[[localeData]] to _foundLocaleData_.
         1. If _r_.[[extension]] is not ~empty~, then
           1. Let _components_ be UnicodeExtensionComponents(_r_.[[extension]]).
           1. Let _keywords_ be _components_.[[Keywords]].
         1. Let _supportedExtension_ be *"-u"*.
         1. For each element _key_ of _relevantExtensionKeys_, do
-          1. Let _foundLocaleData_ be _localeData_.[[&lt;_foundLocale_&gt;]].
-          1. Assert: Type(_foundLocaleData_) is Record.
           1. Let _keyLocaleData_ be _foundLocaleData_.[[&lt;_key_&gt;]].
           1. Assert: Type(_keyLocaleData_) is List.
           1. Let _value_ be _keyLocaleData_[0].
@@ -264,9 +264,10 @@
               1. Set _supportedExtensionAddition_ to *""*.
           1. Set _result_.[[&lt;_key_&gt;]] to _value_.
           1. Set _supportedExtension_ to the string-concatenation of _supportedExtension_ and _supportedExtensionAddition_.
-        1. If _supportedExtension_ is not *"-u"*, then
-          1. Set _foundLocale_ to InsertUnicodeExtensionAndCanonicalize(_foundLocale_, _supportedExtension_).
-        1. Set _result_.[[locale]] to _foundLocale_.
+        1. If _supportedExtension_ is *"-u"*, then
+          1. Set _result_.[[locale]] to _foundLocale_.
+        1. Else,
+          1. Set _result_.[[locale]] to InsertUnicodeExtensionAndCanonicalize(_foundLocale_, _supportedExtension_).
         1. Return _result_.
       </emu-alg>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1461,8 +1461,8 @@
       <emu-alg>
         1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
         1. Let _dataLocale_ be _numberFormat_.[[DataLocale]].
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _patterns_ be _dataLocaleData_.[[patterns]].
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _patterns_ be _resolvedLocaleData_.[[patterns]].
         1. Assert: _patterns_ is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
         1. Let _style_ be _numberFormat_.[[Style]].
         1. If _style_ is *"percent"*, then
@@ -1550,8 +1550,8 @@
       <emu-alg>
         1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
         1. Let _dataLocale_ be _numberFormat_.[[DataLocale]].
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _notationSubPatterns_ be _dataLocaleData_.[[notationSubPatterns]].
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _notationSubPatterns_ be _resolvedLocaleData_.[[notationSubPatterns]].
         1. Assert: _notationSubPatterns_ is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
         1. Let _notation_ be _numberFormat_.[[Notation]].
         1. If _notation_ is *"scientific"* or _notation_ is *"engineering"*, then

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -17,7 +17,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
+        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[LocaleData]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
         1. Perform ? InitializeNumberFormat(_numberFormat_, _locales_, _options_).
         1. If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then
           1. Let _this_ be the *this* value.
@@ -71,7 +71,7 @@
         1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Intl.NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.NumberFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _numberFormat_.[[Locale]] to _r_.[[locale]].
-        1. Set _numberFormat_.[[DataLocale]] to _r_.[[dataLocale]].
+        1. Set _numberFormat_.[[LocaleData]] to _r_.[[localeData]].
         1. Set _numberFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Perform ? SetNumberFormatUnitOptions(_numberFormat_, _options_).
         1. Let _style_ be _numberFormat_.[[Style]].
@@ -572,7 +572,7 @@
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[DataLocale]] is a String value with the language tag of the nearest locale for which the implementation has data to perform the formatting operation. It will be a parent locale of [[Locale]].</li>
+      <li>[[LocaleData]] is a Record representing the data available to the implementation for formatting. It is the value of an entry in %Intl.NumberFormat%.[[LocaleData]] associated with either the value of [[Locale]] or a prefix thereof.</li>
       <li>[[NumberingSystem]] is a String value with the "type" given in <a href="https://unicode.org/reports/tr35/#Key_And_Type_Definitions_">Unicode Technical Standard #35 Part 1 Core, Section 3.6.1 Key and Type Definitions</a> for the numbering system used for formatting.</li>
       <li>[[Style]] is one of the String values *"decimal"*, *"currency"*, *"percent"*, or *"unit"*, identifying the type of quantity being measured.</li>
       <li>[[Currency]] is a String value with the currency code identifying the currency to be used if formatting with the *"currency"* unit type. It is only used when [[Style]] has the value *"currency"*.</li>
@@ -1459,9 +1459,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
-        1. Let _dataLocale_ be _numberFormat_.[[DataLocale]].
-        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _resolvedLocaleData_ be _numberFormat_.[[LocaleData]].
         1. Let _patterns_ be _resolvedLocaleData_.[[patterns]].
         1. Assert: _patterns_ is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
         1. Let _style_ be _numberFormat_.[[Style]].
@@ -1548,9 +1546,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
-        1. Let _dataLocale_ be _numberFormat_.[[DataLocale]].
-        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _resolvedLocaleData_ be _numberFormat_.[[LocaleData]].
         1. Let _notationSubPatterns_ be _resolvedLocaleData_.[[notationSubPatterns]].
         1. Assert: _notationSubPatterns_ is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
         1. Let _notation_ be _numberFormat_.[[Notation]].

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -68,8 +68,7 @@
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ cannot be matched by the <code>type</code> Unicode locale nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
-        1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%Intl.NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.NumberFormat%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _r_ be ResolveLocale(%Intl.NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.NumberFormat%.[[RelevantExtensionKeys]], %Intl.NumberFormat%.[[LocaleData]]).
         1. Set _numberFormat_.[[Locale]] to _r_.[[Locale]].
         1. Set _numberFormat_.[[LocaleData]] to _r_.[[LocaleData]].
         1. Set _numberFormat_.[[NumberingSystem]] to _r_.[[nu]].

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -70,8 +70,8 @@
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Intl.NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.NumberFormat%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _numberFormat_.[[Locale]] to _r_.[[locale]].
-        1. Set _numberFormat_.[[LocaleData]] to _r_.[[localeData]].
+        1. Set _numberFormat_.[[Locale]] to _r_.[[Locale]].
+        1. Set _numberFormat_.[[LocaleData]] to _r_.[[LocaleData]].
         1. Set _numberFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Perform ? SetNumberFormatUnitOptions(_numberFormat_, _options_).
         1. Let _style_ be _numberFormat_.[[Style]].

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -45,7 +45,7 @@
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, 0, 3, *"standard"*).
         1. Let _localeData_ be %Intl.PluralRules%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Intl.PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.PluralRules%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _pluralRules_.[[Locale]] to _r_.[[locale]].
+        1. Set _pluralRules_.[[Locale]] to _r_.[[Locale]].
         1. Return _pluralRules_.
       </emu-alg>
     </emu-clause>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -43,8 +43,7 @@
         1. Let _t_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, 0, 3, *"standard"*).
-        1. Let _localeData_ be %Intl.PluralRules%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%Intl.PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.PluralRules%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _r_ be ResolveLocale(%Intl.PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.PluralRules%.[[RelevantExtensionKeys]], %Intl.PluralRules%.[[LocaleData]]).
         1. Set _pluralRules_.[[Locale]] to _r_.[[Locale]].
         1. Return _pluralRules_.
       </emu-alg>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -48,9 +48,9 @@
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _localeData_ be %Intl.RelativeTimeFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Intl.RelativeTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.RelativeTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
-        1. Let _locale_ be _r_.[[locale]].
+        1. Let _locale_ be _r_.[[Locale]].
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
-        1. Set _relativeTimeFormat_.[[LocaleData]] to _r_.[[localeData]].
+        1. Set _relativeTimeFormat_.[[LocaleData]] to _r_.[[LocaleData]].
         1. Set _relativeTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _relativeTimeFormat_.[[Style]] to _style_.

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -17,7 +17,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.RelativeTimeFormat.prototype%"*, &laquo; [[InitializedRelativeTimeFormat]], [[Locale]], [[DataLocale]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] &raquo;).
+        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.RelativeTimeFormat.prototype%"*, &laquo; [[InitializedRelativeTimeFormat]], [[Locale]], [[LocaleData]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] &raquo;).
         1. Return ? InitializeRelativeTimeFormat(_relativeTimeFormat_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -50,7 +50,7 @@
         1. Let _r_ be ResolveLocale(%Intl.RelativeTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.RelativeTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Let _locale_ be _r_.[[locale]].
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
-        1. Set _relativeTimeFormat_.[[DataLocale]] to _r_.[[dataLocale]].
+        1. Set _relativeTimeFormat_.[[LocaleData]] to _r_.[[localeData]].
         1. Set _relativeTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _relativeTimeFormat_.[[Style]] to _style_.
@@ -256,7 +256,7 @@
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[DataLocale]] is a String value with the language tag of the nearest locale for which the implementation has data to perform the formatting operation. It will be a parent locale of [[Locale]].</li>
+      <li>[[LocaleData]] is a Record representing the data available to the implementation for formatting. It is the value of an entry in %Intl.RelativeTimeFormat%.[[LocaleData]] associated with either the value of [[Locale]] or a prefix thereof.</li>
       <li>[[Style]] is one of the String values *"long"*, *"short"*, or *"narrow"*, identifying the relative time format style used.</li>
       <li>[[Numeric]] is one of the String values *"always"* or *"auto"*, identifying whether numerical descriptions are always used, or used only when no more specific version is available (e.g., "1 day ago" vs "yesterday").</li>
       <li>[[NumberFormat]] is an Intl.NumberFormat object used for formatting.</li>
@@ -309,9 +309,7 @@
       <emu-alg>
         1. If _value_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Let _unit_ be ? SingularRelativeTimeUnit(_unit_).
-        1. Let _localeData_ be %Intl.RelativeTimeFormat%.[[LocaleData]].
-        1. Let _dataLocale_ be _relativeTimeFormat_.[[DataLocale]].
-        1. Let _fields_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _fields_ be _relativeTimeFormat_.[[LocaleData]].
         1. Let _style_ be _relativeTimeFormat_.[[Style]].
         1. If _style_ is equal to *"short"*, then
           1. Let _entry_ be the string-concatenation of _unit_ and *"-short"*.

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -46,8 +46,7 @@
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ cannot be matched by the <code>type</code> Unicode locale nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
-        1. Let _localeData_ be %Intl.RelativeTimeFormat%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%Intl.RelativeTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.RelativeTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _r_ be ResolveLocale(%Intl.RelativeTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.RelativeTimeFormat%.[[RelevantExtensionKeys]], %Intl.RelativeTimeFormat%.[[LocaleData]]).
         1. Let _locale_ be _r_.[[Locale]].
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
         1. Set _relativeTimeFormat_.[[LocaleData]] to _r_.[[LocaleData]].

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -26,7 +26,7 @@
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be %Intl.Segmenter%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Intl.Segmenter%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.Segmenter%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _segmenter_.[[Locale]] to _r_.[[locale]].
+        1. Set _segmenter_.[[Locale]] to _r_.[[Locale]].
         1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, ~string~, &laquo; *"grapheme"*, *"word"*, *"sentence"* &raquo;, *"grapheme"*).
         1. Set _segmenter_.[[SegmenterGranularity]] to _granularity_.
         1. Return _segmenter_.

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -24,8 +24,7 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _localeData_ be %Intl.Segmenter%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%Intl.Segmenter%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.Segmenter%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _r_ be ResolveLocale(%Intl.Segmenter%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.Segmenter%.[[RelevantExtensionKeys]], %Intl.Segmenter%.[[LocaleData]]).
         1. Set _segmenter_.[[Locale]] to _r_.[[Locale]].
         1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, ~string~, &laquo; *"grapheme"*, *"word"*, *"sentence"* &raquo;, *"grapheme"*).
         1. Set _segmenter_.[[SegmenterGranularity]] to _granularity_.


### PR DESCRIPTION
This has been bugging me for quite a while.

* Rename _dataLocaleData_ aliases to the more accurate _resolvedLocaleData_
* Update the return value to include locale data rather than its lookup key
* Capitalize the return value static field names