### PR TITLE
Editorial: regularized wording for table iteration in datetimeformat

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -118,11 +118,11 @@
         1. Set _formatOptions_.[[hourCycle]] to _hc_.
         1. Let _hasExplicitFormatComponents_ be *false*.
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
-          1. Let _prop_ be the name given in the Property column of the row.
+          1. Let _prop_ be the name given in the Property column of the current row.
           1. If _prop_ is *"fractionalSecondDigits"*, then
             1. Let _value_ be ? GetNumberOption(_options_, *"fractionalSecondDigits"*, 1, 3, *undefined*).
           1. Else,
-            1. Let _values_ be a List whose elements are the strings given in the Values column of the row.
+            1. Let _values_ be a List whose elements are the strings given in the Values column of the current row.
             1. Let _value_ be ? GetOption(_options_, _prop_, ~string~, _values_, *undefined*).
           1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
           1. If _value_ is not *undefined*, then
@@ -163,10 +163,10 @@
           1. Else,
             1. Let _bestFormat_ be BestFitFormatMatcher(_formatOptions_, _formats_).
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
-          1. Let _prop_ be the name given in the Property column of the row.
+          1. Let _prop_ be the name given in the Property column of the current row.
           1. If _bestFormat_ has a field [[&lt;_prop_&gt;]], then
             1. Let _p_ be _bestFormat_.[[&lt;_prop_&gt;]].
-            1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.
+            1. Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the current row to _p_.
         1. If _dateTimeFormat_.[[Hour]] is *undefined*, then
           1. Set _dateTimeFormat_.[[HourCycle]] to *undefined*.
         1. If _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
@@ -897,7 +897,7 @@
         1. For each element _format_ of _formats_, do
           1. Let _score_ be 0.
           1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the name given in the Property column of the row.
+            1. Let _property_ be the name given in the Property column of the current row.
             1. If _options_ has a field [[&lt;_property_&gt;]], let _optionsProp_ be _options_.[[&lt;_property_&gt;]]; else let _optionsProp_ be *undefined*.
             1. If _format_ has a field [[&lt;_property_&gt;]], let _formatProp_ be _format_.[[&lt;_property_&gt;]]; else let _formatProp_ be *undefined*.
             1. If _optionsProp_ is *undefined* and _formatProp_ is not *undefined*, then
@@ -1027,9 +1027,9 @@
             1. Let _v_ be _dateTimeFormat_.[[TimeZone]].
             1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_. The String value may also depend on the value of the [[InDST]] field of _tm_ if _f_ is *"short"*, *"long"*, *"shortOffset"*, or *"longOffset"*. If the implementation does not have such a localized representation of _v_, then use the String value of _v_ itself.
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ matches a Property column of the row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, then
+          1. Else if _p_ matches one of the values in the Property column of <emu-xref href="#table-datetimeformat-components"></emu-xref>, then
             1. If _rangeFormatOptions_ is not *undefined*, let _f_ be the value of _rangeFormatOptions_'s field whose name matches _p_.
-            1. Else, let _f_ be the value of _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the matching row.
+            1. Else, let _f_ be the value of _dateTimeFormat_'s internal slot whose name matches the value in the Internal Slot column of the matching row.
             1. Let _v_ be the value of _tm_'s field whose name is the Internal Slot column of the matching row.
             1. If _p_ is *"year"* and _v_ &le; 0, set _v_ to 1 - _v_.
             1. If _p_ is *"month"*, set _v_ to _v_ + 1.
@@ -1155,7 +1155,7 @@
         1. Let _relevantFieldsEqual_ be *true*.
         1. Let _checkMoreFields_ be *true*.
         1. For each row of <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref>, except the header row, in table order, do
-          1. Let _fieldName_ be the name given in the Range Pattern Field column of the row.
+          1. Let _fieldName_ be the name given in the Range Pattern Field column of the current row.
           1. If _rangePatterns_ has a field [[&lt;_fieldName_&gt;]], let _rangePattern_ be _rangePatterns_.[[&lt;_fieldName_&gt;]]; else let _rangePattern_ be *undefined*.
           1. If _selectedRangePattern_ is not *undefined* and _rangePattern_ is *undefined*, then
             1. NOTE: Because there is no range pattern for differences at or below this field, no further checks will be performed.


### PR DESCRIPTION
Used "of the current row" instead of "of the row" when appropriate, to match rest of 402, also fixed unclear wording for FormatDateTimePattern instruction 15.f
