### PR TITLE
Editorial: Remove the use of "dataLocale" throughout the spec

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -74,7 +74,7 @@
           1. If _usage_ is *"sort"*, then
             1. Set _sensitivity_ to *"variant"*.
           1. Else,
-            1. Let _dataLocale_ be _r_.[[dataLocale]].
+            1. Let _dataLocale_ be GetLocaleBaseName(_r_.[[locale]]).
             1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
             1. Set _sensitivity_ to _dataLocaleData_.[[sensitivity]].
         1. Set _collator_.[[Sensitivity]] to _sensitivity_.

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -74,9 +74,9 @@
           1. If _usage_ is *"sort"*, then
             1. Set _sensitivity_ to *"variant"*.
           1. Else,
-            1. Let _dataLocale_ be GetLocaleBaseName(_r_.[[locale]]).
-            1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-            1. Set _sensitivity_ to _dataLocaleData_.[[sensitivity]].
+            1. Let _resolvedLocaleBaseName_ be GetLocaleBaseName(_r_.[[locale]]).
+            1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_resolvedLocaleBaseName_&gt;]].
+            1. Set _sensitivity_ to _resolvedLocaleData_.[[sensitivity]].
         1. Set _collator_.[[Sensitivity]] to _sensitivity_.
         1. Let _ignorePunctuation_ be ? GetOption(_options_, *"ignorePunctuation"*, ~boolean~, ~empty~, *false*).
         1. Set _collator_.[[IgnorePunctuation]] to _ignorePunctuation_.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -85,7 +85,7 @@
         1. Let _resolvedCalendar_ be _r_.[[ca]].
         1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _dataLocale_ be _r_.[[dataLocale]].
+        1. Let _dataLocale_ be GetLocaleBaseName(_r_.[[locale]]).
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. If _hour12_ is *true*, then
           1. Let _hc_ be _dataLocaleData_.[[hourCycle12]].

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -85,16 +85,16 @@
         1. Let _resolvedCalendar_ be _r_.[[ca]].
         1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.
         1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _dataLocale_ be GetLocaleBaseName(_r_.[[locale]]).
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _resolvedLocaleBaseName_ be GetLocaleBaseName(_r_.[[locale]]).
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_resolvedLocaleBaseName_&gt;]].
         1. If _hour12_ is *true*, then
-          1. Let _hc_ be _dataLocaleData_.[[hourCycle12]].
+          1. Let _hc_ be _resolvedLocaleData_.[[hourCycle12]].
         1. Else if _hour12_ is *false*, then
-          1. Let _hc_ be _dataLocaleData_.[[hourCycle24]].
+          1. Let _hc_ be _resolvedLocaleData_.[[hourCycle24]].
         1. Else,
           1. Assert: _hour12_ is *undefined*.
           1. Let _hc_ be _r_.[[hc]].
-          1. If _hc_ is *null*, set _hc_ to _dataLocaleData_.[[hourCycle]].
+          1. If _hc_ is *null*, set _hc_ to _resolvedLocaleData_.[[hourCycle]].
         1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then
@@ -139,7 +139,7 @@
             1. Throw a *TypeError* exception.
           1. If _required_ is ~time~ and _dateStyle_ is not *undefined*, then
             1. Throw a *TypeError* exception.
-          1. Let _styles_ be _dataLocaleData_.[[styles]].[[&lt;_resolvedCalendar_&gt;]].
+          1. Let _styles_ be _resolvedLocaleData_.[[styles]].[[&lt;_resolvedCalendar_&gt;]].
           1. Let _bestFormat_ be DateTimeStyleFormat(_dateStyle_, _timeStyle_, _styles_).
         1. Else,
           1. Let _needDefaults_ be *true*.
@@ -157,7 +157,7 @@
           1. If _needDefaults_ is *true* and _defaults_ is either ~time~ or ~all~, then
             1. For each property name _prop_ of &laquo; *"hour"*, *"minute"*, *"second"* &raquo;, do
               1. Set _formatOptions_.[[&lt;_prop_&gt;]] to *"numeric"*.
-          1. Let _formats_ be _dataLocaleData_.[[formats]].[[&lt;_resolvedCalendar_&gt;]].
+          1. Let _formats_ be _resolvedLocaleData_.[[formats]].[[&lt;_resolvedCalendar_&gt;]].
           1. If _formatMatcher_ is *"basic"*, then
             1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
           1. Else,

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -34,7 +34,7 @@
         1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, &laquo; *"code"*, *"none"* &raquo;, *"code"*).
         1. Set _displayNames_.[[Fallback]] to _fallback_.
         1. Set _displayNames_.[[Locale]] to _r_.[[locale]].
-        1. Let _dataLocale_ be _r_.[[dataLocale]].
+        1. Let _dataLocale_ be GetLocaleBaseName(_r_.[[locale]]).
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _types_ be _dataLocaleData_.[[types]].
         1. Assert: _types_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -34,9 +34,9 @@
         1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, &laquo; *"code"*, *"none"* &raquo;, *"code"*).
         1. Set _displayNames_.[[Fallback]] to _fallback_.
         1. Set _displayNames_.[[Locale]] to _r_.[[locale]].
-        1. Let _dataLocale_ be GetLocaleBaseName(_r_.[[locale]]).
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _types_ be _dataLocaleData_.[[types]].
+        1. Let _resolvedLocaleBaseName_ be GetLocaleBaseName(_r_.[[locale]]).
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_resolvedLocaleBaseName_&gt;]].
+        1. Let _types_ be _resolvedLocaleData_.[[types]].
         1. Assert: _types_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, ~string~, &laquo; *"dialect"*, *"standard"* &raquo;, *"dialect"*).
         1. Let _typeFields_ be _types_.[[&lt;_type_&gt;]].

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -30,10 +30,10 @@
         1. Set _listFormat_.[[Type]] to _type_.
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _listFormat_.[[Style]] to _style_.
-        1. Let _dataLocale_ be GetLocaleBaseName(_r_.[[locale]]).
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _dataLocaleTypes_ be _dataLocaleData_.[[&lt;_type_&gt;]].
-        1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[&lt;_style_&gt;]].
+        1. Let _resolvedLocaleBaseName_ be GetLocaleBaseName(_r_.[[locale]]).
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_resolvedLocaleBaseName_&gt;]].
+        1. Let _resolvedLocaleTypes_ be _resolvedLocaleData_.[[&lt;_type_&gt;]].
+        1. Set _listFormat_.[[Templates]] to _resolvedLocaleTypes_.[[&lt;_style_&gt;]].
         1. Return _listFormat_.
       </emu-alg>
     </emu-clause>

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -30,7 +30,7 @@
         1. Set _listFormat_.[[Type]] to _type_.
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _listFormat_.[[Style]] to _style_.
-        1. Let _dataLocale_ be _r_.[[dataLocale]].
+        1. Let _dataLocale_ be GetLocaleBaseName(_r_.[[locale]]).
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _dataLocaleTypes_ be _dataLocaleData_.[[&lt;_type_&gt;]].
         1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[&lt;_style_&gt;]].

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -90,16 +90,16 @@
           1. If _region_ cannot be matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal, throw a *RangeError* exception.
         1. Set _tag_ to CanonicalizeUnicodeLocaleId(_tag_).
         1. Assert: _tag_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
-        1. Let _languageId_ be the longest prefix of _tag_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
-        1. If _language_ is *undefined*, set _language_ to GetLocaleLanguage(_languageId_).
-        1. If _script_ is *undefined*, set _script_ to GetLocaleScript(_languageId_).
-        1. If _region_ is *undefined*, set _region_ to GetLocaleRegion(_languageId_).
-        1. Let _variants_ be GetLocaleVariants(_languageId_).
-        1. Set _languageId_ to _language_.
-        1. If _script_ is not *undefined*, set _languageId_ to the string-concatenation of _languageId_, *"-"*, and _script_.
-        1. If _region_ is not *undefined*, set _languageId_ to the string-concatenation of _languageId_, *"-"*, and _region_.
-        1. If _variants_ is not *undefined*, set _languageId_ to the string-concatenation of _languageId_, *"-"*, and _variants_.
-        1. Set _tag_ to _tag_ with the <emu-not-ref>substring</emu-not-ref> matched by the <code>unicode_language_id</code> Unicode locale nonterminal replaced by the string _languageId_.
+        1. Let _baseName_ be GetLocaleBaseName(_tag_).
+        1. If _language_ is *undefined*, set _language_ to GetLocaleLanguage(_baseName_).
+        1. If _script_ is *undefined*, set _script_ to GetLocaleScript(_baseName_).
+        1. If _region_ is *undefined*, set _region_ to GetLocaleRegion(_baseName_).
+        1. Let _variants_ be GetLocaleVariants(_baseName_).
+        1. Set _baseName_ to _language_.
+        1. If _script_ is not *undefined*, set _baseName_ to the string-concatenation of _baseName_, *"-"*, and _script_.
+        1. If _region_ is not *undefined*, set _baseName_ to the string-concatenation of _baseName_, *"-"*, and _region_.
+        1. If _variants_ is not *undefined*, set _baseName_ to the string-concatenation of _baseName_, *"-"*, and _variants_.
+        1. Set _tag_ to _tag_ with the <emu-not-ref>substring</emu-not-ref> matched by the <code>unicode_language_id</code> Unicode locale nonterminal replaced by the string _baseName_.
         1. Return CanonicalizeUnicodeLocaleId(_tag_).
       </emu-alg>
     </emu-clause>
@@ -244,8 +244,7 @@
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
-        1. Let _locale_ be _loc_.[[Locale]].
-        1. Return the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
+        1. Return GetLocaleBaseName(_loc_.[[Locale]]).
       </emu-alg>
     </emu-clause>
 
@@ -371,6 +370,20 @@
   <emu-clause id="sec-intl-locale-abstracts">
     <h1>Abstract Operations for Locale Objects</h1>
 
+    <emu-clause id="sec-getlocalebasename" type="abstract operation">
+      <h1>
+        GetLocaleBaseName (
+          _locale_: a String,
+        ): a String
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Assert: _locale_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
+        1. Return the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-getlocalelanguage" type="abstract operation">
       <h1>
         GetLocaleLanguage (
@@ -380,10 +393,9 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _locale_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
-        1. Let _languageId_ be the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
-        1. Assert: The first subtag of _languageId_ can be matched by the <code>unicode_language_subtag</code> Unicode locale nonterminal.
-        1. Return the first subtag of _languageId_.
+        1. Let _baseName_ be GetLocaleBaseName(_locale_).
+        1. Assert: The first subtag of _baseName_ can be matched by the <code>unicode_language_subtag</code> Unicode locale nonterminal.
+        1. Return the first subtag of _baseName_.
       </emu-alg>
     </emu-clause>
 
@@ -396,10 +408,9 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _locale_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
-        1. Let _languageId_ be the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
-        1. Assert: _languageId_ contains at most one subtag that can be matched by the <code>unicode_script_subtag</code> Unicode locale nonterminal.
-        1. If _languageId_ contains a subtag matched by the <code>unicode_script_subtag</code> Unicode locale nonterminal, return that subtag.
+        1. Let _baseName_ be GetLocaleBaseName(_locale_).
+        1. Assert: _baseName_ contains at most one subtag that can be matched by the <code>unicode_script_subtag</code> Unicode locale nonterminal.
+        1. If _baseName_ contains a subtag matched by the <code>unicode_script_subtag</code> Unicode locale nonterminal, return that subtag.
         1. Return *undefined*.
       </emu-alg>
     </emu-clause>
@@ -413,13 +424,12 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _locale_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
-        1. Let _languageId_ be the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
+        1. Let _baseName_ be GetLocaleBaseName(_locale_).
         1. NOTE: A <code>unicode_region_subtag</code> subtag is only valid immediately after an initial <code>unicode_language_subtag</code> subtag, optionally with a single <code>unicode_script_subtag</code> subtag between them. In that position, <code>unicode_region_subtag</code> cannot be confused with any other valid subtag because all their productions are disjoint.
-        1. Assert: The first subtag of _languageId_ can be matched by the <code>unicode_language_subtag</code> Unicode locale nonterminal.
-        1. Let _languageIdTail_ be the suffix of _languageId_ following the first subtag.
-        1. Assert: _languageIdTail_ contains at most one subtag that can be matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal.
-        1. If _languageIdTail_ contains a subtag matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal, return that subtag.
+        1. Assert: The first subtag of _baseName_ can be matched by the <code>unicode_language_subtag</code> Unicode locale nonterminal.
+        1. Let _baseNameTail_ be the suffix of _baseName_ following the first subtag.
+        1. Assert: _baseNameTail_ contains at most one subtag that can be matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal.
+        1. If _baseNameTail_ contains a subtag matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal, return that subtag.
         1. Return *undefined*.
       </emu-alg>
     </emu-clause>
@@ -433,9 +443,8 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _locale_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
-        1. Let _languageId_ be the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
-        1. If there is a non-empty suffix of _languageId_ that is a consecutive sequence of <emu-not-ref>substrings</emu-not-ref> in which each element is a *"-"* followed by a <emu-not-ref>substring</emu-not-ref> that is matched by the <code>unicode_variant_subtag</code> Unicode locale nonterminal, then
+        1. Let _baseName_ be GetLocaleBaseName(_locale_).
+        1. If there is a non-empty suffix of _baseName_ that is a consecutive sequence of <emu-not-ref>substrings</emu-not-ref> in which each element is a *"-"* followed by a <emu-not-ref>substring</emu-not-ref> that is matched by the <code>unicode_variant_subtag</code> Unicode locale nonterminal, then
           1. Let _variants_ be the longest such suffix.
           1. Return the substring of _variants_ from 1.
         1. Return *undefined*.

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -57,11 +57,11 @@
         1. Let _lowerLocale_ be the ASCII-lowercase of _locale_.
         1. If _lowerLocale_ cannot be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal, return *false*.
         1. If _lowerLocale_ uses any of the backwards compatibility syntax described in <a href="https://unicode.org/reports/tr35/#BCP_47_Conformance">Unicode Technical Standard #35 Part 1 Core, Section 3.3 BCP 47 Conformance</a>, return *false*.
-        1. Let _languageId_ be the longest prefix of _lowerLocale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
-        1. Let _variants_ be GetLocaleVariants(_languageId_).
+        1. Let _baseName_ be GetLocaleBaseName(_lowerLocale_).
+        1. Let _variants_ be GetLocaleVariants(_baseName_).
         1. If _variants_ is not *undefined*, then
           1. If _variants_ contains any duplicate subtags, return *false*.
-        1. Let _allExtensions_ be the suffix of _lowerLocale_ following _languageId_.
+        1. Let _allExtensions_ be the suffix of _lowerLocale_ following _baseName_.
         1. If _allExtensions_ contains a <emu-not-ref>substring</emu-not-ref> matched by the <code>pu_extensions</code> Unicode locale nonterminal, let _extensions_ be the prefix of _allExtensions_ preceding the longest such <emu-not-ref>substring</emu-not-ref>. Otherwise, let _extensions_ be _allExtensions_.
         1. If _extensions_ is not the empty String, then
           1. If _extensions_ contains any duplicate singleton subtags, return *false*.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -225,7 +225,6 @@
           1. Let _r_ be BestFitMatcher(_availableLocales_, _requestedLocales_).
         1. Let _foundLocale_ be _r_.[[locale]].
         1. Let _result_ be a new Record.
-        1. Set _result_.[[dataLocale]] to _foundLocale_.
         1. If _r_.[[extension]] is not ~empty~, then
           1. Let _components_ be UnicodeExtensionComponents(_r_.[[extension]]).
           1. Let _keywords_ be _components_.[[Keywords]].

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -17,7 +17,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[DataLocale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
+        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
         1. Perform ? InitializeNumberFormat(_numberFormat_, _locales_, _options_).
         1. If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then
           1. Let _this_ be the *this* value.
@@ -71,7 +71,6 @@
         1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%Intl.NumberFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.NumberFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Set _numberFormat_.[[Locale]] to _r_.[[locale]].
-        1. Set _numberFormat_.[[DataLocale]] to _r_.[[dataLocale]].
         1. Set _numberFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Perform ? SetNumberFormatUnitOptions(_numberFormat_, _options_).
         1. Let _style_ be _numberFormat_.[[Style]].
@@ -572,7 +571,6 @@
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[DataLocale]] is a String value with the language tag of the nearest locale for which the implementation has data to perform the formatting operation. It will be a parent locale of [[Locale]].</li>
       <li>[[NumberingSystem]] is a String value with the "type" given in <a href="https://unicode.org/reports/tr35/#Key_And_Type_Definitions_">Unicode Technical Standard #35 Part 1 Core, Section 3.6.1 Key and Type Definitions</a> for the numbering system used for formatting.</li>
       <li>[[Style]] is one of the String values *"decimal"*, *"currency"*, *"percent"*, or *"unit"*, identifying the type of quantity being measured.</li>
       <li>[[Currency]] is a String value with the currency code identifying the currency to be used if formatting with the *"currency"* unit type. It is only used when [[Style]] has the value *"currency"*.</li>
@@ -1460,7 +1458,7 @@
       </dl>
       <emu-alg>
         1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
-        1. Let _dataLocale_ be _numberFormat_.[[DataLocale]].
+        1. Let _dataLocale_ be GetLocaleBaseName(_numberFormat_.[[Locale]]).
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _patterns_ be _dataLocaleData_.[[patterns]].
         1. Assert: _patterns_ is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
@@ -1549,7 +1547,7 @@
       </dl>
       <emu-alg>
         1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
-        1. Let _dataLocale_ be _numberFormat_.[[DataLocale]].
+        1. Let _dataLocale_ be GetLocaleBaseName(_numberFormat_.[[Locale]]).
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _notationSubPatterns_ be _dataLocaleData_.[[notationSubPatterns]].
         1. Assert: _notationSubPatterns_ is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1458,9 +1458,9 @@
       </dl>
       <emu-alg>
         1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
-        1. Let _dataLocale_ be GetLocaleBaseName(_numberFormat_.[[Locale]]).
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _patterns_ be _dataLocaleData_.[[patterns]].
+        1. Let _resolvedLocaleBaseName_ be GetLocaleBaseName(_numberFormat_.[[Locale]]).
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_resolvedLocaleBaseName_&gt;]].
+        1. Let _patterns_ be _resolvedLocaleData_.[[patterns]].
         1. Assert: _patterns_ is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
         1. Let _style_ be _numberFormat_.[[Style]].
         1. If _style_ is *"percent"*, then
@@ -1547,9 +1547,9 @@
       </dl>
       <emu-alg>
         1. Let _localeData_ be %Intl.NumberFormat%.[[LocaleData]].
-        1. Let _dataLocale_ be GetLocaleBaseName(_numberFormat_.[[Locale]]).
-        1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
-        1. Let _notationSubPatterns_ be _dataLocaleData_.[[notationSubPatterns]].
+        1. Let _resolvedLocaleBaseName_ be GetLocaleBaseName(_numberFormat_.[[Locale]]).
+        1. Let _resolvedLocaleData_ be _localeData_.[[&lt;_resolvedLocaleBaseName_&gt;]].
+        1. Let _notationSubPatterns_ be _resolvedLocaleData_.[[notationSubPatterns]].
         1. Assert: _notationSubPatterns_ is a Record (see <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref>).
         1. Let _notation_ be _numberFormat_.[[Notation]].
         1. If _notation_ is *"scientific"* or _notation_ is *"engineering"*, then

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -17,7 +17,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.RelativeTimeFormat.prototype%"*, &laquo; [[InitializedRelativeTimeFormat]], [[Locale]], [[DataLocale]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] &raquo;).
+        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.RelativeTimeFormat.prototype%"*, &laquo; [[InitializedRelativeTimeFormat]], [[Locale]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] &raquo;).
         1. Return ? InitializeRelativeTimeFormat(_relativeTimeFormat_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -50,7 +50,6 @@
         1. Let _r_ be ResolveLocale(%Intl.RelativeTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.RelativeTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Let _locale_ be _r_.[[locale]].
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
-        1. Set _relativeTimeFormat_.[[DataLocale]] to _r_.[[dataLocale]].
         1. Set _relativeTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
         1. Set _relativeTimeFormat_.[[Style]] to _style_.
@@ -256,7 +255,6 @@
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[DataLocale]] is a String value with the language tag of the nearest locale for which the implementation has data to perform the formatting operation. It will be a parent locale of [[Locale]].</li>
       <li>[[Style]] is one of the String values *"long"*, *"short"*, or *"narrow"*, identifying the relative time format style used.</li>
       <li>[[Numeric]] is one of the String values *"always"* or *"auto"*, identifying whether numerical descriptions are always used, or used only when no more specific version is available (e.g., "1 day ago" vs "yesterday").</li>
       <li>[[NumberFormat]] is an Intl.NumberFormat object used for formatting.</li>
@@ -310,7 +308,7 @@
         1. If _value_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Let _unit_ be ? SingularRelativeTimeUnit(_unit_).
         1. Let _localeData_ be %Intl.RelativeTimeFormat%.[[LocaleData]].
-        1. Let _dataLocale_ be _relativeTimeFormat_.[[DataLocale]].
+        1. Let _dataLocale_ be GetLocaleBaseName(_relativeTimeFormat_.[[Locale]]).
         1. Let _fields_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _style_ be _relativeTimeFormat_.[[Style]].
         1. If _style_ is equal to *"short"*, then

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -308,8 +308,8 @@
         1. If _value_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Let _unit_ be ? SingularRelativeTimeUnit(_unit_).
         1. Let _localeData_ be %Intl.RelativeTimeFormat%.[[LocaleData]].
-        1. Let _dataLocale_ be GetLocaleBaseName(_relativeTimeFormat_.[[Locale]]).
-        1. Let _fields_ be _localeData_.[[&lt;_dataLocale_&gt;]].
+        1. Let _resolvedLocaleBaseName_ be GetLocaleBaseName(_relativeTimeFormat_.[[Locale]]).
+        1. Let _fields_ be _localeData_.[[&lt;_resolvedLocaleBaseName_&gt;]].
         1. Let _style_ be _relativeTimeFormat_.[[Style]].
         1. If _style_ is equal to *"short"*, then
           1. Let _entry_ be the string-concatenation of _unit_ and *"-short"*.


### PR DESCRIPTION
This is a possible alternative for #849 to discuss if we should remove the term "dataLocale" from the spec.