### PR TITLE
Meta: publish biblio in github actions

### DIFF
--- a/.github/workflows/publish-biblio.yml
+++ b/.github/workflows/publish-biblio.yml
@@ -1,0 +1,32 @@
+name: 'ecma-402-biblio'
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: 'publish ecma402-biblio'
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'tc39/ecma402' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish biblio
+        run: scripts/publish-biblio.sh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_FOR_TC39_USER }}

--- a/biblio/README.md
+++ b/biblio/README.md
@@ -1,0 +1,9 @@
+# ECMA-402 Bibliography
+
+This package, available on npm as `@tc39/ecma402-biblio`, contains a machine-readable representation of the terms, clauses, grammar, and abstract operations defined in ECMA-402. This will primarily be of use to people working with the specification itself.
+
+If added as a dependency to a project using ecmarkup, you can load it by passing `--load-biblio @tc39/ecma402-biblio`.
+
+It is automatically updated whenever ECMA-402 is. It is inherently unstable: editorial changes to the specification may add, remove, or modify the biblio, which may break your build (for example, if using ecmarkup with `--lint-spec --strict`). As such, **the usual semver guarantees do not hold**. You should pin a precise version of this package.
+
+Major version bumps may be used for breaking changes to the format of the biblio itself. Minor version bumps may be used for non-breaking additions to the biblio format.

--- a/biblio/package.json
+++ b/biblio/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tc39/ecma402-biblio",
+  "version": "VERSIONED-DURING-PUBLISH",
+  "commit": "POPULATED-DURING-PUBLISH",
+  "description": "Machine-readable representation of the internals of the ecma-402 spec",
+  "keywords": [
+    "ecmascript"
+  ],
+  "author": "TC39",
+  "main": "biblio.json",
+  "exports": {
+    ".": "./biblio.json",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "biblio.json"
+  ],
+  "license": "SEE LICENSE IN LICENSE.md"
+}

--- a/scripts/publish-biblio.sh
+++ b/scripts/publish-biblio.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+
+npx ecmarkup --verbose spec.html --write-biblio biblio/biblio.json /dev/null
+
+cp LICENSE.md biblio/
+
+cd biblio
+
+COMMIT_COUNT=$(git rev-list --count HEAD)
+npm version --no-git-tag-version "2.1.${COMMIT_COUNT}"
+
+SHORT_COMMIT=$(git rev-parse --short HEAD)
+LONG_COMMIT=$(git rev-parse --verify HEAD)
+echo "
+This version was built from commit [${SHORT_COMMIT}](https://github.com/tc39/ecma402/tree/${LONG_COMMIT})." >> README.md
+
+npm pkg set commit="${LONG_COMMIT}"
+
+npm publish --access public


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma402/issues/710. This is just a copy-paste of the relevant files from ecma262 with a find-replace of 262 with 402. It also adds a `LICENSE.md` to the top level of the repo so that it can use the same license for the published biblio package.

In the linked issue @ljharb said he'd need to publish it manually first, but I'm not sure why; I think automation tokens can publish the first version of a package?