### PR TITLE
Editorial: Document that DefaultLocale() returns must not include a "-u-" extension

### DIFF
--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -118,7 +118,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The returned String value represents the structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizeunicodelocaleid"></emu-xref>) language tag for the host environment's current locale.</dd>
+        <dd>The returned String value represents the structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizeunicodelocaleid"></emu-xref>) language tag for the host environment's current locale. It must not contain a Unicode locale extension sequence.</dd>
       </dl>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This is already required:
* LookupMatcher can return { [[locale]]: DefaultLocale(), ... }.
* ResolveLocale uses that result's [[locale]] as the name of a field in its _localeData_ argument and asserts that the corresponding value is a Record.
* The _localeData_ argument to ResolveLocale is generally provided from the value of a service constructor's [[LocaleData]] slot.
* "Internal slots of Service Constructors" constrains those slots to be Records "that have fields for each locale contained in [[AvailableLocales]]", and constrains their [[AvailableLocales]] slots to include only language tags that "must not have a Unicode locale extension sequence".

Therefore, if DefaultLocale() *were* to return a value with a Unicode locale extension sequence, use of it in ResolveLocale would fail to find the required Record at a field with that name in e.g. the service constructor's [[LocaleData]].

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
