### PR TITLE
Editorial: Better align BestAvailableLocale with BCP 47

### DIFF
--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -92,7 +92,8 @@
         1. Repeat,
           1. If _availableLocales_ contains _candidate_, return _candidate_.
           1. Let _pos_ be the index into _candidate_ of the last occurrence of *"-"* (code unit 0x002D HYPHEN-MINUS). If that character does not occur, return *undefined*.
-          1. If _pos_ &ge; 2 and the substring of _candidate_ from _pos_ - 2 to _pos_ - 1 is *"-"*, set _pos_ to _pos_ - 2.
+          1. Repeat, while _pos_ &ge; 2 and the substring of _candidate_ from _pos_ - 2 to _pos_ - 1 is *"-"*,
+            1. Set _pos_ to _pos_ - 2.
           1. Set _candidate_ to the substring of _candidate_ from 0 to _pos_.
       </emu-alg>
 

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -91,9 +91,9 @@
         1. Let _candidate_ be _locale_.
         1. Repeat,
           1. If _availableLocales_ contains _candidate_, return _candidate_.
-          1. Let _pos_ be the character index of the last occurrence of *"-"* (U+002D) within _candidate_. If that character does not occur, return *undefined*.
-          1. If _pos_ &ge; 2 and the character *"-"* occurs at index _pos_ - 2 of candidate, set _pos_ to _pos_ - 2.
-          1. Set _candidate_ to the substring of _candidate_ from position 0, inclusive, to position _pos_, exclusive.
+          1. Let _pos_ be the index into _candidate_ of the last occurrence of *"-"* (code unit 0x002D HYPHEN-MINUS). If that character does not occur, return *undefined*.
+          1. If _pos_ &ge; 2 and the substring of _candidate_ from _pos_ - 2 to _pos_ - 1 is *"-"*, set _pos_ to _pos_ - 2.
+          1. Set _candidate_ to the substring of _candidate_ from 0 to _pos_.
       </emu-alg>
 
       <emu-note>


### PR DESCRIPTION
Per [RFC 4647 section 3.4 - Lookup](https://www.rfc-editor.org/rfc/rfc4647.html#section-3.4),
> Single letter or digit subtags (including both the letter 'x', which introduces private-use sequences, and the subtags that introduce extensions) are removed at the same time as their closest trailing subtag.

This is relevant for a requested locale such as "en-x-y-z-foo", which should be truncated first to "en-x-y-z" and then to "en" ("y" is removed at the same time as its closest trailing subtag "z" and "x" is removed at the same time as its closest trailing subtag "y", which means all three are removed in one step).

However, the change is still editorial because BestAvailableLocale is never called with _availableLocales_ that would contain a language tag like "en-x-y".