### PR TITLE
Editorial: Refactor Locale and Parameter Negotiation to better align with BCP 47

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -21,9 +21,6 @@
         <li>
           The BestFitMatcher algorithm (<emu-xref href="#sec-bestfitmatcher"></emu-xref>)
         </li>
-        <li>
-          The BestFitSupportedLocales algorithm (<emu-xref href="#sec-bestfitsupportedlocales"></emu-xref>)
-        </li>
       </ul>
     </li>
     <li>

--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -19,7 +19,7 @@
           The set of available locales for each constructor (<emu-xref href="#sec-internal-slots"></emu-xref>)
         </li>
         <li>
-          The BestFitMatcher algorithm (<emu-xref href="#sec-bestfitmatcher"></emu-xref>)
+          The LookupMatchingLocaleByBestFit algorithm (<emu-xref href="#sec-lookupmatchinglocalebybestfit"></emu-xref>)
         </li>
       </ul>
     </li>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -118,7 +118,7 @@
       <emu-alg>
         1. Let _availableLocales_ be %Intl.Collator%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
+        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -229,7 +229,7 @@
       <emu-alg>
         1. Let _availableLocales_ be %Intl.DateTimeFormat%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
+        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -79,7 +79,7 @@
       <emu-alg>
         1. Let _availableLocales_ be %Intl.DisplayNames%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
+        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -65,7 +65,7 @@
       <emu-alg>
         1. Let _availableLocales_ be %Intl.ListFormat%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
+        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -80,7 +80,7 @@
           1. Else,
             1. Let _requestedLocale_ be DefaultLocale().
           1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with any Unicode locale extension sequences removed.
-          1. Let _availableLocales_ be a List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
+          1. Let _availableLocales_ be an Available Locales List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
           1. Let _locale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
           1. If _locale_ is *undefined*, set _locale_ to *"und"*.
           1. Let _codePoints_ be StringToCodePoints(_S_).

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -81,7 +81,7 @@
             1. Let _requestedLocale_ be DefaultLocale().
           1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with any Unicode locale extension sequences removed.
           1. Let _availableLocales_ be an Available Locales List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
-          1. Let _match_ be LookupMatcher(_availableLocales_, _noExtensionsLocale_).
+          1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, _noExtensionsLocale_).
           1. If _match_ is not *undefined*, let _locale_ be _match_.[[locale]]; else let _locale_ be *"und"*.
           1. Let _codePoints_ be StringToCodePoints(_S_).
           1. If _targetCase_ is ~lower~, then

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -81,8 +81,8 @@
             1. Let _requestedLocale_ be DefaultLocale().
           1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with any Unicode locale extension sequences removed.
           1. Let _availableLocales_ be an Available Locales List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
-          1. Let _locale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
-          1. If _locale_ is *undefined*, set _locale_ to *"und"*.
+          1. Let _match_ be LookupMatcher(_availableLocales_, _noExtensionsLocale_).
+          1. If _match_ is not *undefined*, let _locale_ be _match_.[[locale]]; else let _locale_ be *"und"*.
           1. Let _codePoints_ be StringToCodePoints(_S_).
           1. If _targetCase_ is ~lower~, then
             1. Let _newCodePoints_ be a List whose elements are the result of a lowercase transformation of _codePoints_ according to an implementation-derived algorithm using _locale_ or the Unicode Default Case Conversion algorithm.

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -80,7 +80,7 @@
           1. Else,
             1. Let _requestedLocale_ be DefaultLocale().
           1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with any Unicode locale extension sequences removed.
-          1. Let _availableLocales_ be an Available Locales List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
+          1. Let _availableLocales_ be an Available Locales List which includes the language tags for which the Unicode Character Database contains language-sensitive case mappings. If the implementation supports additional locale-sensitive case mappings, _availableLocales_ should also include their corresponding language tags.
           1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, _noExtensionsLocale_).
           1. If _match_ is not *undefined*, let _locale_ be _match_.[[locale]]; else let _locale_ be *"und"*.
           1. Let _codePoints_ be StringToCodePoints(_S_).

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -85,9 +85,9 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-lookupmatcher" type="abstract operation" oldids="sec-bestavailablelocale">
+    <emu-clause id="sec-lookupmatchinglocalebyprefix" type="abstract operation" oldids="sec-bestavailablelocale,sec-lookupmatcher">
       <h1>
-        LookupMatcher (
+        LookupMatchingLocaleByPrefix (
           _availableLocales_: an Available Locales List,
           _requestedLocales_: a language priority list,
         ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~) or *undefined*
@@ -117,16 +117,16 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-bestfitmatcher" type="implementation-defined abstract operation">
+    <emu-clause id="sec-lookupmatchinglocalebybestfit" type="implementation-defined abstract operation" oldids="sec-bestfitmatcher">
       <h1>
-        BestFitMatcher (
+        LookupMatchingLocaleByBestFit (
           _availableLocales_: an Available Locales List,
           _requestedLocales_: a language priority list,
         ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~) or *undefined*
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines the best element of _availableLocales_ for satisfying _requestedLocales_, ignoring Unicode locale extension sequences. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would consider at least as good as those produced by the LookupMatcher algorithm. If a non-default match is found, it returns a Record with a [[locale]] field containing the matching language tag from _availableLocales_ and an [[extension]] field containing the Unicode locale extension sequence of the corresponding element of _requestedLocales_ (or ~empty~ if requested language tag has no such sequence).</dd>
+        <dd>It determines the best element of _availableLocales_ for satisfying _requestedLocales_, ignoring Unicode locale extension sequences. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would consider at least as good as those produced by the LookupMatchingLocaleByPrefix algorithm. If a non-default match is found, it returns a Record with a [[locale]] field containing the matching language tag from _availableLocales_ and an [[extension]] field containing the Unicode locale extension sequence of the corresponding element of _requestedLocales_ (or ~empty~ if requested language tag has no such sequence).</dd>
       </dl>
     </emu-clause>
 
@@ -205,14 +205,14 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It performs "lookup" as defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3">RFC 4647 section 3</a>, determining the best element of _availableLocales_ for satisfying _requestedLocales_ using either the BestFitMatcher algorithm or LookupMatcher algorithm as specified by _options_.[[localeMatcher]], ignoring Unicode locale extension sequences, and returning a representation of the match that also includes corresponding data from _localeData_ and a resolved value for each element of _relevantExtensionKeys_ (defaulting to data from the matched locale, superseded by data from the requested Unicode locale extension sequence if present and then by data from _options_ if present). If the matched element from _requestedLocales_ contains a Unicode locale extension sequence, it is copied onto the language tag in the [[Locale]] field of the returned Record, omitting any <code>keyword</code> Unicode locale nonterminal whose <code>key</code> value is not contained within _relevantExtensionKeys_ or <code>type</code> value is superseded by a different value from _options_.</dd>
+        <dd>It performs "lookup" as defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3">RFC 4647 section 3</a>, determining the best element of _availableLocales_ for satisfying _requestedLocales_ using either the LookupMatchingLocaleByBestFit algorithm or LookupMatchingLocaleByPrefix algorithm as specified by _options_.[[localeMatcher]], ignoring Unicode locale extension sequences, and returning a representation of the match that also includes corresponding data from _localeData_ and a resolved value for each element of _relevantExtensionKeys_ (defaulting to data from the matched locale, superseded by data from the requested Unicode locale extension sequence if present and then by data from _options_ if present). If the matched element from _requestedLocales_ contains a Unicode locale extension sequence, it is copied onto the language tag in the [[Locale]] field of the returned Record, omitting any <code>keyword</code> Unicode locale nonterminal whose <code>key</code> value is not contained within _relevantExtensionKeys_ or <code>type</code> value is superseded by a different value from _options_.</dd>
       </dl>
       <emu-alg>
         1. Let _matcher_ be _options_.[[localeMatcher]].
         1. If _matcher_ is *"lookup"*, then
-          1. Let _r_ be LookupMatcher(_availableLocales_, _requestedLocales_).
+          1. Let _r_ be LookupMatchingLocaleByPrefix(_availableLocales_, _requestedLocales_).
         1. Else,
-          1. Let _r_ be BestFitMatcher(_availableLocales_, _requestedLocales_).
+          1. Let _r_ be LookupMatchingLocaleByBestFit(_availableLocales_, _requestedLocales_).
         1. If _r_ is *undefined*, set _r_ to the Record { [[locale]]: DefaultLocale(), [[extension]]: ~empty~ }.
         1. Let _foundLocale_ be _r_.[[locale]].
         1. Let _foundLocaleData_ be _localeData_.[[&lt;_foundLocale_&gt;]].
@@ -273,7 +273,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It performs "filtering" as defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3">RFC 4647 section 3</a>, returning the elements of _requestedLocales_ for which _availableLocales_ contains a matching locale when using either the BestFitMatcher algorithm or LookupMatcher algorithm as specified in _options_, preserving their relative order.</dd>
+        <dd>It performs "filtering" as defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3">RFC 4647 section 3</a>, returning the elements of _requestedLocales_ for which _availableLocales_ contains a matching locale when using either the LookupMatchingLocaleByBestFit algorithm or LookupMatchingLocaleByPrefix algorithm as specified in _options_, preserving their relative order.</dd>
       </dl>
       <emu-alg>
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
@@ -282,9 +282,9 @@
         1. For each element _locale_ of _requestedLocales_, do
           1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
           1. If _matcher_ is *"lookup"*, then
-            1. Let _match_ be LookupMatcher(_availableLocales_, _noExtensionsLocale_).
+            1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, _noExtensionsLocale_).
           1. Else,
-            1. Let _match_ be BestFitMatcher(_availableLocales_, _noExtensionsLocale_).
+            1. Let _match_ be LookupMatchingLocaleByBestFit(_availableLocales_, _noExtensionsLocale_).
           1. If _match_ is not *undefined*, append _locale_ to _subset_.
         1. Return CreateArrayFromList(_subset_).
       </emu-alg>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -263,41 +263,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-lookupsupportedlocales" type="abstract operation">
-      <h1>
-        LookupSupportedLocales (
-          _availableLocales_: an Available Locales List,
-          _requestedLocales_: a language priority list,
-        ): a List of Unicode canonicalized locale identifiers
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns the elements of _requestedLocales_ for which _availableLocales_ has a matching locale when using the BCP 47 Lookup algorithm, preserving their relative order.</dd>
-      </dl>
-      <emu-alg>
-        1. Let _subset_ be a new empty List.
-        1. For each element _locale_ of _requestedLocales_, do
-          1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
-          1. Let _match_ be LookupMatcher(_availableLocales_, _noExtensionsLocale_).
-          1. If _match_ is not *undefined*, append _locale_ to _subset_.
-        1. Return _subset_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-bestfitsupportedlocales" type="implementation-defined abstract operation">
-      <h1>
-        BestFitSupportedLocales (
-          _availableLocales_: an Available Locales List,
-          _requestedLocales_: a language priority list,
-        ): a List of Unicode canonicalized locale identifiers
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns the elements of _requestedLocales_ for which _availableLocales_ has a matching locale when using the BestFitMatcher algorithm, preserving their relative order.</dd>
-      </dl>
-    </emu-clause>
-
-    <emu-clause id="sec-supportedlocales" type="abstract operation">
+    <emu-clause id="sec-supportedlocales" type="abstract operation" oldids="sec-lookupsupportedlocales,sec-bestfitsupportedlocales">
       <h1>
         SupportedLocales (
           _availableLocales_: an Available Locales List,
@@ -307,16 +273,20 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the elements of _requestedLocales_ for which _availableLocales_ has a matching locale when using either the BestFitMatcher algorithm or another as specified in _options_, preserving their relative order.</dd>
+        <dd>It returns the elements of _requestedLocales_ for which _availableLocales_ contains a matching locale when using either the BestFitMatcher algorithm or LookupMatcher algorithm as specified in _options_, preserving their relative order.</dd>
       </dl>
       <emu-alg>
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
-        1. If _matcher_ is *"best fit"*, then
-          1. Let _supportedLocales_ be BestFitSupportedLocales(_availableLocales_, _requestedLocales_).
-        1. Else,
-          1. Let _supportedLocales_ be LookupSupportedLocales(_availableLocales_, _requestedLocales_).
-        1. Return CreateArrayFromList(_supportedLocales_).
+        1. Let _subset_ be a new empty List.
+        1. For each element _locale_ of _requestedLocales_, do
+          1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
+          1. If _matcher_ is *"lookup"*, then
+            1. Let _match_ be LookupMatcher(_availableLocales_, _noExtensionsLocale_).
+          1. Else,
+            1. Let _match_ be BestFitMatcher(_availableLocales_, _noExtensionsLocale_).
+          1. If _match_ is not *undefined*, append _locale_ to _subset_.
+        1. Return CreateArrayFromList(_subset_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -263,9 +263,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-supportedlocales" type="abstract operation" oldids="sec-lookupsupportedlocales,sec-bestfitsupportedlocales">
+    <emu-clause id="sec-filterlocales" type="abstract operation" oldids="sec-lookupsupportedlocales,sec-bestfitsupportedlocales,sec-supportedlocales">
       <h1>
-        SupportedLocales (
+        FilterLocales (
           _availableLocales_: an Available Locales List,
           _requestedLocales_: a language priority list,
           _options_: an ECMAScript language value,

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -205,7 +205,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines the best element of _availableLocales_ for satisfying _requestedLocales_ using either the BestFitMatcher algorithm or LookupMatcher algorithm as specified by _options_.[[localeMatcher]], ignoring Unicode locale extension sequences, and returns a representation of the match that also includes corresponding data from _localeData_ and a resolved value for each element of _relevantExtensionKeys_ (defaulting to data from the matched locale, superseded by data from the requested Unicode locale extension sequence if present and then by data from _options_ if present). If the matched element from _requestedLocales_ contains a Unicode locale extension sequence, it is copied onto the language tag in the [[Locale]] field of the returned Record, omitting any <code>keyword</code> Unicode locale nonterminal whose <code>key</code> value is not contained within _relevantExtensionKeys_ or <code>type</code> value is superseded by a different value from _options_.</dd>
+        <dd>It performs "lookup" as defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3">RFC 4647 section 3</a>, determining the best element of _availableLocales_ for satisfying _requestedLocales_ using either the BestFitMatcher algorithm or LookupMatcher algorithm as specified by _options_.[[localeMatcher]], ignoring Unicode locale extension sequences, and returning a representation of the match that also includes corresponding data from _localeData_ and a resolved value for each element of _relevantExtensionKeys_ (defaulting to data from the matched locale, superseded by data from the requested Unicode locale extension sequence if present and then by data from _options_ if present). If the matched element from _requestedLocales_ contains a Unicode locale extension sequence, it is copied onto the language tag in the [[Locale]] field of the returned Record, omitting any <code>keyword</code> Unicode locale nonterminal whose <code>key</code> value is not contained within _relevantExtensionKeys_ or <code>type</code> value is superseded by a different value from _options_.</dd>
       </dl>
       <emu-alg>
         1. Let _matcher_ be _options_.[[localeMatcher]].
@@ -273,7 +273,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the elements of _requestedLocales_ for which _availableLocales_ contains a matching locale when using either the BestFitMatcher algorithm or LookupMatcher algorithm as specified in _options_, preserving their relative order.</dd>
+        <dd>It performs "filtering" as defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3">RFC 4647 section 3</a>, returning the elements of _requestedLocales_ for which _availableLocales_ contains a matching locale when using either the BestFitMatcher algorithm or LookupMatcher algorithm as specified in _options_, preserving their relative order.</dd>
       </dl>
       <emu-alg>
         1. Set _options_ to ? CoerceOptionsToObject(_options_).

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -85,33 +85,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-bestavailablelocale" type="abstract operation">
-      <h1>
-        BestAvailableLocale (
-          _availableLocales_: an Available Locales List,
-          _locale_: a Unicode canonicalized locale identifier,
-        ): a Unicode canonicalized locale identifier or *undefined*
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It compares _locale_ against the locales in _availableLocales_ and returns either the longest non-empty prefix of _locale_ that is an element of _availableLocales_, or *undefined* if there is no such element. It uses the fallback mechanism of RFC 4647, section 3.4.</dd>
-      </dl>
-      <emu-alg>
-        1. Let _candidate_ be _locale_.
-        1. Repeat,
-          1. If _availableLocales_ contains _candidate_, return _candidate_.
-          1. Let _pos_ be the index into _candidate_ of the last occurrence of *"-"* (code unit 0x002D HYPHEN-MINUS). If that character does not occur, return *undefined*.
-          1. Repeat, while _pos_ &ge; 2 and the substring of _candidate_ from _pos_ - 2 to _pos_ - 1 is *"-"*,
-            1. Set _pos_ to _pos_ - 2.
-          1. Set _candidate_ to the substring of _candidate_ from 0 to _pos_.
-      </emu-alg>
-
-      <emu-note>
-        When _locale_ includes a <a href="https://unicode.org/reports/tr35/#BCP47_T_Extension">Unicode Technical Standard #35 Part 1 Core BCP 47 T Extension</a> subtag sequence, the truncation in this algorithm may temporarily generate invalid language tags. However, none of them will be returned because _availableLocales_ contains only valid language tags.
-      </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-lookupmatcher" type="abstract operation">
+    <emu-clause id="sec-lookupmatcher" type="abstract operation" oldids="sec-bestavailablelocale">
       <h1>
         LookupMatcher (
           _availableLocales_: an Available Locales List,
@@ -128,13 +102,18 @@
           1. If _locale_ contains a Unicode locale extension sequence, then
             1. Set _extension_ to the Unicode locale extension sequence of _locale_.
             1. Set _locale_ to the String value that is _locale_ with any Unicode locale extension sequences removed.
-          1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _locale_).
-          1. If _availableLocale_ is not *undefined*, return the Record { [[locale]]: _availableLocale_, [[extension]]: _extension_ }.
+          1. Let _prefix_ be _locale_.
+          1. Repeat, while _prefix_ is not the empty String,
+            1. If _availableLocales_ contains _prefix_, return the Record { [[locale]]: _prefix_, [[extension]]: _extension_ }.
+            1. If _prefix_ contains *"-"* (code unit 0x002D HYPHEN-MINUS), let _pos_ be the index into _prefix_ of the last occurrence of *"-"*; else let _pos_ be 0.
+            1. Repeat, while _pos_ &ge; 2 and the substring of _prefix_ from _pos_ - 2 to _pos_ - 1 is *"-"*,
+              1. Set _pos_ to _pos_ - 2.
+            1. Set _prefix_ to the substring of _prefix_ from 0 to _pos_.
         1. Return *undefined*.
       </emu-alg>
 
       <emu-note>
-        The algorithm is based on the Lookup algorithm described in RFC 4647 section 3.4, but options specified through Unicode locale extension sequences are ignored in the lookup. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record also contains an [[extension]] field whose value is the substring of the Unicode locale extension sequence within the request locale language tag.
+        When a requested locale includes a <a href="https://unicode.org/reports/tr35/#BCP47_T_Extension">Unicode Technical Standard #35 Part 1 Core BCP 47 T Extension</a> subtag sequence, the truncation in this algorithm may temporarily generate invalid language tags. However, none of them will be returned because _availableLocales_ contains only valid language tags.
       </emu-note>
     </emu-clause>
 
@@ -299,8 +278,8 @@
         1. Let _subset_ be a new empty List.
         1. For each element _locale_ of _requestedLocales_, do
           1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
-          1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
-          1. If _availableLocale_ is not *undefined*, append _locale_ to _subset_.
+          1. Let _match_ be LookupMatcher(_availableLocales_, _noExtensionsLocale_).
+          1. If _match_ is not *undefined*, append _locale_ to _subset_.
         1. Return _subset_.
       </emu-alg>
     </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -116,24 +116,21 @@
         LookupMatcher (
           _availableLocales_: an Available Locales List,
           _requestedLocales_: a language priority list,
-        ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~)
+        ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~) or *undefined*
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It compares _requestedLocales_, which must be a List as returned by CanonicalizeLocaleList, against the locales in _availableLocales_ and determines the best available language to meet the request.</dd>
+        <dd>It determines the best element of _availableLocales_ for satisfying _requestedLocales_ using the Lookup algorithm defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3.4">RFC 4647 section 3.4</a>, ignoring Unicode locale extension sequences. If a non-default match is found, it returns a Record with a [[locale]] field containing the matching language tag from _availableLocales_ and an [[extension]] field containing the Unicode locale extension sequence of the corresponding element of _requestedLocales_ (or ~empty~ if requested language tag has no such sequence).</dd>
       </dl>
       <emu-alg>
         1. For each element _locale_ of _requestedLocales_, do
-          1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
-          1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _noExtensionsLocale_).
-          1. If _availableLocale_ is not *undefined*, then
-            1. If _locale_ and _noExtensionsLocale_ are not the same String value, then
-              1. Let _extension_ be the String value consisting of the substring of the Unicode locale extension sequence within _locale_.
-            1. Else,
-              1. Let _extension_ be ~empty~.
-            1. Return the Record { [[locale]]: _availableLocale_, [[extension]]: _extension_ }.
-        1. Let _defLocale_ be DefaultLocale().
-        1. Return the Record { [[locale]]: _defLocale_, [[extension]]: ~empty~ }.
+          1. Let _extension_ be ~empty~.
+          1. If _locale_ contains a Unicode locale extension sequence, then
+            1. Set _extension_ to the Unicode locale extension sequence of _locale_.
+            1. Set _locale_ to the String value that is _locale_ with any Unicode locale extension sequences removed.
+          1. Let _availableLocale_ be BestAvailableLocale(_availableLocales_, _locale_).
+          1. If _availableLocale_ is not *undefined*, return the Record { [[locale]]: _availableLocale_, [[extension]]: _extension_ }.
+        1. Return *undefined*.
       </emu-alg>
 
       <emu-note>
@@ -146,11 +143,11 @@
         BestFitMatcher (
           _availableLocales_: an Available Locales List,
           _requestedLocales_: a language priority list,
-        ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~)
+        ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~) or *undefined*
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It compares _requestedLocales_, which must be a List as returned by CanonicalizeLocaleList, against the locales in _availableLocales_ and determines the best available language to meet the request. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would perceive as at least as good as those produced by the LookupMatcher abstract operation. Options specified through Unicode locale extension sequences must be ignored by the algorithm. Information about such subsequences is returned separately. The abstract operation returns a record with a [[locale]] field, whose value is the language tag of the selected locale, which must be an element of _availableLocales_. If the language tag of the request locale that led to the selected locale contained a Unicode locale extension sequence, then the returned record's [[extension]] field is set to the substring of the Unicode locale extension sequence within the request locale language tag. Otherwise the [[extension]] field is set to ~empty~.</dd>
+        <dd>It determines the best element of _availableLocales_ for satisfying _requestedLocales_, ignoring Unicode locale extension sequences. The algorithm is implementation dependent, but should produce results that a typical user of the requested locales would consider at least as good as those produced by the LookupMatcher algorithm. If a non-default match is found, it returns a Record with a [[locale]] field containing the matching language tag from _availableLocales_ and an [[extension]] field containing the Unicode locale extension sequence of the corresponding element of _requestedLocales_ (or ~empty~ if requested language tag has no such sequence).</dd>
       </dl>
     </emu-clause>
 
@@ -229,7 +226,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines the best element of _availableLocales_ for satisfying _requestedLocales_, ignoring Unicode locale extension sequences, and returns a representation of the match that also includes corresponding data from _localeData_ and a resolved value for each element of _relevantExtensionKeys_ (defaulting to data from the matched locale, superseded by data from the requested Unicode locale extension sequence if present and then by data from _options_ if present).</dd>
+        <dd>It determines the best element of _availableLocales_ for satisfying _requestedLocales_ using either the BestFitMatcher algorithm or LookupMatcher algorithm as specified by _options_.[[localeMatcher]], ignoring Unicode locale extension sequences, and returns a representation of the match that also includes corresponding data from _localeData_ and a resolved value for each element of _relevantExtensionKeys_ (defaulting to data from the matched locale, superseded by data from the requested Unicode locale extension sequence if present and then by data from _options_ if present). If the matched element from _requestedLocales_ contains a Unicode locale extension sequence, it is copied onto the language tag in the [[Locale]] field of the returned Record, omitting any <code>keyword</code> Unicode locale nonterminal whose <code>key</code> value is not contained within _relevantExtensionKeys_ or <code>type</code> value is superseded by a different value from _options_.</dd>
       </dl>
       <emu-alg>
         1. Let _matcher_ be _options_.[[localeMatcher]].
@@ -237,6 +234,7 @@
           1. Let _r_ be LookupMatcher(_availableLocales_, _requestedLocales_).
         1. Else,
           1. Let _r_ be BestFitMatcher(_availableLocales_, _requestedLocales_).
+        1. If _r_ is *undefined*, set _r_ to the Record { [[locale]]: DefaultLocale(), [[extension]]: ~empty~ }.
         1. Let _foundLocale_ be _r_.[[locale]].
         1. Let _foundLocaleData_ be _localeData_.[[&lt;_foundLocale_&gt;]].
         1. Assert: Type(_foundLocaleData_) is Record.
@@ -284,10 +282,6 @@
           1. Set _result_.[[Locale]] to InsertUnicodeExtensionAndCanonicalize(_foundLocale_, _supportedExtension_).
         1. Return _result_.
       </emu-alg>
-
-      <emu-note>
-        Non-normative summary: Two algorithms are available to match the locales: the Lookup algorithm described in RFC 4647 section 3.4, and an implementation dependent best-fit algorithm. Independent of the locale matching algorithm, options specified through Unicode locale extension sequences are negotiated separately, taking the caller's relevant extension keys and locale data into consideration as well as the client-provided options. The abstract operation returns a Record with a field for each key in _relevantExtensionKeys_, containing the selected values for those keys. This Record also contains a [[locale]] field which stores the language tag of the selected locale with Unicode locale extension sequence <code>key</code> subtags restricted to those in _relevantExtensionKeys_. If an extension's value is specified in the Unicode locale extension sequence and a different value for that extension is specified in an option, the value from the option is used to set the value of the corresponding field and the overridden extension keyword (the <code>key</code> subtag along with any immediately following <code>type</code> subtags and associated separators) is removed from the string stored in [[locale]].
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-lookupsupportedlocales" type="abstract operation">

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -21,7 +21,7 @@
     </p>
 
     <ul>
-      <li>[[AvailableLocales]] is an Available Locales List. It must include the value returned by DefaultLocale. Additionally, each element with more than one subtag requires it to also include a less narrow language tag with the same language subtag and a strict subset of the same following subtags (i.e., omitting one or more), to serve as a potential fallback from <emu-xref href="#sec-resolvelocale">ResolveLocale</emu-xref> (and in particular, each element with a language subtag and a script subtag and a region subtag must be accompanied by another element consisting of only the same language subtag and region subtag but missing the script subtag). For example,
+      <li>[[AvailableLocales]] is an Available Locales List. It must include the value returned by DefaultLocale. Additionally, for each element with more than one subtag, it must also include a less narrow language tag with the same language subtag and a strict subset of the same following subtags (i.e., omitting one or more) to serve as a potential fallback from <emu-xref href="#sec-resolvelocale">ResolveLocale</emu-xref>. In particular, each element with a language subtag and a script subtag and a region subtag must be accompanied by another element consisting of only the same language subtag and region subtag but missing the script subtag. For example,
         <ul>
           <li>If [[AvailableLocales]] contains *"de-DE"*, then it must also contain *"de"* (which might be selected to satisfy requested locales such as *"de-AT"* and *"de-CH"*).</li>
           <li>If [[AvailableLocales]] contains *"az-Latn-AZ"*, then it must also contain *"az-AZ"* (which might be selected to satisfy requested locales such as *"az-Cyrl-AZ"* if *"az-Cyrl"* is unavailable).</li>
@@ -94,7 +94,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines the best element of _availableLocales_ for satisfying _requestedLocales_ using the Lookup algorithm defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3.4">RFC 4647 section 3.4</a>, ignoring Unicode locale extension sequences. If a non-default match is found, it returns a Record with a [[locale]] field containing the matching language tag from _availableLocales_ and an [[extension]] field containing the Unicode locale extension sequence of the corresponding element of _requestedLocales_ (or ~empty~ if requested language tag has no such sequence).</dd>
+        <dd>It determines the best element of _availableLocales_ for satisfying _requestedLocales_ using the lookup algorithm defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3.4">RFC 4647 section 3.4</a>, ignoring Unicode locale extension sequences. If a non-default match is found, it returns a Record with a [[locale]] field containing the matching language tag from _availableLocales_ and an [[extension]] field containing the Unicode locale extension sequence of the corresponding element of _requestedLocales_ (or ~empty~ if requested language tag has no such sequence).</dd>
       </dl>
       <emu-alg>
         1. For each element _locale_ of _requestedLocales_, do
@@ -122,7 +122,7 @@
         LookupMatchingLocaleByBestFit (
           _availableLocales_: an Available Locales List,
           _requestedLocales_: a language priority list,
-        ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~) or *undefined*
+        ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~), or *undefined*
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -205,7 +205,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It performs "lookup" as defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3">RFC 4647 section 3</a>, determining the best element of _availableLocales_ for satisfying _requestedLocales_ using either the LookupMatchingLocaleByBestFit algorithm or LookupMatchingLocaleByPrefix algorithm as specified by _options_.[[localeMatcher]], ignoring Unicode locale extension sequences, and returning a representation of the match that also includes corresponding data from _localeData_ and a resolved value for each element of _relevantExtensionKeys_ (defaulting to data from the matched locale, superseded by data from the requested Unicode locale extension sequence if present and then by data from _options_ if present). If the matched element from _requestedLocales_ contains a Unicode locale extension sequence, it is copied onto the language tag in the [[Locale]] field of the returned Record, omitting any <code>keyword</code> Unicode locale nonterminal whose <code>key</code> value is not contained within _relevantExtensionKeys_ or <code>type</code> value is superseded by a different value from _options_.</dd>
+        <dd>It performs "lookup" as defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3">RFC 4647 section 3</a>, determining the best element of _availableLocales_ for satisfying _requestedLocales_ using either the LookupMatchingLocaleByBestFit algorithm or LookupMatchingLocaleByPrefix algorithm as specified by _options_.[[localeMatcher]], ignoring Unicode locale extension sequences, and returns a representation of the match that also includes corresponding data from _localeData_ and a resolved value for each element of _relevantExtensionKeys_ (defaulting to data from the matched locale, superseded by data from the requested Unicode locale extension sequence if present and then by data from _options_ if present). If the matched element from _requestedLocales_ contains a Unicode locale extension sequence, it is copied onto the language tag in the [[Locale]] field of the returned Record, omitting any <code>keyword</code> Unicode locale nonterminal whose <code>key</code> value is not contained within _relevantExtensionKeys_ or <code>type</code> value is superseded by a different value from _options_.</dd>
       </dl>
       <emu-alg>
         1. Let _matcher_ be _options_.[[localeMatcher]].

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -2,7 +2,15 @@
   <h1>Locale and Parameter Negotiation</h1>
 
   <p>
-    <emu-xref href="#service-constructor">Service constructors</emu-xref> use a common pattern to negotiate the requests represented by their _locales_ and _options_ arguments against the actual capabilities of their implementations. That common behaviour is explained here in terms of internal slots describing the capabilities and abstract operations using these internal slots.
+    <emu-xref href="#service-constructor">Service constructors</emu-xref> use common patterns to negotiate the requests represented by _locales_ and _options_ arguments against the actual capabilities of an implementation. That common behaviour is explained here in terms of internal slots describing the capabilities, abstract operations using these internal slots, and specialized data types defined below.
+  </p>
+
+  <p>
+    An <dfn id="available-locales-list">Available Locales List</dfn> is an arbitrarily-ordered duplicate-free List of language tags, each of which is <emu-xref href="#sec-isstructurallyvalidlanguagetag">structurally valid</emu-xref>, <emu-xref href="#sec-canonicalizeunicodelocaleid">canonicalized</emu-xref>, and lacks a Unicode locale extension sequence. It represents all locales for which the implementation provides functionality within a particular context.
+  </p>
+
+  <p>
+    A <dfn id="language-priority-list">language priority list</dfn> is a List of <emu-xref href="#sec-isstructurallyvalidlanguagetag">structurally valid</emu-xref> and <emu-xref href="#sec-canonicalizeunicodelocaleid">canonicalized</emu-xref> language tags representing a sequence of locale preferences by descending priority. It corresponds with the term of the same name defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-2.3">RFC 4647 section 2.3</a> but prohibits *"\*"* elements and contains only canonicalized contents.
   </p>
 
   <emu-clause id="sec-internal-slots">
@@ -13,30 +21,31 @@
     </p>
 
     <ul>
-      <li>[[AvailableLocales]] is a List that contains structurally valid (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizeunicodelocaleid"></emu-xref>) language tags identifying the locales for which the implementation provides the functionality of the constructed objects. Language tags on the list must not have a Unicode locale extension sequence. The list must include the value returned by the DefaultLocale abstract operation (<emu-xref href="#sec-defaultlocale"></emu-xref>), and must not include duplicates. Implementations must include in [[AvailableLocales]] locales that can serve as fallbacks in the algorithm used to resolve locales (see <emu-xref href="#sec-resolvelocale"></emu-xref>). For example, implementations that provide a *"de-DE"* locale must include a *"de"* locale that can serve as a fallback for requests such as *"de-AT"* and *"de-CH"*. For locales that include a script subtag in addition to language and region, the corresponding locale without a script subtag must also be supported; that is, if an implementation recognizes *"zh-Hant-TW"*, it is also expected to recognize *"zh-TW"*. The ordering of the locales within [[AvailableLocales]] is irrelevant.</li>
+      <li>[[AvailableLocales]] is an Available Locales List. It must include the value returned by DefaultLocale. Additionally, each element with more than one subtag requires it to also include a less narrow language tag with the same language subtag and a strict subset of the same following subtags (i.e., omitting one or more), to serve as a potential fallback from <emu-xref href="#sec-resolvelocale">ResolveLocale</emu-xref> (and in particular, each element with a language subtag and a script subtag and a region subtag must be accompanied by another element consisting of only the same language subtag and region subtag but missing the script subtag). For example,
+        <ul>
+          <li>If [[AvailableLocales]] contains *"de-DE"*, then it must also contain *"de"* (which might be selected to satisfy requested locales such as *"de-AT"* and *"de-CH"*).</li>
+          <li>If [[AvailableLocales]] contains *"az-Latn-AZ"*, then it must also contain *"az-AZ"* (which might be selected to satisfy requested locales such as *"az-Cyrl-AZ"* if *"az-Cyrl"* is unavailable).</li>
+        </ul>
+      </li>
       <li>[[RelevantExtensionKeys]] is a List of Unicode locale extension sequence keys defined in <a href="https://unicode.org/reports/tr35/#Key_And_Type_Definitions_">Unicode Technical Standard #35 Part 1 Core, Section 3.6.1 Key and Type Definitions</a> that are relevant for the functionality of the constructed objects.</li>
-      <li>[[SortLocaleData]] and [[SearchLocaleData]] (for Intl.Collator) and [[LocaleData]] (for every other service constructor) are Records that have fields for each locale contained in [[AvailableLocales]]. The value of each of these fields must be a Record in which each element of [[RelevantExtensionKeys]] identifies the name of a field whose value is a non-empty List of Strings representing the type values that are supported by the implementation in the relevant locale for the corresponding Unicode locale extension sequence key, with the first element providing the default value for that key in the locale.</li>
+      <li>[[SortLocaleData]] and [[SearchLocaleData]] (for Intl.Collator) and [[LocaleData]] (for every other service constructor) are Records. In addition to fields specific to its service constructor, each such Record has a field for each locale contained in [[AvailableLocales]]. The value of each such locale-named field is a Record in which each element of [[RelevantExtensionKeys]] identifies the name of a field whose value is a non-empty List of Strings representing the type values that are supported by the implementation in the relevant locale for the corresponding Unicode locale extension sequence key, with the first element providing the default value for that key in the locale.</li>
     </ul>
 
     <emu-note>
       For example, an implementation of DateTimeFormat might include the language tag *"fa-IR"* in its [[AvailableLocales]] internal slot, and must (according to <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>) include the keys *"ca"*, *"hc"*, and *"nu"* in its [[RelevantExtensionKeys]] internal slot.
       The default calendar for that locale is usually *"persian"*, but an implementation might also support *"gregory"*, *"islamic"*, and *"islamic-civil"*.
-	  The Record in the DateTimeFormat [[LocaleData]] internal slot would therefore include a [[fa-IR]] field whose value is a Record like { [[ca]]: « *"persian"*, *"gregory"*, *"islamic"*, *"islamic-civil"* », [[hc]]: « … », [[nu]]: « … » }, along with other locale-named fields having the same value shape but different elements in their Lists.
+      The Record in the DateTimeFormat [[LocaleData]] internal slot would therefore include a [[fa-IR]] field whose value is a Record like { [[ca]]: « *"persian"*, *"gregory"*, *"islamic"*, *"islamic-civil"* », [[hc]]: « … », [[nu]]: « … » }, along with other locale-named fields having the same value shape but different elements in their Lists.
     </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-abstract-operations">
     <h1>Abstract Operations</h1>
 
-    <p>
-      Where the following abstract operations take an _availableLocales_ argument, it must be an [[AvailableLocales]] List as specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
-    </p>
-
     <emu-clause id="sec-canonicalizelocalelist" type="abstract operation">
       <h1>
         CanonicalizeLocaleList (
           _locales_: an ECMAScript language value,
-        ): either a normal completion containing a List of Unicode canonicalized locale identifiers or a throw completion
+        ): either a normal completion containing a language priority list or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -79,7 +88,7 @@
     <emu-clause id="sec-bestavailablelocale" type="abstract operation">
       <h1>
         BestAvailableLocale (
-          _availableLocales_: a List of Unicode canonicalized locale identifiers,
+          _availableLocales_: an Available Locales List,
           _locale_: a Unicode canonicalized locale identifier,
         ): a Unicode canonicalized locale identifier or *undefined*
       </h1>
@@ -105,8 +114,8 @@
     <emu-clause id="sec-lookupmatcher" type="abstract operation">
       <h1>
         LookupMatcher (
-          _availableLocales_: a List of Unicode canonicalized locale identifiers,
-          _requestedLocales_: a List of Unicode canonicalized locale identifiers,
+          _availableLocales_: an Available Locales List,
+          _requestedLocales_: a language priority list,
         ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~)
       </h1>
       <dl class="header">
@@ -135,8 +144,8 @@
     <emu-clause id="sec-bestfitmatcher" type="implementation-defined abstract operation">
       <h1>
         BestFitMatcher (
-          _availableLocales_: a List of Unicode canonicalized locale identifiers,
-          _requestedLocales_: a List of Unicode canonicalized locale identifiers,
+          _availableLocales_: an Available Locales List,
+          _requestedLocales_: a language priority list,
         ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~)
       </h1>
       <dl class="header">
@@ -211,8 +220,8 @@
     <emu-clause id="sec-resolvelocale" type="abstract operation">
       <h1>
         ResolveLocale (
-          _availableLocales_: a List of Unicode canonicalized locale identifiers,
-          _requestedLocales_: a List of Unicode canonicalized locale identifiers,
+          _availableLocales_: an Available Locales List,
+          _requestedLocales_: a language priority list,
           _options_: a Record,
           _relevantExtensionKeys_: a List of Strings,
           _localeData_: a Record,
@@ -220,7 +229,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It compares a BCP 47 language priority list _requestedLocales_ against the locales in _availableLocales_ and determines the best available language to meet the request.</dd>
+        <dd>It determines the best element of _availableLocales_ for satisfying _requestedLocales_, ignoring Unicode locale extension sequences, and returns a representation of the match that also includes corresponding data from _localeData_ and a resolved value for each element of _relevantExtensionKeys_ (defaulting to data from the matched locale, superseded by data from the requested Unicode locale extension sequence if present and then by data from _options_ if present).</dd>
       </dl>
       <emu-alg>
         1. Let _matcher_ be _options_.[[localeMatcher]].
@@ -284,13 +293,13 @@
     <emu-clause id="sec-lookupsupportedlocales" type="abstract operation">
       <h1>
         LookupSupportedLocales (
-          _availableLocales_: a List of Unicode canonicalized locale identifiers,
-          _requestedLocales_: a List of Unicode canonicalized locale identifiers,
+          _availableLocales_: an Available Locales List,
+          _requestedLocales_: a language priority list,
         ): a List of Unicode canonicalized locale identifiers
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the subset of the provided BCP 47 language priority list _requestedLocales_ for which _availableLocales_ has a matching locale when using the BCP 47 Lookup algorithm. Locales appear in the same order in the returned list as in _requestedLocales_.</dd>
+        <dd>It returns the elements of _requestedLocales_ for which _availableLocales_ has a matching locale when using the BCP 47 Lookup algorithm, preserving their relative order.</dd>
       </dl>
       <emu-alg>
         1. Let _subset_ be a new empty List.
@@ -305,27 +314,27 @@
     <emu-clause id="sec-bestfitsupportedlocales" type="implementation-defined abstract operation">
       <h1>
         BestFitSupportedLocales (
-          _availableLocales_: a List of Unicode canonicalized locale identifiers,
-          _requestedLocales_: a List of Unicode canonicalized locale identifiers,
+          _availableLocales_: an Available Locales List,
+          _requestedLocales_: a language priority list,
         ): a List of Unicode canonicalized locale identifiers
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the subset of the provided BCP 47 language priority list _requestedLocales_ for which _availableLocales_ has a matching locale when using the Best Fit Matcher algorithm. Locales appear in the same order in the returned list as in _requestedLocales_.</dd>
+        <dd>It returns the elements of _requestedLocales_ for which _availableLocales_ has a matching locale when using the BestFitMatcher algorithm, preserving their relative order.</dd>
       </dl>
     </emu-clause>
 
     <emu-clause id="sec-supportedlocales" type="abstract operation">
       <h1>
         SupportedLocales (
-          _availableLocales_: a List of Unicode canonicalized locale identifiers,
-          _requestedLocales_: a List of Unicode canonicalized locale identifiers,
+          _availableLocales_: an Available Locales List,
+          _requestedLocales_: a language priority list,
           _options_: an ECMAScript language value,
         ): either a normal completion containing a List of Unicode canonicalized locale identifiers or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the subset of the provided BCP 47 language priority list _requestedLocales_ for which _availableLocales_ has a matching locale. Two algorithms are available to match the locales: the Lookup algorithm described in RFC 4647 section 3.4, and an implementation dependent best-fit algorithm. Locales appear in the same order in the returned list as in _requestedLocales_.</dd>
+        <dd>It returns the elements of _requestedLocales_ for which _availableLocales_ has a matching locale when using either the BestFitMatcher algorithm or another as specified in _options_, preserving their relative order.</dd>
       </dl>
       <emu-alg>
         1. Set _options_ to ? CoerceOptionsToObject(_options_).

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -255,7 +255,7 @@
       <emu-alg>
         1. Let _availableLocales_ be %Intl.NumberFormat%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
+        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -78,7 +78,7 @@
       <emu-alg>
         1. Let _availableLocales_ be %Intl.PluralRules%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
+        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -90,7 +90,7 @@
       <emu-alg>
         1. Let _availableLocales_ be %Intl.RelativeTimeFormat%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
+        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -61,7 +61,7 @@
       <emu-alg>
         1. Let _availableLocales_ be %Intl.Segmenter%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
+        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Best reviewed commit-by-commit.

[RFC 4647 section 2.3](https://www.rfc-editor.org/rfc/rfc4647.html#section-2.3) defines "language priority list" as "_a prioritized or weighted list of language ranges_", and corresponds to _requestedLocales_ in various ECMA-402 operations.
[RFC 4647 section 3](https://www.rfc-editor.org/rfc/rfc4647.html#section-3) differentiates "matching schemes" applying such lists against available locales into "filtering" (producing zero or more matches) and "lookup" (producing exactly one match). [Language Tags and Locale Identifiers for the World Wide Web](https://www.w3.org/International/core/langtags/#sec-locale-vs-language) reinforces their significance ("_Specifications that define operations on language tags or locale values using matching MUST specify whether the resulting language priority list contains a single result (**lookup** as defined in [[RFC 4647]](https://www.w3.org/International/core/langtags/#rfc4647)), or a possible empty set of results (**filtering** as defined in [[RFC 4647]](https://www.w3.org/International/core/langtags/#rfc4647))_").

This PR incorporates those terms and refactors the algorithms to better align with BCP 47, consolidating many of them and establishing clear entry points at ResolveLocale for lookup and FilterLocales (née SupportedLocales) and filtering.