### PR TITLE
Editorial: Retarget the link explaining lack of parsers

### DIFF
--- a/spec/overview.html
+++ b/spec/overview.html
@@ -40,7 +40,7 @@
       The Intl object is used to package all functionality defined in this specification in order to avoid name collisions.
     </p>
 
-    <emu-note>While the API includes a variety of formatters, it does not provide any parsing facilities. This is intentional, has been discussed extensively, and concluded after weighing in all the benefits and drawbacks of including said functionality. See the discussion on the <a href="https://github.com/tc39/ecma402/issues/342">issue tracker</a>.</emu-note>
+    <emu-note>While the API includes a variety of formatters, it does not provide any parsing facilities. This is intentional, has been discussed extensively, and concluded after weighing in all the benefits and drawbacks of including said functionality. See the discussion on the <a href="https://github.com/tc39/ecma402/issues/424">issue tracker</a>.</emu-note>
   </emu-clause>
 
   <emu-clause id="sec-api-conventions">


### PR DESCRIPTION
gh-424 is more comprehensive than gh-342, which is specific to DateTimeFormat