### PR TITLE
Editorial: update for String{,Last}IndexOf returning not-found

### DIFF
--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -264,7 +264,7 @@
         1. If IsSanctionedSingleUnitIdentifier(_unitIdentifier_) is *true*, then
           1. Return *true*.
         1. Let _i_ be StringIndexOf(_unitIdentifier_, *"-per-"*, 0).
-        1. If _i_ is -1 or StringIndexOf(_unitIdentifier_, *"-per-"*, _i_ + 1) is not -1, then
+        1. If _i_ is ~not-found~ or StringIndexOf(_unitIdentifier_, *"-per-"*, _i_ + 1) is not ~not-found~, then
           1. Return *false*.
         1. Assert: The five-character substring *"-per-"* occurs exactly once in _unitIdentifier_, at index _i_.
         1. Let _numerator_ be the substring of _unitIdentifier_ from 0 to _i_.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -165,7 +165,7 @@
         1. Let _k_ be 3.
         1. Repeat, while _k_ &lt; _size_,
           1. Let _e_ be StringIndexOf(_extension_, *"-"*, _k_).
-          1. If _e_ = -1, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
+          1. If _e_ is ~not-found~, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
           1. Let _subtag_ be the substring of _extension_ from _k_ to _k_ + _len_.
           1. NOTE: A <emu-not-ref>keyword</emu-not-ref> is a sequence of subtags in which the first is a key of length 2 and any subsequent ones (if present) have length in the inclusive interval from 3 to 8, collectively constituting a value along with their medial *"-"* separators. An attribute is a single subtag with length in the inclusive interval from 3 to 8 that precedes all <emu-not-ref>keywords</emu-not-ref>.
           1. Assert: _len_ &ge; 2.
@@ -197,7 +197,7 @@
       <emu-alg>
         1. Assert: _locale_ does not contain a Unicode locale extension sequence.
         1. Let _privateIndex_ be StringIndexOf(_locale_, *"-x-"*, 0).
-        1. If _privateIndex_ = -1, then
+        1. If _privateIndex_ is ~not-found~, then
           1. Let _newLocale_ be the string-concatenation of _locale_ and _extension_.
         1. Else,
           1. Let _preExtension_ be the substring of _locale_ from 0 to _privateIndex_.
@@ -493,9 +493,9 @@
         1. Let _endIndex_ be 0.
         1. Let _nextIndex_ be 0.
         1. Let _length_ be the number of code units in _pattern_.
-        1. Repeat, while _beginIndex_ is an integer index into _pattern_,
+        1. Repeat, while _beginIndex_ is not ~not-found~,
           1. Set _endIndex_ to StringIndexOf(_pattern_, *"}"*, _beginIndex_).
-          1. Assert: _endIndex_ is greater than _beginIndex_.
+          1. Assert: _endIndex_ is an integer greater than _beginIndex_.
           1. If _beginIndex_ is greater than _nextIndex_, then
             1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _literal_ } to _result_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -780,7 +780,7 @@
         1. Let _string_ be _result_.[[FormattedString]].
         1. If _intlObject_.[[TrailingZeroDisplay]] is *"stripIfInteger"* and <emu-eqn>_x_ modulo 1 = 0</emu-eqn>, then
           1. Let _i_ be StringIndexOf(_string_, *"."*, 0).
-          1. If _i_ &ne; -1, set _string_ to the substring of _string_ from 0 to _i_.
+          1. If _i_ is not ~not-found~, set _string_ to the substring of _string_ from 0 to _i_.
         1. Let _int_ be _result_.[[IntegerDigitsCount]].
         1. Let _minInteger_ be _intlObject_.[[MinimumIntegerDigits]].
         1. If _int_ &lt; _minInteger_, then
@@ -920,7 +920,7 @@
               1. Else,
                 1. Use an implementation dependent algorithm to map _n_ to the appropriate representation of _n_ in the given numbering system.
               1. Let _decimalSepIndex_ be StringIndexOf(_n_, *"."*, 0).
-              1. If _decimalSepIndex_ &gt; 0, then
+              1. If _decimalSepIndex_ is not ~not-found~ and _decimalSepIndex_ &gt; 0, then
                 1. Let _integer_ be the substring of _n_ from position 0, inclusive, to position _decimalSepIndex_, exclusive.
                 1. Let _fraction_ be the substring of _n_ from position _decimalSepIndex_, exclusive, to the end of _n_.
               1. Else,

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -312,7 +312,7 @@
          1. Let _n_ be ! ToNumber(_s_).
          1. Assert: _n_ is finite.
          1. Let _dp_ be StringIndexOf(_s_, *"."*, 0).
-         1. If _dp_ = -1, then
+         1. If _dp_ is ~not-found~, then
            1. Let _intPart_ be _n_.
            1. Let _fracSlice_ be *""*.
          1. Else,


### PR DESCRIPTION
Update for https://github.com/tc39/ecma262/pull/3300. Marked as draft until that lands; I will update this PR to pull in the extra biblio when it does (though the type-checking isn't yet able to do anything with that).

I'm not absolute sure about the changes PartitionPattern (what does  and PartitionNotationSubPattern and would appreciate extra scrutiny there.