### PR TITLE
Normative: specify time zone ID requirements to reduce divergence between engines

### DIFF
--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -170,39 +170,74 @@
     <p>
       Implementations that adopt this specification must be time zone aware: they must use the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a> to supply time zone identifiers and data used in ECMAScript calculations and formatting.
       This section defines how the IANA Time Zone Database should be used by time zone aware implementations.
-    </p>
-    <p>
-      Except as overridden by AvailableNamedTimeZoneIdentifiers, each Zone in the IANA Time Zone Database must be a primary time zone identifier and each Link name in the IANA Time Zone Database must be a non-primary time zone identifier.
       No String may be an available named time zone identifier unless it is a Zone name or a Link name in the IANA Time Zone Database.
       Available named time zone identifiers returned by ECMAScript built-in objects must use the casing found in the IANA Time Zone Database.
     </p>
     <p>
-      In the IANA Time Zone Database, the UTC time zone is represented by the Zone *"Etc/UTC"* which is distinct from the Zone *"Etc/GMT"*.
-      For historical reasons, ECMAScript uses *"UTC"* as the primary identifier for the former Zone and does not recognize the latter Zone as distinct, instead requiring *"Etc/UTC"*, *"Etc/GMT"*, and *"GMT"* (if available) to be non-primary identifiers that resolve to *"UTC"*.
-      This is the only deviation from the IANA Time Zone Database that is required of a time zone aware ECMAScript implementation.
+      Each Zone in the IANA Time Zone Database must be a primary time zone identifier and each Link name in the IANA Time Zone Database must be a non-primary time zone identifier that resolves to its corresponding Zone name, with the following exceptions implemented in AvailableNamedTimeZoneIdentifiers:
     </p>
-    <p>
-      The IANA Time Zone Database is typically updated between five and ten times per year.
-      These updates may add new Zone or Link names, may change Zones to Links, and may change the UTC offsets and transitions associated with any Zone.
-      ECMAScript implementations are recommended to include updates to the IANA Time Zone Database as soon as possible.
-      Such prompt action ensures that ECMAScript programs can accurately perform time-zone-sensitive calculations and can use newly-added available named time zone identifiers supplied by external input or the host environment.
-    </p>
-
-    <p>
-      If implementations revise time zone information during the lifetime of an agent, then it is recommended that the list of available named time zone identifiers, the primary time zone identifier associated with any available named time zone identifier, and the UTC offsets and transitions associated with any available named time zone identifier, be consistent with results previously observed by that agent.
-      Due to the complexity of supporting this recommendation, it is recommended that implementations maintain a fully consistent copy of the IANA Time Zone Database for the lifetime of each agent.
-    </p>
-
-    <p>This section complements but does not supersede <emu-xref href="#sec-time-zone-identifiers"></emu-xref>.</p>
+    <ul>
+      <li>
+        For historical reasons, *"UTC"* must be a primary time zone identifier.
+        *"Etc/UTC"*, *"Etc/GMT"*, and *"GMT"*, as well as all Link names that resolve to any of them, must be non-primary time identifiers that resolve to *"UTC"*.
+      </li>
+      <li>
+        Any Link name that is present in the “TZ” column of file <code>zone.tab</code> must be a primary time zone identifier.
+        For example, both *"Europe/Prague"* and *"Europe/Bratislava"* must be primary time zone identifiers.
+        This requirement guarantees at least one primary time zone identifier for each <a href="https://www.iso.org/glossary-for-iso-3166.html">ISO 3166-1 Alpha-2</a> country code, and ensures that future changes to time zone rules of one country will not affect ECMAScript programs that use another country's time zone(s), unless those countries' territorial boundaries have also changed.
+      </li>
+      <li>
+        Any Link name that is not listed in the “TZ” column of file <code>zone.tab</code> and that represents a geographical area entirely contained within the territory of a single <a href="https://www.iso.org/glossary-for-iso-3166.html">ISO 3166-1 Alpha-2</a> country code must resolve to a primary identifier that also represents a geographical area entirely contained within the territory of the same country code.
+        For example, *"Atlantic/Jan_Mayen"* must resolve to *"Arctic/Longyearbyen"*.
+      </li>
+    </ul>
 
     <emu-note>
       <p>
         The IANA Time Zone Database offers build options that affect which time zone identifiers are primary.
-        The default build options merge different countries' time zones, for example *"Atlantic/Reykjavik"* being a Link to the Zone *"Africa/Abidjan"*.
+        The default build options merge different countries' time zones, for example *"Atlantic/Reykjavik"* is built as a Link to the Zone *"Africa/Abidjan"*.
         Geographically and politically distinct locations are likely to introduce divergent time zone rules in a future version of the IANA Time Zone Database.
-        Therefore, it is recommended that ECMAScript implementations instead use build options such as <code>PACKRATDATA=backzone PACKRATLIST=zone.tab</code> or a similar alternative that ensures at least one primary identifier for each <a href="https://www.iso.org/glossary-for-iso-3166.html">ISO 3166-1 Alpha-2</a> country code.
+        The exceptions above serve to mitigate these future-compatibility issues.
+      </p>
+      <p>
+        The Unicode Common Locale Data Repository (<a href="https://cldr.unicode.org">CLDR</a>) implements most of the exceptions above when determining which available named time zone identifiers are primary or non-primary.
+        Although use of CLDR data is recommended for consistency between implementations, it is not required.
+        Non-CLDR-based implementations can still use CLDR's identifier data in <a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/timezone.xml"><code>timezone.xml</code></a>.
+        Implementations may also build the IANA Time Zone Database directly, for example by using build options such as <code>PACKRATDATA=backzone PACKRATLIST=zone.tab</code> and performing any post-processing needed to ensure compliance with the requirements above.
       </p>
     </emu-note>
+
+    <p>
+      The IANA Time Zone Database is typically updated between five and ten times per year.
+      These updates may add new Zone or Link names, may change Zones to Links, and may change the UTC offsets and transitions associated with any Zone.
+      Implementations are recommended to include updates to the IANA Time Zone Database as soon as possible.
+      Such prompt action ensures that ECMAScript programs can accurately perform time-zone-sensitive calculations and can use newly-added available named time zone identifiers supplied by external input or the host environment.
+    </p>
+    <p>
+      Although the IANA Time Zone Database maintainers strive for stability, in rare cases (averaging less than once per year) a Zone may be replaced by a new Zone.
+      For example, in 2022 "*Europe/Kiev*" was deprecated to a Link resolving to a new "*Europe/Kyiv*" Zone.
+      The deprecated Link is called a <dfn variants="renamed time zone identifiers">renamed time zone identifier</dfn> and the newly-added Zone is called a <dfn variants="replacement time zone identifiers">replacement time zone identifier</dfn>.
+    </p>
+    <p>
+      To reduce disruption from these infrequent changes, implementations should initially add each replacement time zone identifier as a non-primary time zone identifier that resolves to the existing renamed time zone identifier.
+      This allows ECMAScript programs to recognize both identifiers, but also reduces the chance that an ECMAScript program will send the replacement time zone identifier to another system that does not yet recognize it.
+      After a <dfn id="rename-waiting-period">rename waiting period</dfn>, implementations should promote the new Zone to a primary time zone identifier while simultaneously demoting the renamed time zone identifier to non-primary.
+      To provide ample time for other systems to be updated, the recommended rename waiting period is two years.
+      However, it does not need to be either exact or dynamic.
+      Instead, implementations should make the replacement time zone identifier primary after the waiting period as part of their normal release process for updating time zone data.
+    </p>
+    <p>
+      A waiting period should only apply when a new Zone is added to replace an existing Zone.
+      If an existing Zone and Link are swapped, then no renaming has happened and no waiting period is necessary.
+    </p>
+
+    <p>
+      If implementations revise time zone information during the lifetime of an agent, then it is required that the list of available named time zone identifiers, the primary time zone identifier associated with any available named time zone identifier, and the UTC offsets and transitions associated with any available named time zone identifier, be consistent with results previously observed by that agent.
+      Due to the complexity of supporting this requirement, it is recommended that implementations maintain a fully consistent copy of the IANA Time Zone Database for the lifetime of each agent.
+    </p>
+
+    <p>This section complements but does not supersede <emu-xref href="#sec-time-zone-identifiers"></emu-xref>.</p>
+    </emu-clause>
 
     <emu-clause id="sup-availablenamedtimezoneidentifiers" oldids="sec-availabletimezones" type="implementation-defined abstract operation">
       <h1>AvailableNamedTimeZoneIdentifiers ( ): a List of Time Zone Identifier Records</h1>
@@ -219,20 +254,67 @@
       <emu-alg>
         1. Let _identifiers_ be a List containing the String value of each Zone or Link name in the IANA Time Zone Database.
         1. Assert: No element of _identifiers_ is an ASCII-case-insensitive match for any other element.
-        1. Assert: Every element of _identifiers_ identifies a Zone or Link name in the IANA Time Zone Database.
         1. Sort _identifiers_ according to lexicographic code unit order.
         1. Let _result_ be a new empty List.
         1. For each element _identifier_ of _identifiers_, do
           1. Let _primary_ be _identifier_.
-          1. If _identifier_ is a Link name and _identifier_ is not *"UTC"*, then
-            1. Set _primary_ to the Zone name that _identifier_ resolves to, according to the rules for resolving Link names in the IANA Time Zone Database.
-            1. NOTE: An implementation may need to resolve _identifier_ iteratively.
+          1. If _identifier_ is a Link name in the IANA Time Zone Database and _identifier_ is not present in the “TZ” column of <code>zone.tab</code> of the IANA Time Zone Database, then
+            1. Let _zone_ be the Zone name that _identifier_ resolves to, according to the rules for resolving Link names in the IANA Time Zone Database.
+            1. If _zone_ starts with *"Etc/"*, then
+              1. Set _primary_ to _zone_.
+            1. Else,
+              1. Let _identifierCountryCode_ be the <a href="https://www.iso.org/glossary-for-iso-3166.html">ISO 3166-1 Alpha-2</a> country code whose territory contains the geographical area corresponding to _identifier_.
+              1. Let _zoneCountryCode_ be the ISO 3166-1 Alpha-2 country code whose territory contains the geographical area corresponding to _zone_.
+              1. If _identifierCountryCode_ is _zoneCountryCode_, then
+                1. Set _primary_ to _zone_.
+              1. Else,
+                1. Let _countryCodeLineCount_ be the number of lines in file <code>zone.tab</code> of the IANA Time Zone Database where the “country-code” column is _identifierCountryCode_.
+                1. If _countryCodeLineCount_ is 1, then
+                  1. Let _countryCodeLine_ be the line in file <code>zone.tab</code> of the IANA Time Zone Database where the “country-code” column is _identifierCountryCode_.
+                  1. Set _primary_ to the contents of the “TZ” column of _countryCodeLine_.
+                1. Else,
+                  1. Let _backzone_ be *undefined*.
+                  1. Let _backzoneLinkLines_ be the List of lines in the file <code>backzone</code> of the IANA Time Zone Database that start with either *"Link "* or *"#PACKRATLIST zone.tab Link "*.
+                  1. For each element _line_ of _backzoneLinkLines_, do
+                    1. Let _i_ be StringIndexOf(_line_, *"Link "*, 0).
+                    1. Set _line_ to the substring of _line_ from _i_ + 5.
+                    1. Let _backzoneAndLink_ be StringSplitToList(_line_, *" "*).
+                    1. Assert: _backzoneAndLink_ has at least two elements, and both _backzoneAndLink_[0] and _backzoneAndLink_[1] are available named time zone identifiers.
+                    1. If _backzoneAndLink_[1] is _identifier_, then
+                      1. Assert: _backzone_ is *undefined*.
+                      1. Set _backzone_ to _backzoneAndLink_[0].
+                  1. Assert: _backzone_ is not *undefined*.
+                  1. Set _primary_ to _backzone_.
           1. If _primary_ is one of *"Etc/UTC"*, *"Etc/GMT"*, or *"GMT"*, set _primary_ to *"UTC"*.
+          1. If _primary_ is a replacement time zone identifier and its rename waiting period has not concluded, then
+            1. Let _renamedIdentifier_ be the renamed time zone identifier that _primary_ replaced.
+            1. Set _primary_ to _renamedIdentifier_.
           1. Let _record_ be the Time Zone Identifier Record { [[Identifier]]: _identifier_, [[PrimaryIdentifier]]: _primary_ }.
           1. Append _record_ to _result_.
         1. Assert: _result_ contains a Time Zone Identifier Record _r_ such that _r_.[[Identifier]] is *"UTC"* and _r_.[[PrimaryIdentifier]] is *"UTC"*.
         1. Return _result_.
       </emu-alg>
+
+      <emu-note>
+        <p>
+          The algorithm above for resolving Links to primary time zone identifiers is intended to correspond to the behaviour of <code>icu::TimeZone::getIanaID()</code> in the International Components for Unicode (<a href="https://icu.unicode.org/">ICU</a>) and the processes for maintaining time zone identifier data in the Unicode Common Locale Data Repository (<a href="https://cldr.unicode.org">CLDR</a>).
+        </p>
+        <p>
+          This algorithm resolves Links to primary time zone identifiers without crossing the boundaries of ISO 3166-1 Alpha-2 country codes, using data from files <code>zone.tab</code> and <code>backzone</code> of the IANA Time Zone Database.
+          If the country code of a Link has only one line in <code>zone.tab</code>, then that line will determine the primary time zone identifier.
+          However, if that country code has multiple lines in <code>zone.tab</code>, then historical mappings in <code>backzone</code> must be used to identify the correct primary time zone identifier.
+        </p>
+        <p>
+          For example, to resolve "Pacific/Truk" (in country code "FM") if the default build options of the IANA Time Zone Database identify it as a Link to "Pacific/Port_Moresby" (in country code "PG"), then the “country-code” column of <code>zone.tab</code> must be checked for lines corresponding with "FM".
+          If there were only one such line, then the “TZ” column of that line would determine the primary time zone identifier associated with "Pacific/Truk".
+          But if there are multiple "FM" lines in <code>zone.tab</code>, then <code>backzone</code> must be inspected and a line such as "Link Pacific/Chuuk Pacific/Truk" would result in using "Pacific/Chuuk" as the primary time zone identifier.
+        </p>
+        <p>
+          Note that <code>zone.tab</code> is the preferred source of mapping data because <code>backzone</code> mappings may, in rare cases, cross the boundaries of ISO 3166-1 Alpha-2 country codes.
+          For example, "Atlantic/Jan_Mayen" (in country code "SJ") is mapped in <code>backzone</code> to "Europe/Oslo" (in country code "NO").
+          As of the 2024a release of the IANA Time Zone Database, "Atlantic/Jan_Mayen" is the only case where this happens.
+        </p>
+      </emu-note>
 
       <emu-note>
         Time zone identifiers in the IANA Time Zone Database can change over time.
@@ -260,9 +342,9 @@
         1. Return ~empty~.
       </emu-alg>
       <emu-note>
-        For any _timeZoneIdentifier_, or any value that is an ASCII-case-insensitive match for it, it is recommended that the resulting Time Zone Identifier Record contain the same field values for the lifetime of the surrounding agent.
-        Furthermore, it is recommended that time zone identifiers not dynamically change from primary to non-primary during the lifetime of the surrounding agent, meaning that if _timeZoneIdentifier_ is an ASCII-case-insensitive match for the [[PrimaryIdentifier]] field of the result of a previous call to GetAvailableNamedTimeZoneIdentifier, then GetAvailableNamedTimeZoneIdentifier(_timeZoneIdentifier_) must return a Record where [[Identifier]] is [[PrimaryIdentifier]].
-        Due to the complexity of supporting these recommendations, it is recommended that the result of AvailableNamedTimeZoneIdentifiers (and therefore GetAvailableNamedTimeZoneIdentifier too) remains the same for the lifetime of the surrounding agent.
+        For any _timeZoneIdentifier_, or any value that is an ASCII-case-insensitive match for it, it is required that the resulting Time Zone Identifier Record contain the same field values for the lifetime of the surrounding agent.
+        Furthermore, it is required that time zone identifiers not dynamically change from primary to non-primary during the lifetime of the surrounding agent, meaning that if _timeZoneIdentifier_ is an ASCII-case-insensitive match for the [[PrimaryIdentifier]] field of the result of a previous call to GetAvailableNamedTimeZoneIdentifier, then GetAvailableNamedTimeZoneIdentifier(_timeZoneIdentifier_) must return a Time Zone Identifier Record where [[Identifier]] is [[PrimaryIdentifier]].
+        Due to the complexity of supporting these requirements, it is recommended that the result of AvailableNamedTimeZoneIdentifiers (and therefore GetAvailableNamedTimeZoneIdentifier too) remains the same for the lifetime of the surrounding agent.
       </emu-note>
     </emu-clause>
 
@@ -285,6 +367,38 @@
         1. Return _result_.
       </emu-alg>
     </emu-clause>
+
+      <emu-clause id="sec-string-split-to-list" type="abstract operation">
+        <h1>
+          StringSplitToList (
+            _S_: a String,
+            _separator_: a String,
+          ): a List of Strings
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>
+            The returned List contains all disjoint substrings of _S_ that do not contain _separator_ but are immediately preceded and/or immediately followed by an occurrence of _separator_.
+            Each such <emu-not-ref>substring</emu-not-ref> will be the empty String between adjacent occurrences of _separator_, before a _separator_ at the very start of _S_, or after a _separator_ at the very end of _S_, but otherwise will not be empty.
+          </dd>
+        </dl>
+        <emu-alg>
+          1. Assert: _S_ is not the empty String.
+          1. Assert: _separator_ is not the empty String.
+          1. Let _separatorLength_ be the length of _separator_.
+          1. Let _substrings_ be a new empty List.
+          1. Let _i_ be 0.
+          1. Let _j_ be StringIndexOf(_S_, _separator_, 0).
+          1. Repeat, while _j_ is not ~not-found~,
+            1. Let _T_ be the substring of _S_ from _i_ to _j_.
+            1. Append _T_ to _substrings_.
+            1. Set _i_ to _j_ + _separatorLength_.
+            1. Set _j_ to StringIndexOf(_S_, _separator_, _i_).
+          1. Let _T_ be the substring of _S_ from _i_.
+          1. Append _T_ to _substrings_.
+          1. Return _substrings_.
+        </emu-alg>
+      </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-measurement-unit-identifiers">


### PR DESCRIPTION
This proposed change resolves #825 by adding normative spec text to clarify how ECMA-402 implementations should decide which IANA time zone IDs should be primary vs. non-primary. This will enable more consistency between ECMAScript implementations and prevent future divergence.

This PR also accommodates to web reality by aligning ECMA-402 with CLDR and ICU. This should make it easier for all ECMAScript engines to comply with the spec while still being able to use ICU. 

This PR is stacked on #876, so please ignore the first commit when reviewing this PR.

Note that the problem of out-of-date primary IDs for renamed Zones (like Asia/Calcutta) is out of scope to this PR, because the [spec](https://tc39.es/ecma402/#sec-canonicalizetimezonename) already requires current IDs, and there's already a [plan](https://github.com/tc39/ecma402/issues/806#issuecomment-1904654534) to fix it that requires no spec changes.

### Summary of proposed changes

This PR implements "Option C" in https://github.com/tc39/ecma402/issues/825 by deterministically defining ECMAScript's exceptions from the IANA Time Zone Database's defaults, and then pointing implementers at ICU as a convenient implementation of those exceptions.

We'll start with a baseline of IANA's Zone and Link names and specify a few exceptions:
1. Existing [special-cases](https://tc39.es/ecma402/#sec-canonicalizetimezonename) for Etc/UTC, Etc/GMT, and GMT will be retained.
2. Primary and non-primary IDs must share the same ISO-3166-2 country code, so IANA's time zone merges between countries will be reverted. CLDR and ICU already disallow merges across country boundaries. Note that IANA's merges of time zones \*inside\* of a country (e.g. Asia/Chongquing=>Asia/Shanghai) will be accepted, also matching current ICU/CLDR behavior.

This PR also makes two other smaller text changes that we expect to have zero impact on current engines:
* Changes #876's recommendations into requirements to limit observable dynamic updating of TZDB info. AFAIK, no existing ECMAScript engine updates TZDB (observably or otherwise!) during the lifetime of the surrounding agent, so this is really a future-compatibility change.
* Adds text recommending a two-year waiting period before a newly-renamed ID becomes primary. These are rare (the last was 2022's Europe/Kiev=>Europe/Kyiv) and when the next rename happens, we'll try to convince CLDR to implement this requirement for us. There are no pending renames, so this is also a future-compatibility change.

### Per-engine changes required

Implementing the changes in this PR will impact JS engines differently, given the current divergence between engines:

* For V8 (cc @FrankYFTang) and JSC (cc @Constellation), there should be no change because they rely on ICU and CLDR which already behave like 1-3 above. Note that this PR doesn't affect the [plan](https://github.com/tc39/ecma402/issues/806#issuecomment-1904654534) to fix out-of-date canonicalizations like Asia/Calcutta and Europe/Kiev. This plan is unchanged: as part of landing Temporal Stage 4, switch to use ICU's new [`icu::TimeZone::getIanaID()`](https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/classicu_1_1TimeZone.html#a7e182f60aa75c78a623065ad8470d290), which returns the latest IANA IDs instead of out-of-date canonical IDs like Asia/Calcutta.

* For SpiderMonkey (cc @anba), more changes are needed because currently SpiderMonkey conforms to the [spec](https://tc39.es/ecma402/#sec-canonicalizetimezonename) which requires using `backward` in TZDB to determine canonicalization. SM could use  [`icu::TimeZone::getIanaID()`](https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/classicu_1_1TimeZone.html#a7e182f60aa75c78a623065ad8470d290) to implement (2) and (3) above, or could implement the same behavior by reading CLDR data or IANA data directly. Also, this PR will reduce SM's [differences](https://github.com/tc39/ecma402/issues/778) in `Intl.supportedValuesOf('timeZone')` vs. V8/JSC.

### Testing

Test262 changes will be needed to validate these normative changes, but I'm not sure how we can run those tests except using the Temporal polyfill. @ptomato I'll be looking for your advice (and perhaps help writing tests!) on this point.

### Feedback requested

Feedback is welcome on any part of this proposal, but I'm most interested in making sure that the spec text actually accomplishes what the summary above claims that it does. 