### PR TITLE
Editorial: Fix missing dot operator in Intl.Segmenter-related objects

### DIFF
--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -94,12 +94,12 @@
         <tr>
           <td>%Intl.SegmentIteratorPrototype%</td>
           <td></td>
-          <td>The prototype of Segment Iterator objects (<emu-xref href="#sec-intlsegmentiteratorprototype-object"></emu-xref>)</td>
+          <td>The prototype of Segment Iterator objects (<emu-xref href="#sec-intl-segmentiteratorprototype-object"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%Intl.SegmentsPrototype%</td>
           <td></td>
-          <td>The prototype of Segments objects (<emu-xref href="#sec-intlsegmentsprototype-object"></emu-xref>)</td>
+          <td>The prototype of Segments objects (<emu-xref href="#sec-intl-segmentsprototype-object"></emu-xref>)</td>
         </tr>
       </table>
     </emu-table>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -94,12 +94,12 @@
         <tr>
           <td>%Intl.SegmentIteratorPrototype%</td>
           <td></td>
-          <td>The prototype of Segment Iterator objects (<emu-xref href="#sec-%intlsegmentiteratorprototype%-object"></emu-xref>)</td>
+          <td>The prototype of Segment Iterator objects (<emu-xref href="#sec-intlsegmentiteratorprototype-object"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%Intl.SegmentsPrototype%</td>
           <td></td>
-          <td>The prototype of Segments objects (<emu-xref href="#sec-%intlsegmentsprototype%-object"></emu-xref>)</td>
+          <td>The prototype of Segments objects (<emu-xref href="#sec-intlsegmentsprototype-object"></emu-xref>)</td>
         </tr>
       </table>
     </emu-table>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -92,12 +92,12 @@
           <td>The `Intl.Segmenter` constructor (<emu-xref href="#sec-intl-segmenter-constructor"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%IntlSegmentIteratorPrototype%</td>
+          <td>%Intl.SegmentIteratorPrototype%</td>
           <td></td>
           <td>The prototype of Segment Iterator objects (<emu-xref href="#sec-%intlsegmentiteratorprototype%-object"></emu-xref>)</td>
         </tr>
         <tr>
-          <td>%IntlSegmentsPrototype%</td>
+          <td>%Intl.SegmentsPrototype%</td>
           <td></td>
           <td>The prototype of Segments objects (<emu-xref href="#sec-%intlsegmentsprototype%-object"></emu-xref>)</td>
         </tr>

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -192,7 +192,7 @@
     <h1>Segments Objects</h1>
 
     <p>
-      A <dfn>Segments instance</dfn> is an object that represents the segments of a specific string, subject to the locale and options of its constructing Intl.Segmenter instance.
+      A <dfn>Segments</dfn> is an object that represents the segments of a specific string, subject to the locale and options of its constructing Intl.Segmenter instance.
     </p>
 
     <emu-clause id="sec-createsegmentsobject" type="abstract operation">
@@ -217,7 +217,7 @@
 
     <emu-clause id="sec-intl-segmentsprototype-object" oldids="sec-%intlsegmentsprototype%-object,sec-%segmentsprototype%-object">
       <h1>The %Intl.SegmentsPrototype% Object</h1>
-      <p>The <dfn>%Intl.SegmentsPrototype%</dfn> object:</p>
+      <p>The <dfn>%Intl.SegmentsPrototype%</dfn> intrinsic object:</p>
       <ul>
         <li>is the prototype of all Segments objects.</li>
         <li>is an ordinary object.</li>
@@ -301,7 +301,7 @@
 
     <emu-clause id="sec-intl-segmentiteratorprototype-object" oldids="sec-%segmentiteratorprototype%-object,sec-%intlsegmentiteratorprototype%-object">
       <h1>The %Intl.SegmentIteratorPrototype% Object</h1>
-      <p>The <dfn>%Intl.SegmentIteratorPrototype%</dfn> object:</p>
+      <p>The <dfn>%Intl.SegmentIteratorPrototype%</dfn> intrinsic object:</p>
       <ul>
         <li>is the prototype of all Segment Iterator objects.</li>
         <li>is an ordinary object.</li>

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -215,7 +215,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-intlsegmentsprototype-object" oldids="sec-%intlsegmentsprototype%-object,sec-%segmentsprototype%-object">
+    <emu-clause id="sec-intl-segmentsprototype-object" oldids="sec-%intlsegmentsprototype%-object,sec-%segmentsprototype%-object">
       <h1>The %Intl.SegmentsPrototype% Object</h1>
       <p>The <dfn>%Intl.SegmentsPrototype%</dfn> object:</p>
       <ul>
@@ -224,7 +224,7 @@
         <li>has the following properties:</li>
       </ul>
 
-      <emu-clause id="sec-intlsegmentsprototype.containing" oldids="sec-%intlsegmentsprototype%.containing,sec-%segmentsprototype%.containing">
+      <emu-clause id="sec-intl-segmentsprototype.containing" oldids="sec-%intlsegmentsprototype%.containing,sec-%segmentsprototype%.containing">
         <h1>Intl.SegmentsPrototype.containing ( _index_ )</h1>
         <p>The `containing` method is called on a Segments instance with argument _index_ to return a Segment Data object describing the segment in the string including the code unit at the specified index according to the locale and options of the Segments instance's constructing Intl.Segmenter instance. The following steps are taken:</p>
         <emu-alg>
@@ -241,7 +241,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-intlsegmentsprototype-@@iterator" oldids="sec-%segmentsprototype%-@@iterator,sec-%intlsegmentsprototype%-@@iterator">
+      <emu-clause id="sec-intl-segmentsprototype-@@iterator" oldids="sec-%segmentsprototype%-@@iterator,sec-%intlsegmentsprototype%-@@iterator">
         <h1>Intl.SegmentsPrototype [ @@iterator ] ( )</h1>
         <p>The `@@iterator` method is called on a Segments instance to create a Segment Iterator over its string using the locale and options of its constructing Intl.Segmenter instance. The following steps are taken:</p>
         <emu-alg>
@@ -299,7 +299,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-intlsegmentiteratorprototype-object" oldids="sec-%segmentiteratorprototype%-object,sec-%intlsegmentiteratorprototype%-object">
+    <emu-clause id="sec-intl-segmentiteratorprototype-object" oldids="sec-%segmentiteratorprototype%-object,sec-%intlsegmentiteratorprototype%-object">
       <h1>The %Intl.SegmentIteratorPrototype% Object</h1>
       <p>The <dfn>%Intl.SegmentIteratorPrototype%</dfn> object:</p>
       <ul>
@@ -309,7 +309,7 @@
         <li>has the following properties:</li>
       </ul>
 
-      <emu-clause id="sec-intlsegmentiteratorprototype.next" oldids="sec-%segmentiteratorprototype%.next,sec-%intlsegmentiteratorprototype%.next">
+      <emu-clause id="sec-intl-segmentiteratorprototype.next" oldids="sec-%segmentiteratorprototype%.next,sec-%intlsegmentiteratorprototype%.next">
         <h1>Intl.SegmentIteratorPrototype.next ( )</h1>
         <p>The `next` method is called on a Segment Iterator instance to advance it forward one segment and return an <i>IteratorResult</i> object either describing the new segment or declaring iteration done. The following steps are taken:</p>
         <emu-alg>
@@ -327,7 +327,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-intlsegmentiteratorprototype.@@tostringtag" oldids="sec-%intlsegmentiteratorprototype%.@@tostringtag,sec-%segmentiteratorprototype%.@@tostringtag">
+      <emu-clause id="sec-intl-segmentiteratorprototype.@@tostringtag" oldids="sec-%intlsegmentiteratorprototype%.@@tostringtag,sec-%segmentiteratorprototype%.@@tostringtag">
         <h1>Intl.SegmentIteratorPrototype [ @@toStringTag ]</h1>
 
         <p>

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -215,7 +215,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-%intlsegmentsprototype%-object" oldids="sec-%segmentsprototype%-object">
+    <emu-clause id="sec-intlsegmentsprototype-object" oldids="sec-%intlsegmentsprototype%-object,sec-%segmentsprototype%-object">
       <h1>The %Intl.SegmentsPrototype% Object</h1>
       <p>The <dfn>%Intl.SegmentsPrototype%</dfn> object:</p>
       <ul>
@@ -224,8 +224,8 @@
         <li>has the following properties:</li>
       </ul>
 
-      <emu-clause id="sec-%intlsegmentsprototype%.containing" oldids="sec-%segmentsprototype%.containing">
-        <h1>%Intl.SegmentsPrototype%.containing ( _index_ )</h1>
+      <emu-clause id="sec-intlsegmentsprototype.containing" oldids="sec-%intlsegmentsprototype%.containing,sec-%segmentsprototype%.containing">
+        <h1>Intl.SegmentsPrototype.containing ( _index_ )</h1>
         <p>The `containing` method is called on a Segments instance with argument _index_ to return a Segment Data object describing the segment in the string including the code unit at the specified index according to the locale and options of the Segments instance's constructing Intl.Segmenter instance. The following steps are taken:</p>
         <emu-alg>
           1. Let _segments_ be the *this* value.
@@ -241,8 +241,8 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%intlsegmentsprototype%-@@iterator" oldids="sec-%segmentsprototype%-@@iterator">
-        <h1>%Intl.SegmentsPrototype% [ @@iterator ] ( )</h1>
+      <emu-clause id="sec-intlsegmentsprototype-@@iterator" oldids="sec-%segmentsprototype%-@@iterator,sec-%intlsegmentsprototype%-@@iterator">
+        <h1>Intl.SegmentsPrototype [ @@iterator ] ( )</h1>
         <p>The `@@iterator` method is called on a Segments instance to create a Segment Iterator over its string using the locale and options of its constructing Intl.Segmenter instance. The following steps are taken:</p>
         <emu-alg>
           1. Let _segments_ be the *this* value.
@@ -299,7 +299,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-%intlsegmentiteratorprototype%-object" oldids="sec-%segmentiteratorprototype%-object">
+    <emu-clause id="sec-intlsegmentiteratorprototype-object" oldids="sec-%segmentiteratorprototype%-object,sec-%intlsegmentiteratorprototype%-object">
       <h1>The %Intl.SegmentIteratorPrototype% Object</h1>
       <p>The <dfn>%Intl.SegmentIteratorPrototype%</dfn> object:</p>
       <ul>
@@ -309,8 +309,8 @@
         <li>has the following properties:</li>
       </ul>
 
-      <emu-clause id="sec-%intlsegmentiteratorprototype%.next" oldids="sec-%segmentiteratorprototype%.next">
-        <h1>%Intl.SegmentIteratorPrototype%.next ( )</h1>
+      <emu-clause id="sec-intlsegmentiteratorprototype.next" oldids="sec-%segmentiteratorprototype%.next,sec-%intlsegmentiteratorprototype%.next">
+        <h1>Intl.SegmentIteratorPrototype.next ( )</h1>
         <p>The `next` method is called on a Segment Iterator instance to advance it forward one segment and return an <i>IteratorResult</i> object either describing the new segment or declaring iteration done. The following steps are taken:</p>
         <emu-alg>
           1. Let _iterator_ be the *this* value.
@@ -327,8 +327,8 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%intlsegmentiteratorprototype%.@@tostringtag" oldids="sec-%segmentiteratorprototype%.@@tostringtag">
-        <h1>%Intl.SegmentIteratorPrototype% [ @@toStringTag ]</h1>
+      <emu-clause id="sec-intlsegmentiteratorprototype.@@tostringtag" oldids="sec-%intlsegmentiteratorprototype%.@@tostringtag,sec-%segmentiteratorprototype%.@@tostringtag">
+        <h1>Intl.SegmentIteratorPrototype [ @@toStringTag ]</h1>
 
         <p>
           The initial value of the @@toStringTag property is the String value *"Segmenter String Iterator"*.

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -208,7 +208,7 @@
       </dl>
       <emu-alg>
         1. Let _internalSlotsList_ be &laquo; [[SegmentsSegmenter]], [[SegmentsString]] &raquo;.
-        1. Let _segments_ be OrdinaryObjectCreate(%IntlSegmentsPrototype%, _internalSlotsList_).
+        1. Let _segments_ be OrdinaryObjectCreate(%Intl.SegmentsPrototype%, _internalSlotsList_).
         1. Set _segments_.[[SegmentsSegmenter]] to _segmenter_.
         1. Set _segments_.[[SegmentsString]] to _string_.
         1. Return _segments_.
@@ -216,8 +216,8 @@
     </emu-clause>
 
     <emu-clause id="sec-%intlsegmentsprototype%-object" oldids="sec-%segmentsprototype%-object">
-      <h1>The %IntlSegmentsPrototype% Object</h1>
-      <p>The <dfn>%IntlSegmentsPrototype%</dfn> object:</p>
+      <h1>The %Intl.SegmentsPrototype% Object</h1>
+      <p>The <dfn>%Intl.SegmentsPrototype%</dfn> object:</p>
       <ul>
         <li>is the prototype of all Segments objects.</li>
         <li>is an ordinary object.</li>
@@ -225,7 +225,7 @@
       </ul>
 
       <emu-clause id="sec-%intlsegmentsprototype%.containing" oldids="sec-%segmentsprototype%.containing">
-        <h1>%IntlSegmentsPrototype%.containing ( _index_ )</h1>
+        <h1>%Intl.SegmentsPrototype%.containing ( _index_ )</h1>
         <p>The `containing` method is called on a Segments instance with argument _index_ to return a Segment Data object describing the segment in the string including the code unit at the specified index according to the locale and options of the Segments instance's constructing Intl.Segmenter instance. The following steps are taken:</p>
         <emu-alg>
           1. Let _segments_ be the *this* value.
@@ -242,7 +242,7 @@
       </emu-clause>
 
       <emu-clause id="sec-%intlsegmentsprototype%-@@iterator" oldids="sec-%segmentsprototype%-@@iterator">
-        <h1>%IntlSegmentsPrototype% [ @@iterator ] ( )</h1>
+        <h1>%Intl.SegmentsPrototype% [ @@iterator ] ( )</h1>
         <p>The `@@iterator` method is called on a Segments instance to create a Segment Iterator over its string using the locale and options of its constructing Intl.Segmenter instance. The following steps are taken:</p>
         <emu-alg>
           1. Let _segments_ be the *this* value.
@@ -258,7 +258,7 @@
       <h1>Properties of Segments Instances</h1>
 
       <p>
-        Segments instances are ordinary objects that inherit properties from %IntlSegmentsPrototype%.
+        Segments instances are ordinary objects that inherit properties from %Intl.SegmentsPrototype%.
       </p>
 
       <p>
@@ -291,7 +291,7 @@
       </dl>
       <emu-alg>
         1. Let _internalSlotsList_ be &laquo; [[IteratingSegmenter]], [[IteratedString]], [[IteratedStringNextSegmentCodeUnitIndex]] &raquo;.
-        1. Let _iterator_ be OrdinaryObjectCreate(%IntlSegmentIteratorPrototype%, _internalSlotsList_).
+        1. Let _iterator_ be OrdinaryObjectCreate(%Intl.SegmentIteratorPrototype%, _internalSlotsList_).
         1. Set _iterator_.[[IteratingSegmenter]] to _segmenter_.
         1. Set _iterator_.[[IteratedString]] to _string_.
         1. Set _iterator_.[[IteratedStringNextSegmentCodeUnitIndex]] to 0.
@@ -300,8 +300,8 @@
     </emu-clause>
 
     <emu-clause id="sec-%intlsegmentiteratorprototype%-object" oldids="sec-%segmentiteratorprototype%-object">
-      <h1>The %IntlSegmentIteratorPrototype% Object</h1>
-      <p>The <dfn>%IntlSegmentIteratorPrototype%</dfn> object:</p>
+      <h1>The %Intl.SegmentIteratorPrototype% Object</h1>
+      <p>The <dfn>%Intl.SegmentIteratorPrototype%</dfn> object:</p>
       <ul>
         <li>is the prototype of all Segment Iterator objects.</li>
         <li>is an ordinary object.</li>
@@ -310,7 +310,7 @@
       </ul>
 
       <emu-clause id="sec-%intlsegmentiteratorprototype%.next" oldids="sec-%segmentiteratorprototype%.next">
-        <h1>%IntlSegmentIteratorPrototype%.next ( )</h1>
+        <h1>%Intl.SegmentIteratorPrototype%.next ( )</h1>
         <p>The `next` method is called on a Segment Iterator instance to advance it forward one segment and return an <i>IteratorResult</i> object either describing the new segment or declaring iteration done. The following steps are taken:</p>
         <emu-alg>
           1. Let _iterator_ be the *this* value.
@@ -328,7 +328,7 @@
       </emu-clause>
 
       <emu-clause id="sec-%intlsegmentiteratorprototype%.@@tostringtag" oldids="sec-%segmentiteratorprototype%.@@tostringtag">
-        <h1>%IntlSegmentIteratorPrototype% [ @@toStringTag ]</h1>
+        <h1>%Intl.SegmentIteratorPrototype% [ @@toStringTag ]</h1>
 
         <p>
           The initial value of the @@toStringTag property is the String value *"Segmenter String Iterator"*.


### PR DESCRIPTION
The intrinsics `%Intl.SegmentIteratorPrototype%` and `%Intl.SegmentsPrototype%` had been written without the member access operator, i.e. `%IntlSegmentIteratorPrototype%` and `%IntlSegmentsPrototype%`. Also regularized wording of `<emu-clause>` `id` attributes