### PR TITLE
Editorial: Replace irregular "is equal to" language

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -140,7 +140,7 @@
       <ul>
         <li>The first element of [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] must be *null*.</li>
         <li>The values *"standard"* and *"search"* must not be used as elements in any [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] list.</li>
-        <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] must have a [[sensitivity]] field with a String value equal to *"base"*, *"accent"*, *"case"*, or *"variant"*.</li>
+        <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] must have a [[sensitivity]] field with one of the String values *"base"*, *"accent"*, *"case"*, or *"variant"*.</li>
         <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] and [[SortLocaleData]].[[&lt;_locale_&gt;]] must have an [[ignorePunctuation]] field with a Boolean value.</li>
       </ul>
     </emu-clause>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -260,13 +260,13 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hc]] must be &laquo; *null*, *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle]] must be a String value equal to *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle]] must be one of the String values *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle12]] must be a String value equal to *"h11"* or *"h12"*.
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle12]] must be one of the String values *"h11"* or *"h12"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle24]] must be a String value equal to *"h23"* or *"h24"*.
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle24]] must be one of the String values *"h23"* or *"h24"*.
         </li>
         <li>
           [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. This [[formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a list of records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
@@ -1010,17 +1010,17 @@
           1. Let _p_ be _patternPart_.[[Type]].
           1. If _p_ is *"literal"*, then
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
-          1. Else if _p_ is equal to *"fractionalSecondDigits"*, then
+          1. Else if _p_ is *"fractionalSecondDigits"*, then
             1. Assert: _fractionalSecondDigits_ is not *undefined*.
             1. Let _v_ be _tm_.[[Millisecond]].
             1. Set _v_ to floor(_v_ &times; 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
             1. Let _fv_ be FormatNumeric(_nf3_, _v_).
             1. Append the Record { [[Type]]: *"fractionalSecond"*, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is equal to *"dayPeriod"*, then
+          1. Else if _p_ is *"dayPeriod"*, then
             1. Let _f_ be _dateTimeFormat_.[[DayPeriod]].
             1. Let _fv_ be a String value representing the day period of _tm_ in the form given by _f_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is equal to *"timeZoneName"*, then
+          1. Else if _p_ is *"timeZoneName"*, then
             1. Let _f_ be _dateTimeFormat_.[[TimeZoneName]].
             1. Let _v_ be _dateTimeFormat_.[[TimeZone]].
             1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_. The String value may also depend on the value of the [[InDST]] field of _tm_ if _f_ is *"short"*, *"long"*, *"shortOffset"*, or *"longOffset"*. If the implementation does not have such a localized representation of _v_, then use the String value of _v_ itself.
@@ -1044,18 +1044,18 @@
             1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then
               1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether _dateTimeFormat_.[[Day]] is *undefined*. If _p_ is *"month"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[day]] is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether _dateTimeFormat_.[[Era]] is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[era]] is *undefined*. If the implementation does not have such a localized representation of _v_, then use ! ToString(_v_).
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is equal to *"ampm"*, then
+          1. Else if _p_ is *"ampm"*, then
             1. Let _v_ be _tm_.[[Hour]].
             1. If _v_ is greater than 11, then
               1. Let _fv_ be an implementation and locale dependent String value representing *"post meridiem"*.
             1. Else,
               1. Let _fv_ be an implementation and locale dependent String value representing *"ante meridiem"*.
             1. Append the Record { [[Type]]: *"dayPeriod"*, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is equal to *"relatedYear"*, then
+          1. Else if _p_ is *"relatedYear"*, then
             1. Let _v_ be _tm_.[[RelatedYear]].
             1. Let _fv_ be FormatNumeric(_nf_, _v_).
             1. Append the Record { [[Type]]: *"relatedYear"*, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is equal to *"yearName"*, then
+          1. Else if _p_ is *"yearName"*, then
             1. Let _v_ be _tm_.[[YearName]].
             1. Let _fv_ be an implementation and locale dependent String value representing _v_.
             1. Append the Record { [[Type]]: *"yearName"*, [[Value]]: _fv_ } to _result_.
@@ -1160,13 +1160,13 @@
             1. Set _checkMoreFields_ to *false*.
           1. If _relevantFieldsEqual_ is *true* and _checkMoreFields_ is *true*, then
             1. Set _selectedRangePattern_ to _rangePattern_.
-            1. If _fieldName_ is equal to [[AmPm]], then
+            1. If _fieldName_ is [[AmPm]], then
               1. If _tm1_.[[Hour]] is less than 12, let _v1_ be *"am"*; else let _v1_ be *"pm"*.
               1. If _tm2_.[[Hour]] is less than 12, let _v2_ be *"am"*; else let _v2_ be *"pm"*.
-            1. Else if _fieldName_ is equal to [[DayPeriod]], then
+            1. Else if _fieldName_ is [[DayPeriod]], then
               1. Let _v1_ be a String value representing the day period of _tm1_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
               1. Let _v2_ be a String value representing the day period of _tm2_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
-            1. Else if _fieldName_ is equal to [[FractionalSecondDigits]], then
+            1. Else if _fieldName_ is [[FractionalSecondDigits]], then
               1. Let _fractionalSecondDigits_ be _dateTimeFormat_.[[FractionalSecondDigits]].
               1. If _fractionalSecondDigits_ is *undefined*, then
                 1. Set _fractionalSecondDigits_ to 3.
@@ -1176,7 +1176,7 @@
             1. Else,
               1. Let _v1_ be _tm1_.[[&lt;_fieldName_&gt;]].
               1. Let _v2_ be _tm2_.[[&lt;_fieldName_&gt;]].
-            1. If _v1_ is not equal to _v2_, then
+            1. If _v1_ is not _v2_, then
               1. Set _relevantFieldsEqual_ to *false*.
         1. If _relevantFieldsEqual_ is *true*, then
           1. Let _collapsedResult_ be a new empty List.

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -97,7 +97,7 @@
             1. Set _newExtension_ to the string-concatenation of _newExtension_, *"-"*, and _keyword_.[[Key]].
             1. If _keyword_.[[Value]] is not the empty String, then
               1. Set _newExtension_ to the string-concatenation of _newExtension_, *"-"*, and _keyword_.[[Value]].
-          1. Assert: _newExtension_ is not equal to *"-u"*.
+          1. Assert: _newExtension_ is not *"-u"*.
           1. Set _localeId_ to a copy of _localeId_ in which the first appearance of <emu-not-ref>substring</emu-not-ref> _extension_ has been replaced with _newExtension_.
         1. Return _localeId_.
       </emu-alg>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -183,7 +183,7 @@
           1. Set _intlObj_.[[ComputedRoundingPriority]] to *"auto"*.
         1. If _roundingIncrement_ is not 1, then
           1. If _intlObj_.[[RoundingType]] is not ~fraction-digits~, throw a *TypeError* exception.
-          1. If _intlObj_.[[MaximumFractionDigits]] is not equal to _intlObj_.[[MinimumFractionDigits]], throw a *RangeError* exception.
+          1. If _intlObj_.[[MaximumFractionDigits]] is not _intlObj_.[[MinimumFractionDigits]], throw a *RangeError* exception.
         1. Return ~unused~.
       </emu-alg>
     </emu-clause>
@@ -712,7 +712,7 @@
       </dl>
       <emu-alg>
         1. Assert: IsWellFormedCurrencyCode(_currency_) is *true*.
-        1. Assert: _currency_ is equal to the ASCII-uppercase of _currency_.
+        1. Assert: _currency_ is the ASCII-uppercase of _currency_.
         1. If the ISO 4217 currency and funds code list contains _currency_ as an alphabetic code, return the minor unit value corresponding to the _currency_ from the list; otherwise, return 2.
       </emu-alg>
     </emu-clause>
@@ -828,39 +828,39 @@
           1. Let _p_ be _patternPart_.[[Type]].
           1. If _p_ is *"literal"*, then
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
-          1. Else if _p_ is equal to *"number"*, then
+          1. Else if _p_ is *"number"*, then
             1. Let _notationSubParts_ be PartitionNotationSubPattern(_numberFormat_, _x_, _n_, _exponent_).
             1. For each Record { [[Type]], [[Value]] } _subPart_ of _notationSubParts_, do
               1. Append _subPart_ to _result_.
-          1. Else if _p_ is equal to *"plusSign"*, then
+          1. Else if _p_ is *"plusSign"*, then
             1. Let _plusSignSymbol_ be the ILND String representing the plus sign.
             1. Append the Record { [[Type]]: *"plusSign"*, [[Value]]: _plusSignSymbol_ } to _result_.
-          1. Else if _p_ is equal to *"minusSign"*, then
+          1. Else if _p_ is *"minusSign"*, then
             1. Let _minusSignSymbol_ be the ILND String representing the minus sign.
             1. Append the Record { [[Type]]: *"minusSign"*, [[Value]]: _minusSignSymbol_ } to _result_.
-          1. Else if _p_ is equal to *"percentSign"* and _numberFormat_.[[Style]] is *"percent"*, then
+          1. Else if _p_ is *"percentSign"* and _numberFormat_.[[Style]] is *"percent"*, then
             1. Let _percentSignSymbol_ be the ILND String representing the percent sign.
             1. Append the Record { [[Type]]: *"percentSign"*, [[Value]]: _percentSignSymbol_ } to _result_.
-          1. Else if _p_ is equal to *"unitPrefix"* and _numberFormat_.[[Style]] is *"unit"*, then
+          1. Else if _p_ is *"unitPrefix"* and _numberFormat_.[[Style]] is *"unit"*, then
             1. Let _unit_ be _numberFormat_.[[Unit]].
             1. Let _unitDisplay_ be _numberFormat_.[[UnitDisplay]].
             1. Let _mu_ be an ILD String value representing _unit_ before _x_ in _unitDisplay_ form, which may depend on _x_ in languages having different plural forms.
             1. Append the Record { [[Type]]: *"unit"*, [[Value]]: _mu_ } to _result_.
-          1. Else if _p_ is equal to *"unitSuffix"* and _numberFormat_.[[Style]] is *"unit"*, then
+          1. Else if _p_ is *"unitSuffix"* and _numberFormat_.[[Style]] is *"unit"*, then
             1. Let _unit_ be _numberFormat_.[[Unit]].
             1. Let _unitDisplay_ be _numberFormat_.[[UnitDisplay]].
             1. Let _mu_ be an ILD String value representing _unit_ after _x_ in _unitDisplay_ form, which may depend on _x_ in languages having different plural forms.
             1. Append the Record { [[Type]]: *"unit"*, [[Value]]: _mu_ } to _result_.
-          1. Else if _p_ is equal to *"currencyCode"* and _numberFormat_.[[Style]] is *"currency"*, then
+          1. Else if _p_ is *"currencyCode"* and _numberFormat_.[[Style]] is *"currency"*, then
             1. Let _currency_ be _numberFormat_.[[Currency]].
             1. Let _cd_ be _currency_.
             1. Append the Record { [[Type]]: *"currency"*, [[Value]]: _cd_ } to _result_.
-          1. Else if _p_ is equal to *"currencyPrefix"* and _numberFormat_.[[Style]] is *"currency"*, then
+          1. Else if _p_ is *"currencyPrefix"* and _numberFormat_.[[Style]] is *"currency"*, then
             1. Let _currency_ be _numberFormat_.[[Currency]].
             1. Let _currencyDisplay_ be _numberFormat_.[[CurrencyDisplay]].
             1. Let _cd_ be an ILD String value representing _currency_ before _x_ in _currencyDisplay_ form, which may depend on _x_ in languages having different plural forms.
             1. Append the Record { [[Type]]: *"currency"*, [[Value]]: _cd_ } to _result_.
-          1. Else if _p_ is equal to *"currencySuffix"* and _numberFormat_.[[Style]] is *"currency"*, then
+          1. Else if _p_ is *"currencySuffix"* and _numberFormat_.[[Style]] is *"currency"*, then
             1. Let _currency_ be _numberFormat_.[[Currency]].
             1. Let _currencyDisplay_ be _numberFormat_.[[CurrencyDisplay]].
             1. Let _cd_ be an ILD String value representing _currency_ after _x_ in _currencyDisplay_ form, which may depend on _x_ in languages having different plural forms. If the implementation does not have such a representation of _currency_, use _currency_ itself.
@@ -901,7 +901,7 @@
             1. Let _p_ be _patternPart_.[[Type]].
             1. If _p_ is *"literal"*, then
               1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
-            1. Else if _p_ is equal to *"number"*, then
+            1. Else if _p_ is *"number"*, then
               1. If the _numberFormat_.[[NumberingSystem]] matches one of the values in the Numbering System column of <emu-xref href="#table-numbering-system-digits"></emu-xref> below, then
                 1. Let _digits_ be a List whose elements are the code points specified in the Digits column of the matching row in <emu-xref href="#table-numbering-system-digits"></emu-xref>.
                 1. Assert: The length of _digits_ is 10.
@@ -941,16 +941,16 @@
                 1. Let _decimalSepSymbol_ be the ILND String representing the decimal separator.
                 1. Append the Record { [[Type]]: *"decimal"*, [[Value]]: _decimalSepSymbol_ } to _result_.
                 1. Append the Record { [[Type]]: *"fraction"*, [[Value]]: _fraction_ } to _result_.
-            1. Else if _p_ is equal to *"compactSymbol"*, then
+            1. Else if _p_ is *"compactSymbol"*, then
               1. Let _compactSymbol_ be an ILD string representing _exponent_ in short form, which may depend on _x_ in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a *"{compactSymbol}"* placeholder.
               1. Append the Record { [[Type]]: *"compact"*, [[Value]]: _compactSymbol_ } to _result_.
-            1. Else if _p_ is equal to *"compactName"*, then
+            1. Else if _p_ is *"compactName"*, then
               1. Let _compactName_ be an ILD string representing _exponent_ in long form, which may depend on _x_ in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a *"{compactName}"* placeholder.
               1. Append the Record { [[Type]]: *"compact"*, [[Value]]: _compactName_ } to _result_.
-            1. Else if _p_ is equal to *"scientificSeparator"*, then
+            1. Else if _p_ is *"scientificSeparator"*, then
               1. Let _scientificSeparator_ be the ILND String representing the exponent separator.
               1. Append the Record { [[Type]]: *"exponentSeparator"*, [[Value]]: _scientificSeparator_ } to _result_.
-            1. Else if _p_ is equal to *"scientificExponent"*, then
+            1. Else if _p_ is *"scientificExponent"*, then
               1. If _exponent_ &lt; 0, then
                 1. Let _minusSignSymbol_ be the ILND String representing the minus sign.
                 1. Append the Record { [[Type]]: *"exponentMinusSign"*, [[Value]]: _minusSignSymbol_ } to _result_.
@@ -1832,7 +1832,7 @@
         <dd>It considers _x_, bracketed below by _r1_ and above by _r2_, and returns either _r1_ or _r2_ according to _unsignedRoundingMode_.</dd>
       </dl>
       <emu-alg>
-        1. If _x_ is equal to _r1_, return _r1_.
+        1. If _x_ is _r1_, return _r1_.
         1. Assert: _r1_ &lt; _x_ &lt; _r2_.
         1. Assert: _unsignedRoundingMode_ is not *undefined*.
         1. If _unsignedRoundingMode_ is ~zero~, return _r1_.
@@ -1841,7 +1841,7 @@
         1. Let _d2_ be <emu-eqn>_r2_ – _x_</emu-eqn>.
         1. If _d1_ &lt; _d2_, return _r1_.
         1. If _d2_ &lt; _d1_, return _r2_.
-        1. Assert: _d1_ is equal to _d2_.
+        1. Assert: _d1_ is _d2_.
         1. If _unsignedRoundingMode_ is ~half-zero~, return _r1_.
         1. If _unsignedRoundingMode_ is ~half-infinity~, return _r2_.
         1. Assert: _unsignedRoundingMode_ is ~half-even~.
@@ -1868,7 +1868,7 @@
         1. Let _result_ be a new empty List.
         1. Let _xResult_ be PartitionNumberPattern(_numberFormat_, _x_).
         1. Let _yResult_ be PartitionNumberPattern(_numberFormat_, _y_).
-        1. If FormatNumeric(_numberFormat_, _x_) is equal to FormatNumeric(_numberFormat_, _y_), then
+        1. If FormatNumeric(_numberFormat_, _x_) is FormatNumeric(_numberFormat_, _y_), then
           1. Let _appxResult_ be FormatApproximately(_numberFormat_, _xResult_).
           1. For each element _r_ of _appxResult_, do
             1. Set _r_.[[Source]] to *"shared"*.


### PR DESCRIPTION
Editorial: Inspired by https://github.com/tc39/ecma402/pull/869/, regularize comparison language by replacing "is equal to" and "is not equal to" with "is" and "is not" as appropriate.
