### PR TITLE
Editorial: capitalized previously-uncapitalized instances of "list" and "record" as appropriate

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -139,7 +139,7 @@
 
       <ul>
         <li>The first element of [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] must be *null*.</li>
-        <li>The values *"standard"* and *"search"* must not be used as elements in any [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] list.</li>
+        <li>The values *"standard"* and *"search"* must not be used as elements in any [[SortLocaleData]].[[&lt;_locale_&gt;]].[[co]] and [[SearchLocaleData]].[[&lt;_locale_&gt;]].[[co]] List.</li>
         <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] must have a [[sensitivity]] field with one of the String values *"base"*, *"accent"*, *"case"*, or *"variant"*.</li>
         <li>[[SearchLocaleData]].[[&lt;_locale_&gt;]] and [[SortLocaleData]].[[&lt;_locale_&gt;]] must have an [[ignorePunctuation]] field with a Boolean value.</li>
       </ul>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -269,7 +269,7 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle24]] must be one of the String values *"h23"* or *"h24"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. This [[formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a list of records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple records in a list may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. This [[formats]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The value of this field must be a List of Records, each of which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Multiple Records in a List may use the same subset of the fields as long as they have different values for the fields. The following subsets must be available for each locale:
           <ul>
             <li>weekday, year, month, day, hour, minute, second, fractionalSecondDigits</li>
             <li>weekday, year, month, day, hour, minute, second</li>
@@ -284,45 +284,45 @@
             <li>dayPeriod, hour, minute, second</li>
             <li>dayPeriod, hour, minute</li>
           </ul>
-          Each of the records must also have the following fields:
+          Each of the Records must also have the following fields:
           <ol>
-            <li>A [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*.</li>
-            <li>If the record has an [[hour]] field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the [[pattern]] field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</li>
-            <li>If the record has a [[year]] field, the [[pattern]] and [[pattern12]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</li>
+            <li>A [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the Record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*.</li>
+            <li>If the Record has an [[hour]] field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the [[pattern]] field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</li>
+            <li>If the Record has a [[year]] field, the [[pattern]] and [[pattern12]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</li>
             <li>
               A [[rangePatterns]] field with a Record value:
                 <ul>
-                  <li>The [[rangePatterns]] record may have any of the fields in <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref>, where each field represents a range pattern and its value is a Record.
+                  <li>The [[rangePatterns]] Record may have any of the fields in <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref>, where each field represents a range pattern and its value is a Record.
                     <ul>
                       <li>The name of the field indicates the largest calendar element that must be different between the start and end dates in order to use this range pattern. For example, if the field name is [[Month]], it contains the range pattern that should be used to format a date range where the era and year values are the same, but the month value is different.</li>
-                      <li>The record will contain the following fields:</li>
+                      <li>The Record will contain the following fields:</li>
                         <ul>
-                          <li>A subset of the fields shown in the Property column of <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for that field in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref>. All fields required to format a date for any of the [[PatternParts]] records must be present.</li>
-                          <li>A [[PatternParts]] field whose value is a list of Records each representing a part of the range pattern. Each record contains a [[Pattern]] field and a [[Source]] field. The [[Pattern]] field's value is a String of the same format as the regular date pattern String. The [[Source]] field is one of the String values *"shared"*, *"startRange"*, or *"endRange"*. It indicates which of the range's dates should be formatted using the value of the [[Pattern]] field.</li>
+                          <li>A subset of the fields shown in the Property column of <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for that field in the Values column of <emu-xref href="#table-datetimeformat-components"></emu-xref>. All fields required to format a date for any of the [[PatternParts]] Records must be present.</li>
+                          <li>A [[PatternParts]] field whose value is a List of Records each representing a part of the range pattern. Each Record contains a [[Pattern]] field and a [[Source]] field. The [[Pattern]] field's value is a String of the same format as the regular date pattern String. The [[Source]] field is one of the String values *"shared"*, *"startRange"*, or *"endRange"*. It indicates which of the range's dates should be formatted using the value of the [[Pattern]] field.</li>
                         </ul>
                     </ul>
                   </li>
-                  <li>The [[rangePatterns]] record must have a [[Default]] field which contains the default range pattern used when the specific range pattern is not available. Its value is a list of records with the same structure as the other fields in the [[rangePatterns]] record.</li>
+                  <li>The [[rangePatterns]] Record must have a [[Default]] field which contains the default range pattern used when the specific range pattern is not available. Its value is a List of Records with the same structure as the other fields in the [[rangePatterns]] Record.</li>
                 </ul>
             </li>
-            <li>If the record has an [[hour]] field, it must also have a [[rangePatterns12]] field. Its value is similar to the Record in [[rangePatterns]], but it uses a String similar to [[pattern12]] for each part of the range pattern.</li>
-            <li>If the record has a [[year]] field, the [[rangePatterns]] and [[rangePatterns12]] fields may contain range patterns where the [[Pattern]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</li>
+            <li>If the Record has an [[hour]] field, it must also have a [[rangePatterns12]] field. Its value is similar to the Record in [[rangePatterns]], but it uses a String similar to [[pattern12]] for each part of the range pattern.</li>
+            <li>If the Record has a [[year]] field, the [[rangePatterns]] and [[rangePatterns12]] fields may contain range patterns where the [[Pattern]] values may contain the substrings *"{yearName}"* and *"{relatedYear}"*.</li>
           </ol>
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[styles]] field. The [[styles]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The calendar records must contain [[DateFormat]], [[TimeFormat]], [[DateTimeFormat]] and [[DateTimeRangeFormat]] fields, the value of these fields are Records, where each of which has [[full]], [[long]], [[medium]] and [[short]] fields. For [[DateFormat]] and [[TimeFormat]], the value of these fields must be a record, which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Each of the records must also have the following fields:
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[styles]] field. The [[styles]] field must be a Record with [[&lt;_calendar_&gt;]] fields for all calendar values _calendar_. The calendar Records must contain [[DateFormat]], [[TimeFormat]], [[DateTimeFormat]] and [[DateTimeRangeFormat]] fields, the value of these fields are Records, where each of which has [[full]], [[long]], [[medium]] and [[short]] fields. For [[DateFormat]] and [[TimeFormat]], the value of these fields must be a Record, which has a subset of the fields shown in <emu-xref href="#table-datetimeformat-components"></emu-xref>, where each field must have one of the values specified for the field in <emu-xref href="#table-datetimeformat-components"></emu-xref>. Each of the Records must also have the following fields:
           <ol>
-            <li>A [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*.</li>
-            <li>If the record has an [[hour]] field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the pattern field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</li>
-            <li>A [[rangePatterns]] field that contains a record similar to the one described in the [[formats]] field.</li>
-            <li>If the record has an [[hour]] field, it must also have a [[rangePatterns12]] field. Its value is similar to the record in [[rangePatterns]] but it uses a string similar to [[pattern12]] for each range pattern.</li>
+            <li>A [[pattern]] field, whose value is a String value that contains for each of the date and time format component fields of the Record a substring starting with *"{"*, followed by the name of the field, followed by *"}"*.</li>
+            <li>If the Record has an [[hour]] field, it must also have a [[pattern12]] field, whose value is a String value that, in addition to the substrings of the pattern field, contains at least one of the substrings *"{ampm}"* or *"{dayPeriod}"*.</li>
+            <li>A [[rangePatterns]] field that contains a Record similar to the one described in the [[formats]] field.</li>
+            <li>If the Record has an [[hour]] field, it must also have a [[rangePatterns12]] field. Its value is similar to the Record in [[rangePatterns]] but it uses a string similar to [[pattern12]] for each range pattern.</li>
           </ol>
           For [[DateTimeFormat]], the value for each of the fields [[full]], [[long]], [[medium]], and [[short]] must be a string pattern which contains the strings *"{0}"* and *"{1}"*. For [[DateTimeRangeFormat]] the value of these fields must be a nested Record which also has [[full]], [[long]], [[medium]] and [[short]] fields. The [[full]], [[long]], [[medium]] and [[short]] fields in the enclosing Record refer to the date style of the range pattern, while the fields in the nested Record refers to the time style of the range pattern. The value of these fields in the nested Record is a Record with a [[rangePatterns]] field and a [[rangePatterns12]] field which are similar to the [[rangePatterns]] and [rangePatterns12]] fields in [[DateFormat]] and [[TimeFormat]].
          </li>
       </ul>
 
       <emu-note>
-        For example, an implementation might include the following record as part of its English locale data:
+        For example, an implementation might include the following Record as part of its English locale data:
         <ul>
           <li>[[hour]]: *"numeric"*</li>
           <li>[[minute]]: *"numeric"*</li>
@@ -840,7 +840,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>_styles_ is a record from %Intl.DateTimeFormat%.[[LocaleData]].[[&lt;_locale_&gt;]].[[styles]].[[&lt;_calendar_&gt;]] for some locale _locale_ and calendar _calendar_. It returns the appropriate format record for date time formatting based on the parameters.</dd>
+        <dd>_styles_ is a Record from %Intl.DateTimeFormat%.[[LocaleData]].[[&lt;_locale_&gt;]].[[styles]].[[&lt;_calendar_&gt;]] for some locale _locale_ and calendar _calendar_. It returns the appropriate format Record for date time formatting based on the parameters.</dd>
       </dl>
       <emu-alg>
         1. Assert: _dateStyle_ is not *undefined* or _timeStyle_ is not *undefined*.

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -240,9 +240,9 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It deconstructs the pattern string into a list of parts.
+          It deconstructs the pattern string into a List of parts.
           <p>
-            _placeables_ is a Record whose keys are placeables tokens used in the pattern string, and values are parts records (as from PartitionPattern) which will be used in the result List to represent the token part.
+            _placeables_ is a Record whose keys are placeables tokens used in the pattern string, and values are parts Records (as from PartitionPattern) which will be used in the result List to represent the token part.
             Example:
           </p>
           <pre>
@@ -252,7 +252,7 @@ Input:
     [[yy]]: {[[Type]]: "minute", [[Value]]: "06"}
   })
 
-Output (List of parts records):
+Output (List of parts Records):
   &laquo;
     {[[Type]]: "literal", [[Value]]: "AA"},
     {[[Type]]: "hour", [[Value]]: "15"},
@@ -291,7 +291,7 @@ Output (List of parts records):
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It creates the corresponding list of parts according to the effective locale and the formatting options of _listFormat_.</dd>
+        <dd>It creates the corresponding List of parts according to the effective locale and the formatting options of _listFormat_.</dd>
       </dl>
       <emu-alg>
         1. Let _size_ be the number of elements of _list_.

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -250,7 +250,7 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          If _timeZoneIdentifier_ is an available named time zone identifier, then it returns one of the records in the List returned by AvailableNamedTimeZoneIdentifiers.
+          If _timeZoneIdentifier_ is an available named time zone identifier, then it returns one of the Records in the List returned by AvailableNamedTimeZoneIdentifiers.
           Otherwise, ~empty~ will be returned.
         </dd>
       </dl>
@@ -261,7 +261,7 @@
       </emu-alg>
       <emu-note>
         For any _timeZoneIdentifier_, or any value that is an ASCII-case-insensitive match for it, it is recommended that the resulting Time Zone Identifier Record contain the same field values for the lifetime of the surrounding agent.
-        Furthermore, it is recommended that time zone identifiers not dynamically change from primary to non-primary during the lifetime of the surrounding agent, meaning that if _timeZoneIdentifier_ is an ASCII-case-insensitive match for the [[PrimaryIdentifier]] field of the result of a previous call to GetAvailableNamedTimeZoneIdentifier, then GetAvailableNamedTimeZoneIdentifier(_timeZoneIdentifier_) must return a record where [[Identifier]] is [[PrimaryIdentifier]].
+        Furthermore, it is recommended that time zone identifiers not dynamically change from primary to non-primary during the lifetime of the surrounding agent, meaning that if _timeZoneIdentifier_ is an ASCII-case-insensitive match for the [[PrimaryIdentifier]] field of the result of a previous call to GetAvailableNamedTimeZoneIdentifier, then GetAvailableNamedTimeZoneIdentifier(_timeZoneIdentifier_) must return a Record where [[Identifier]] is [[PrimaryIdentifier]].
         Due to the complexity of supporting these recommendations, it is recommended that the result of AvailableNamedTimeZoneIdentifiers (and therefore GetAvailableNamedTimeZoneIdentifier too) remains the same for the lifetime of the surrounding agent.
       </emu-note>
     </emu-clause>
@@ -421,7 +421,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The returned List is sorted according to lexicographic code unit order, and contains unique canonical numbering systems identifiers identifying the numbering systems for which the implementation provides the functionality of Intl.DateTimeFormat, Intl.NumberFormat, and Intl.RelativeTimeFormat objects. The list must include the Numbering System value of every row of <emu-xref href="#table-numbering-system-digits"></emu-xref>, except the header row.</dd>
+        <dd>The returned List is sorted according to lexicographic code unit order, and contains unique canonical numbering systems identifiers identifying the numbering systems for which the implementation provides the functionality of Intl.DateTimeFormat, Intl.NumberFormat, and Intl.RelativeTimeFormat objects. The List must include the Numbering System value of every row of <emu-xref href="#table-numbering-system-digits"></emu-xref>, except the header row.</dd>
       </dl>
     </emu-clause>
   </emu-clause>
@@ -459,7 +459,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The returned List is sorted according to lexicographic code unit order, and contains unique canonical calendar types identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects. The list must include *"iso8601"*.</dd>
+        <dd>The returned List is sorted according to lexicographic code unit order, and contains unique canonical calendar types identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects. The List must include *"iso8601"*.</dd>
       </dl>
     </emu-clause>
   </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -10,7 +10,7 @@
   </p>
 
   <p>
-    A <dfn id="language-priority-list">language priority list</dfn> is a List of <emu-xref href="#sec-isstructurallyvalidlanguagetag">structurally valid</emu-xref> and <emu-xref href="#sec-canonicalizeunicodelocaleid">canonicalized</emu-xref> language tags representing a sequence of locale preferences by descending priority. It corresponds with the term of the same name defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-2.3">RFC 4647 section 2.3</a> but prohibits *"\*"* elements and contains only canonicalized contents.
+    A <dfn id="language-priority-list">Language Priority List</dfn> is a List of <emu-xref href="#sec-isstructurallyvalidlanguagetag">structurally valid</emu-xref> and <emu-xref href="#sec-canonicalizeunicodelocaleid">canonicalized</emu-xref> language tags representing a sequence of locale preferences by descending priority. It corresponds with the term of the same name defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-2.3">RFC 4647 section 2.3</a> but prohibits *"\*"* elements and contains only canonicalized contents.
   </p>
 
   <emu-clause id="sec-internal-slots">
@@ -45,7 +45,7 @@
       <h1>
         CanonicalizeLocaleList (
           _locales_: an ECMAScript language value,
-        ): either a normal completion containing a language priority list or a throw completion
+        ): either a normal completion containing a Language Priority List or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -89,7 +89,7 @@
       <h1>
         LookupMatchingLocaleByPrefix (
           _availableLocales_: an Available Locales List,
-          _requestedLocales_: a language priority list,
+          _requestedLocales_: a Language Priority List,
         ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~) or *undefined*
       </h1>
       <dl class="header">
@@ -121,7 +121,7 @@
       <h1>
         LookupMatchingLocaleByBestFit (
           _availableLocales_: an Available Locales List,
-          _requestedLocales_: a language priority list,
+          _requestedLocales_: a Language Priority List,
         ): a Record with fields [[locale]] (a Unicode canonicalized locale identifier) and [[extension]] (a Unicode locale extension sequence or ~empty~), or *undefined*
       </h1>
       <dl class="header">
@@ -197,7 +197,7 @@
       <h1>
         ResolveLocale (
           _availableLocales_: an Available Locales List,
-          _requestedLocales_: a language priority list,
+          _requestedLocales_: a Language Priority List,
           _options_: a Record,
           _relevantExtensionKeys_: a List of Strings,
           _localeData_: a Record,
@@ -267,7 +267,7 @@
       <h1>
         FilterLocales (
           _availableLocales_: an Available Locales List,
-          _requestedLocales_: a language priority list,
+          _requestedLocales_: a Language Priority List,
           _options_: an ECMAScript language value,
         ): either a normal completion containing a List of Unicode canonicalized locale identifiers or a throw completion
       </h1>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -279,7 +279,7 @@
       </p>
 
       <ul>
-        <li>The list that is the value of the *"nu"* field of any locale field of [[LocaleData]] must not include the values *"native"*, *"traditio"*, or *"finance"*.</li>
+        <li>The List that is the value of the *"nu"* field of any locale field of [[LocaleData]] must not include the values *"native"*, *"traditio"*, or *"finance"*.</li>
         <li>[[LocaleData]].[[&lt;_locale_&gt;]] must have a [[patterns]] field for all locale values _locale_. The value of this field must be a Record, which must have fields with the names of the four number format styles: *"decimal"*, *"percent"*, *"currency"*, and *"unit"*.</li>
         <li>
           The two fields *"currency"* and *"unit"* noted above must be Records with at least one field, *"fallback"*.

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -121,7 +121,7 @@
         </ul>
         </li>
         <li>
-          The list that is the value of the *"nu"* field of any locale field of [[LocaleData]] must not include the values *"native"*, *"traditio"*, or *"finance"*.
+          The List that is the value of the *"nu"* field of any locale field of [[LocaleData]] must not include the values *"native"*, *"traditio"*, or *"finance"*.
         </li>
       </ul>
 


### PR DESCRIPTION
`Intl.DateTimeFormat` used "record" and "list" to refer to Records and List should have been used. This PR capitalizes those words as appropriate.