### PR TITLE
Editorial: Replace AvailableCanonicalCalendars with AvailableCalendars

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -128,7 +128,11 @@
       <emu-alg>
         1. Let _key_ be ? ToString(_key_).
         1. If _key_ is *"calendar"*, then
-          1. Let _list_ be AvailableCanonicalCalendars( ).
+          1. Let _list_ be a new empty List.
+          1. For each element _identifier_ of AvailableCalendars(), do
+            1. Let _canonical_ be CanonicalizeUValue(*"ca"*, _identifier_).
+            1. If _identifier_ is _canonical_, then
+              1. Append _identifier_ to _list_.
         1. Else if _key_ is *"collation"*, then
           1. Let _list_ be AvailableCanonicalCollations( ).
         1. Else if _key_ is *"currency"*, then

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -133,9 +133,7 @@
           1. Assert: _options_ has a field [[&lt;_key_&gt;]].
           1. Let _overrideValue_ be _options_.[[&lt;_key_&gt;]].
           1. If _overrideValue_ is not *undefined*, then
-            1. Assert: _overrideValue_ is a String.
-            1. Set _overrideValue_ to the ASCII-lowercase of _overrideValue_.
-            1. Set _value_ to the String value resulting from canonicalizing _overrideValue_ as a value of key _key_ per <a href="https://unicode.org/reports/tr35/#processing-localeids">Unicode Technical Standard #35 Part 1 Core, Annex C LocaleId Canonicalization Section 5 Canonicalizing Syntax, Processing LocaleIds</a>.
+            1. Set _value_ to CanonicalizeUValue(_key_, _overrideValue_).
             1. If _entry_ is not ~empty~, then
               1. Set _entry_.[[Value]] to _value_.
             1. Else,

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -452,14 +452,14 @@
       This specification identifies calendars using a <dfn variants="calendar types">calendar type</dfn> as defined by <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Elements">Unicode Technical Standard #35 Part 4 Dates, Section 2 Calendar Elements</a>. Their canonical form is a string containing only Unicode Basic Latin lowercase letters (U+0061 LATIN SMALL LETTER A through U+007A LATIN SMALL LETTER Z) with zero or more medial hyphens (U+002D HYPHEN-MINUS).
     </p>
 
-    <emu-clause id="sec-availablecanonicalcalendars" type="implementation-defined abstract operation">
+    <emu-clause id="sec-availablecalendars" oldids="sec-availablecanonicalcalendars" type="implementation-defined abstract operation">
       <h1>
-        AvailableCanonicalCalendars (
+        AvailableCalendars (
         ): a List of Strings
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The returned List is sorted according to lexicographic code unit order, and contains unique canonical calendar types identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects. The List must include *"iso8601"*.</dd>
+        <dd>The returned List is sorted according to lexicographic code unit order, and contains unique calendar types in canonical form (<emu-xref href="#sec-calendar-types"></emu-xref>) identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects, including their aliases (e.g., either both or neither of *"islamicc"* and *"islamic-civil"*). The List must include *"iso8601"*.</dd>
       </dl>
     </emu-clause>
   </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -84,6 +84,25 @@
       </emu-note>
     </emu-clause>
 
+    <emu-clause id="sec-canonicalizeuvalue" type="abstract operation">
+      <h1>
+        CanonicalizeUValue (
+          _ukey_: a Unicode locale extension sequence key defined in <a href="https://unicode.org/reports/tr35/#Key_And_Type_Definitions_">Unicode Technical Standard #35 Part 1 Core Section 3.6.1 Key and Type Definitions</a>,
+          _uvalue_: a String,
+        ): a String
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>The returned String is the canonical and case-regularized form of _uvalue_ as a value of _ukey_.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _lowerValue_ be the ASCII-lowercase of _uvalue_.
+        1. Let _canonicalized_ be the String value resulting from canonicalizing _lowerValue_ as a value of key _ukey_ per <a href="https://unicode.org/reports/tr35/#processing-localeids">Unicode Technical Standard #35 Part 1 Core, Annex C LocaleId Canonicalization Section 5 Canonicalizing Syntax, Processing LocaleIds</a>.
+        1. NOTE: It is recommended that implementations use the 'u' extension data in <code>common/bcp47</code> provided by the Common Locale Data Repository (available at <a href="https://cldr.unicode.org/">https://cldr.unicode.org/</a>).
+        1. Return _canonicalized_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-lookupmatchinglocalebyprefix" type="abstract operation" oldids="sec-bestavailablelocale,sec-lookupmatcher">
       <h1>
         LookupMatchingLocaleByPrefix (
@@ -253,9 +272,7 @@
           1. Assert: _optionsValue_ is a String, or _optionsValue_ is either *undefined* or *null*.
           1. If _optionsValue_ is a String, then
             1. Let _ukey_ be the ASCII-lowercase of _key_.
-            1. Let _optionsUValue_ be the ASCII-lowercase of _optionsValue_.
-            1. Set _optionsValue_ to the String value resulting from canonicalizing _optionsUValue_ as a value of key _ukey_ per <a href="https://unicode.org/reports/tr35/#processing-localeids">Unicode Technical Standard #35 Part 1 Core, Annex C LocaleId Canonicalization Section 5 Canonicalizing Syntax, Processing LocaleIds</a>.
-            1. NOTE: It is recommended that implementations use the 'u' extension data in <code>common/bcp47</code> provided by the Common Locale Data Repository (available at <a href="https://cldr.unicode.org/">https://cldr.unicode.org/</a>).
+            1. Set _optionsValue_ to CanonicalizeUValue(_ukey_, _optionsValue_).
             1. If _optionsValue_ is the empty String, then
               1. Set _optionsValue_ to *"true"*.
           1. If SameValue(_optionsValue_, _value_) is *false* and _keyLocaleData_ contains _optionsValue_, then


### PR DESCRIPTION
AvailableCalendars should return all possible aliases, so that other places in the spec (e.g. in the future, validating a string calendar ID in Temporal) can use them to determine whether a given input value is valid. This input value can subsequently be canonicalized by another abstract operation, CanonicalizeUValue, which we can use in several other places.

In Intl.supportedValuesOf(), on the other hand, we should not return all possible aliases, so we filter them out using CanonicalizeUValue before returning the list of AvailableCalendars codes as an array to the caller.

See https://github.com/tc39/proposal-intl-enumeration/pull/49. This is the part of that PR that I consider relevant for the future integration of Temporal. The time zone parts were already done as part of #876. If desired, I could implement the rest of that PR, adding CanonicalizeCollation, CanonicalizeCurrency, CanonicalizeNumberingSystem, and CanonicalizeUnit as well.

Closes: #726

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
