### PR TITLE
Editorial: Fix various rebase errors

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -60,7 +60,7 @@
       </dl>
 
       <emu-alg>
-        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%DateTimeFormat.prototype%"*, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[DateTimeFormat]], [[BoundFormat]] &raquo;).
+        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.DateTimeFormat.prototype%"*, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[DateTimeFormat]], [[BoundFormat]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
@@ -129,7 +129,16 @@
         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.
         1. Let _timeStyle_ be ? GetOption(_options_, *"timeStyle"*, ~string~, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
         1. Set _dateTimeFormat_.[[TimeStyle]] to _timeStyle_.
-        1. If _dateStyle_ is *undefined* and _timeStyle_ is *undefined*, then
+        1. If _dateStyle_ is not *undefined* or _timeStyle_ is not *undefined*, then
+          1. If _hasExplicitFormatComponents_ is *true*, then
+            1. Throw a *TypeError* exception.
+          1. If _required_ is ~date~ and _timeStyle_ is not *undefined*, then
+            1. Throw a *TypeError* exception.
+          1. If _required_ is ~time~ and _dateStyle_ is not *undefined*, then
+            1. Throw a *TypeError* exception.
+          1. Let _styles_ be _resolvedLocaleData_.[[styles]].[[&lt;_resolvedCalendar_&gt;]].
+          1. Let _bestFormat_ be DateTimeStyleFormat(_dateStyle_, _timeStyle_, _styles_).
+        1. Else,
           1. Let _needDefaults_ be *true*.
           1. If _required_ is ~date~ or ~any~, then
             1. For each property name _prop_ of &laquo; *"weekday"*, *"year"*, *"month"*, *"day"* &raquo;, do
@@ -150,7 +159,7 @@
             1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
           1. Else,
             1. Let _bestFormat_ be BestFitFormatMatcher(_formatOptions_, _formats_).
-        1. Set _dateTimeFormat_.[[Patterns]] to _bestFormat_.
+        1. Set _dateTimeFormat_.[[DateTimeFormat]] to _bestFormat_.
         1. If _bestFormat_ has a field [[hour]], then
           1. Set _dateTimeFormat_.[[HourCycle]] to _hc_.
         1. Return _dateTimeFormat_.
@@ -247,7 +256,7 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle24]] must be one of the String values *"h23"* or *"h24"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. The value of this [[formats]] field must be a Record with a [[&lt;_calendar_&gt;]] field for each calendar value _calendar_. The value of each [[&lt;_calendar_&gt;]] field must be a List of DateTimeFormat Patterns Record. Multiple Records in such a List may use the same subset of the fields as long as the corresponding values differ for at least one field. The following subsets must be available for each locale:
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[formats]] field. The value of this [[formats]] field must be a Record with a [[&lt;_calendar_&gt;]] field for each calendar value _calendar_. The value of each [[&lt;_calendar_&gt;]] field must be a List of DateTime Format Records. Multiple Records in such a List may use the same subset of the fields as long as the corresponding values differ for at least one field. The following subsets must be available for each locale:
           <ul>
             <li>weekday, year, month, day, hour, minute, second, fractionalSecondDigits</li>
             <li>weekday, year, month, day, hour, minute, second</li>
@@ -264,18 +273,18 @@
           </ul>
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[styles]] field. The value of this [[styles]] field must be a Record with a [[&lt;_calendar_&gt;]] field for each calendar value _calendar_. The value of each [[&lt;_calendar_&gt;]] field must be a DateTimeFormat Styles Record.
+          [[LocaleData]].[[&lt;_locale_&gt;]] must have a [[styles]] field. The value of this [[styles]] field must be a Record with a [[&lt;_calendar_&gt;]] field for each calendar value _calendar_. The value of each [[&lt;_calendar_&gt;]] field must be a DateTime Styles Record.
          </li>
       </ul>
 
-      <emu-clause id="sec-datetimeformat-patterns-record">
-        <h1>DateTimeFormat Patterns Records</h1>
+      <emu-clause id="sec-datetimeformat-format-record">
+        <h1>DateTime Format Records</h1>
 
         <p>
-          Each <dfn id="datetimeformat-patterns-record" variants="DateTimeFormat Patterns Records">DateTimeFormat Patterns Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-patterns-record"></emu-xref>.
+          Each <dfn id="datetimeformat-format-record" variants="DateTime Format Records">DateTime Format Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-format-record"></emu-xref>.
         </p>
-        <emu-table id="table-datetimeformat-patterns-record">
-          <emu-caption>DateTimeFormat Patterns Record</emu-caption>
+        <emu-table id="table-datetimeformat-format-record">
+          <emu-caption>DateTime Format Record</emu-caption>
           <table class="real-table">
             <thead>
               <tr>
@@ -548,14 +557,14 @@
         </emu-table>
       </emu-clause>
 
-      <emu-clause id="sec-datetimeformat-calendar-style-record">
-        <h1>DateTime Calendar Style Records</h1>
+      <emu-clause id="sec-datetimeformat-styles-record">
+        <h1>DateTime Styles Records</h1>
 
         <p>
-          Each <dfn id="datetimeformat-calendar-style-record">DateTime Calendar Style Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-calendar-style-record"></emu-xref>.
+          Each <dfn id="datetimeformat-styles-record">DateTime Styles Record</dfn> has the fields defined in <emu-xref href="#table-datetimeformat-styles-record"></emu-xref>.
         </p>
-        <emu-table id="table-datetimeformat-calendar-style-record">
-          <emu-caption>DateTime Calendar Style Record</emu-caption>
+        <emu-table id="table-datetimeformat-styles-record">
+          <emu-caption>DateTime Styles Record</emu-caption>
           <table class="real-table">
             <thead>
               <tr>
@@ -564,15 +573,15 @@
               </tr>
             </thead>
             <tr>
-              <td>[[DateFormat]]</td>
+              <td>[[Date]]</td>
               <td>a DateTime Style Record</td>
             </tr>
             <tr>
-              <td>[[TimeFormat]]</td>
+              <td>[[Time]]</td>
               <td>a DateTime Style Record</td>
             </tr>
             <tr>
-              <td>[[DateTimeFormat]]</td>
+              <td>[[Connector]]</td>
               <td>a DateTime Connector Record</td>
             </tr>
             <tr>
@@ -1241,7 +1250,7 @@
         DateTimeStyleFormat (
           _dateStyle_: *"full"*, *"long"*, *"medium"*, *"short"*, or *undefined*,
           _timeStyle_: *"full"*, *"long"*, *"medium"*, *"short"*, or *undefined*,
-          _styles_: a DateTime Calendar Style Record,
+          _styles_: a DateTime Styles Record,
         ): a DateTime Format Record
       </h1>
       <dl class="header">
@@ -1252,15 +1261,15 @@
         1. Assert: _dateStyle_ is not *undefined* or _timeStyle_ is not *undefined*.
         1. If _timeStyle_ is not *undefined*, then
           1. Assert: _timeStyle_ is one of *"full"*, *"long"*, *"medium"*, or *"short"*.
-          1. Let _timeFormat_ be _styles_.[[TimeFormat]].[[&lt;_timeStyle_&gt;]].
+          1. Let _timeFormat_ be _styles_.[[Time]].[[&lt;_timeStyle_&gt;]].
         1. If _dateStyle_ is not *undefined*, then
           1. Assert: _dateStyle_ is one of *"full"*, *"long"*, *"medium"*, or *"short"*.
-          1. Let _dateFormat_ be _styles_.[[DateFormat]].[[&lt;_dateStyle_&gt;]].
+          1. Let _dateFormat_ be _styles_.[[Date]].[[&lt;_dateStyle_&gt;]].
         1. If _dateStyle_ is not *undefined* and _timeStyle_ is not *undefined*, then
           1. Let _format_ be a new DateTime Format Record.
           1. Add to _format_ all fields from _dateFormat_ except [[pattern]] and [[rangePatterns]].
           1. Add to _format_ all fields from _timeFormat_ except [[pattern]], [[rangePatterns]], [[pattern12]], and [[rangePatterns12]], if present.
-          1. Let _connector_ be _styles_.[[DateTimeFormat]].[[&lt;_dateStyle_&gt;]].
+          1. Let _connector_ be _styles_.[[Connector]].[[&lt;_dateStyle_&gt;]].
           1. Let _pattern_ be the string _connector_ with the substring *"{0}"* replaced with _timeFormat_.[[pattern]] and the substring *"{1}"* replaced with _dateFormat_.[[pattern]].
           1. Set _format_.[[pattern]] to _pattern_.
           1. If _timeFormat_ has a [[pattern12]] field, then
@@ -1403,12 +1412,12 @@
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"minimumIntegerDigits"*, *2*<sub>𝔽</sub>).
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"useGrouping"*, *false*).
         1. Let _nf2_ be ! Construct(%Intl.NumberFormat%, &laquo; _locale_, _nf2Options_ &raquo;).
-        1. Let _fractionalSecondDigits_ be _dateTimeFormat_.[[FractionalSecondDigits]].
-        1. If _fractionalSecondDigits_ is *undefined*, set _fractionalSecondDigits_ to 1.
-        1. Let _nf3Options_ be OrdinaryObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, 𝔽(_fractionalSecondDigits_)).
-        1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
-        1. Let _nf3_ be ! Construct(%NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
+        1. If _format_ has a field [[fractionalSecondDigits]], then
+          1. Let _fractionalSecondDigits_ be _format_.[[fractionalSecondDigits]].
+          1. Let _nf3Options_ be OrdinaryObjectCreate(*null*).
+          1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, 𝔽(_fractionalSecondDigits_)).
+          1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
+          1. Let _nf3_ be ! Construct(%Intl.NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
         1. Let _tm_ be ToLocalTime(ℤ(ℝ(_x_) &times; 10<sup>6</sup>), _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. Let _result_ be a new empty List.
@@ -1416,18 +1425,18 @@
           1. Let _p_ be _patternPart_.[[Type]].
           1. If _p_ is *"literal"*, then
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
-          1. Else if _p_ is equal to *"fractionalSecondDigits"*, then
+          1. Else if _p_ is *"fractionalSecondDigits"*, then
             1. Assert: _format_ has a field [[fractionalSecondDigits]].
             1. Let _v_ be _tm_.[[Millisecond]].
             1. Set _v_ to floor(_v_ &times; 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
             1. Let _fv_ be FormatNumeric(_nf3_, _v_).
             1. Append the Record { [[Type]]: *"fractionalSecond"*, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is equal to *"dayPeriod"*, then
+          1. Else if _p_ is *"dayPeriod"*, then
             1. Assert: _format_ has a field [[dayPeriod]].
             1. Let _f_ be _format_.[[dayPeriod]].
             1. Let _fv_ be a String value representing the day period of _tm_ in the form given by _f_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is equal to *"timeZoneName"*, then
+          1. Else if _p_ is *"timeZoneName"*, then
             1. Assert: _format_ has a field [[timeZoneName]].
             1. Let _f_ be _format_.[[timeZoneName]].
             1. Let _v_ be _dateTimeFormat_.[[TimeZone]].
@@ -1468,7 +1477,7 @@
             1. Let _v_ be _tm_.[[RelatedYear]].
             1. Let _fv_ be FormatNumeric(_nf_, _v_).
             1. Append the Record { [[Type]]: *"relatedYear"*, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is equal to *"yearName"*, then
+          1. Else if _p_ is *"yearName"*, then
             1. Let _v_ be _tm_.[[YearName]].
             1. Let _fv_ be an implementation and locale dependent String value representing _v_.
             1. Append the Record { [[Type]]: *"yearName"*, [[Value]]: _fv_ } to _result_.
@@ -1590,9 +1599,10 @@
               1. Let _v1_ be a String value representing the day period of _tm1_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
               1. Let _v2_ be a String value representing the day period of _tm2_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
             1. Else if _fieldName_ is [[FractionalSecondDigits]], then
-              1. Let _fractionalSecondDigits_ be _dateTimeFormat_.[[FractionalSecondDigits]].
-              1. If _fractionalSecondDigits_ is *undefined*, then
-                1. Set _fractionalSecondDigits_ to 3.
+              1. If _format_ has a [[fractionalSecondDigits]] field, then
+                1. Let _fractionalSecondDigits_ be _format_.[[fractionalSecondDigits]].
+              1. Else,
+                1. Let _fractionalSecondDigits_ be 3.
               1. Let _exp_ be _fractionalSecondDigits_ - 3.
               1. Let _v1_ be floor(_tm1_.[[Millisecond]] &times; 10<sup>_exp_</sup>).
               1. Let _v2_ be floor(_tm2_.[[Millisecond]] &times; 10<sup>_exp_</sup>).
@@ -1604,7 +1614,7 @@
         1. If _relevantFieldsEqual_ is *true*, then
           1. Let _collapsedResult_ be a new empty List.
           1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _format_, _pattern_, _x_).
-          1. For each Record { [[Type]], [[Value]] } _r_ in _resultParts_, do
+          1. For each Record { [[Type]], [[Value]] } _r_ of _resultParts_, do
             1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: *"shared"* } to _collapsedResult_.
           1. Return _collapsedResult_.
         1. Let _rangeResult_ be a new empty List.
@@ -1618,7 +1628,7 @@
           1. Else,
             1. Let _z_ be _y_.
           1. Let _resultParts_ be ! FormatDateTimePattern(_dateTimeFormat_, _selectedRangePattern_, _pattern_, _z_).
-          1. For each Record { [[Type]], [[Value]] } _r_ in _resultParts_, do
+          1. For each Record { [[Type]], [[Value]] } _r_ of _resultParts_, do
             1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: _source_ } to _rangeResult_.
         1. Return _rangeResult_.
       </emu-alg>

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -338,7 +338,7 @@ Output (List of parts Records):
       </dl>
       <emu-alg>
         1. Let _parts_ be CreatePartsFromList(_listFormat_, _list_).
-        1. Let _result_ be an empty String.
+        1. Let _result_ be the empty String.
         1. For each Record { [[Type]], [[Value]] } _part_ of _parts_, do
           1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
         1. Return _result_.

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -83,9 +83,8 @@
             1. Let _requestedLocale_ be _requestedLocales_[0].
           1. Else,
             1. Let _requestedLocale_ be DefaultLocale().
-          1. Let _noExtensionsLocale_ be the String value that is _requestedLocale_ with any Unicode locale extension sequences removed.
           1. Let _availableLocales_ be an Available Locales List which includes the language tags for which the Unicode Character Database contains language-sensitive case mappings. If the implementation supports additional locale-sensitive case mappings, _availableLocales_ should also include their corresponding language tags.
-          1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, _noExtensionsLocale_).
+          1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, &laquo; _requestedLocale_ &raquo;).
           1. If _match_ is not *undefined*, let _locale_ be _match_.[[locale]]; else let _locale_ be *"und"*.
           1. Let _codePoints_ be StringToCodePoints(_S_).
           1. If _targetCase_ is ~lower~, then

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -212,8 +212,6 @@
           Its result describes all available named time zone identifiers in this implementation, as well as the primary time zone identifier corresponding to each available named time zone identifier.
           The List is ordered according to the [[Identifier]] field of each Time Zone Identifier Record.
         </dd>
-        <dt>redefinition</dt>
-        <dd>true</dd>
       </dl>
       <p>This definition supersedes the definition provided in <emu-xref href="#sec-availablenamedtimezoneidentifiers"></emu-xref>.</p>
       <emu-alg>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -73,6 +73,7 @@
             1. Let _canonicalizedTag_ be CanonicalizeUnicodeLocaleId(_tag_).
             1. If _seen_ does not contain _canonicalizedTag_, append _canonicalizedTag_ to _seen_.
           1. Set _k_ to _k_ + 1.
+        1. Return _seen_.
       </emu-alg>
 
       <emu-note>
@@ -283,7 +284,7 @@
         1. If _supportedKeywords_ is not empty, then
           1. Let _supportedAttributes_ be a new empty List.
           1. Set _foundLocale_ to InsertUnicodeExtensionAndCanonicalize(_foundLocale_, _supportedAttributes_, _supportedKeywords_).
-        1. Set _result_.[[locale]] to _foundLocale_.
+        1. Set _result_.[[Locale]] to _foundLocale_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -305,11 +306,10 @@
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Let _subset_ be a new empty List.
         1. For each element _locale_ of _requestedLocales_, do
-          1. Let _noExtensionsLocale_ be the String value that is _locale_ with any Unicode locale extension sequences removed.
           1. If _matcher_ is *"lookup"*, then
-            1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, _noExtensionsLocale_).
+            1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, &laquo; _locale_ &raquo;).
           1. Else,
-            1. Let _match_ be LookupMatchingLocaleByBestFit(_availableLocales_, _noExtensionsLocale_).
+            1. Let _match_ be LookupMatchingLocaleByBestFit(_availableLocales_, &laquo; _locale_ &raquo;).
           1. If _match_ is not *undefined*, append _locale_ to _subset_.
         1. Return CreateArrayFromList(_subset_).
       </emu-alg>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -77,7 +77,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _newTarget_ is *undefined* and ? OrdinaryHasInstance(%NumberFormat%, _this_) is *true*, then
+          1. If _newTarget_ is *undefined* and ? OrdinaryHasInstance(%Intl.NumberFormat%, _this_) is *true*, then
             1. Perform ? DefinePropertyOrThrow(_this_, %Intl%.[[FallbackSymbol]], PropertyDescriptor{ [[Value]]: _numberFormat_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Return _this_.
           1. Return _numberFormat_.
@@ -818,7 +818,7 @@
             1. Append the Record { [[Type]]: *"plusSign"*, [[Value]]: _plusSignSymbol_ } to _result_.
           1. Else if _p_ is *"minusSign"*, then
             1. Let _minusSignSymbol_ be the ILND String representing the minus sign.
-            1. Append a new Record { [[Type]]: *"minusSign"*, [[Value]]: _minusSignSymbol_ } to _result_.
+            1. Append the Record { [[Type]]: *"minusSign"*, [[Value]]: _minusSignSymbol_ } to _result_.
           1. Else if _p_ is *"percentSign"* and _numberFormat_.[[Style]] is *"percent"*, then
             1. Let _percentSignSymbol_ be the ILND String representing the percent sign.
             1. Append the Record { [[Type]]: *"percentSign"*, [[Value]]: _percentSignSymbol_ } to _result_.
@@ -826,7 +826,7 @@
             1. Let _unit_ be _numberFormat_.[[Unit]].
             1. Let _unitDisplay_ be _numberFormat_.[[UnitDisplay]].
             1. Let _mu_ be an ILD String value representing _unit_ before _x_ in _unitDisplay_ form, which may depend on _x_ in languages having different plural forms.
-            1. Append a new Record { [[Type]]: *"unit"*, [[Value]]: _mu_ } to _result_.
+            1. Append the Record { [[Type]]: *"unit"*, [[Value]]: _mu_ } to _result_.
           1. Else if _p_ is *"unitSuffix"* and _numberFormat_.[[Style]] is *"unit"*, then
             1. Let _unit_ be _numberFormat_.[[Unit]].
             1. Let _unitDisplay_ be _numberFormat_.[[UnitDisplay]].
@@ -919,6 +919,8 @@
                   1. If _groups_ List is not empty, then
                     1. Append the Record { [[Type]]: *"group"*, [[Value]]: _groupSepSymbol_ } to _result_.
               1. If _fraction_ is not *undefined*, then
+                1. Let _decimalSepSymbol_ be the ILND String representing the decimal separator.
+                1. Append the Record { [[Type]]: *"decimal"*, [[Value]]: _decimalSepSymbol_ } to _result_.
                 1. Append the Record { [[Type]]: *"fraction"*, [[Value]]: _fraction_ } to _result_.
             1. Else if _p_ is *"compactSymbol"*, then
               1. Let _compactSymbol_ be an ILD string representing _exponent_ in short form, which may depend on _x_ in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a *"{compactSymbol}"* placeholder.
@@ -1852,11 +1854,11 @@
             1. Set _r_.[[Source]] to *"shared"*.
           1. Return _appxResult_.
         1. Let _result_ be a new empty List.
-        1. For each element _r_ in _xResult_, do
+        1. For each element _r_ of _xResult_, do
           1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: *"startRange"* } to _result_.
         1. Let _rangeSeparator_ be an ILND String value used to separate two numbers.
         1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _rangeSeparator_, [[Source]]: *"shared"* } to _result_.
-        1. For each element _r_ in _yResult_, do
+        1. For each element _r_ of _yResult_, do
           1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: *"endRange"* } to _result_.
         1. Return CollapseNumberRange(_result_).
       </emu-alg>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -23,9 +23,8 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _localeData_ be %Intl.PluralRules%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(%Intl.PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.PluralRules%.[[RelevantExtensionKeys]], _localeData_).
-        1. Set _pluralRules_.[[Locale]] to _r_.[[locale]].
+        1. Let _r_ be ResolveLocale(%Intl.PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.PluralRules%.[[RelevantExtensionKeys]], %Intl.PluralRules%.[[LocaleData]]).
+        1. Set _pluralRules_.[[Locale]] to _r_.[[Locale]].
         1. Let _t_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, 0, 3, *"standard"*).

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -17,7 +17,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%RelativeTimeFormat.prototype%"*, &laquo; [[InitializedRelativeTimeFormat]], [[Locale]], [[LocaleData]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] &raquo;).
+        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.RelativeTimeFormat.prototype%"*, &laquo; [[InitializedRelativeTimeFormat]], [[Locale]], [[LocaleData]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
@@ -332,7 +332,7 @@
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]], [[Unit]]: ~empty~ } to _result_.
           1. Else,
             1. Assert: _patternPart_.[[Type]] is *"0"*.
-            1. For each Record { [[Type]], [[Value]] } _part_ in _parts_, do
+            1. For each Record { [[Type]], [[Value]] } _part_ of _parts_, do
               1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: _unit_ } to _result_.
         1. Return _result_.
       </emu-alg>
@@ -365,7 +365,7 @@
 
       <emu-alg>
         1. Let _parts_ be ? PartitionRelativeTimePattern(_relativeTimeFormat_, _value_, _unit_).
-        1. Let _result_ be an empty String.
+        1. Let _result_ be the empty String.
         1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ of _parts_, do
           1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
         1. Return _result_.


### PR DESCRIPTION
Fixes a couple of rebase errors. Also reverts attempts to address review feedback ("pattern" instead of "format" for some records), because the changes were largely unfinished and actually using "pattern" would result in equally confusing code like `pattern.[[pattern]]` which doesn't seem like an improvement when compared to `format.[[pattern]]`. For example see  [FormatDateTimePattern](https://tc39.es/ecma402/#sec-formatdatetimepattern), which has `format` and `pattern` arguments.

Fixes #899. 