### PR TITLE
Editorial: replace use of Type macro

### DIFF
--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -242,7 +242,7 @@
         1. If _r_ is *undefined*, set _r_ to the Record { [[locale]]: DefaultLocale(), [[extension]]: ~empty~ }.
         1. Let _foundLocale_ be _r_.[[locale]].
         1. Let _foundLocaleData_ be _localeData_.[[&lt;_foundLocale_&gt;]].
-        1. Assert: Type(_foundLocaleData_) is Record.
+        1. Assert: _foundLocaleData_ is a Record.
         1. Let _result_ be a new Record.
         1. Set _result_.[[LocaleData]] to _foundLocaleData_.
         1. If _r_.[[extension]] is not ~empty~, then


### PR DESCRIPTION
`Type()` is kind of a weird operation; it's not totally clear what `Type` would return for an arbitrary Record. For example, [Completion Records](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-ecmascript-specification-types) are listed as specification types, so would `Type(_cr_)` be "Record" or "Completion Record"? https://github.com/tc39/ecma262/pull/3339 will clarify this, but will do so by precisely defining the domain of input to be only ES language types, not specification types.

In any case, it's also not necessary to use the macro here; the prose is easier to read anyway. This was the only use of this AO in 402.