### PR TITLE
Editorial: replaced &ge; &infin; &laquo; &ldquo; &le; &mdash; &ne; &r…

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -15,7 +15,7 @@
       </p>
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _internalSlotsList_ be &laquo; [[InitializedCollator]], [[Locale]], [[Usage]], [[Sensitivity]], [[IgnorePunctuation]], [[Collation]], [[BoundCompare]] &raquo;.
+        1. Let _internalSlotsList_ be « [[InitializedCollator]], [[Locale]], [[Usage]], [[Sensitivity]], [[IgnorePunctuation]], [[Collation]], [[BoundCompare]] ».
         1. If %Intl.Collator%.[[RelevantExtensionKeys]] contains *"kn"*, then
           1. Append [[Numeric]] to _internalSlotsList_.
         1. If %Intl.Collator%.[[RelevantExtensionKeys]] contains *"kf"*, then
@@ -23,14 +23,14 @@
         1. Let _collator_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.Collator.prototype%"*, _internalSlotsList_).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
-        1. Let _usage_ be ? GetOption(_options_, *"usage"*, ~string~, &laquo; *"sort"*, *"search"* &raquo;, *"sort"*).
+        1. Let _usage_ be ? GetOption(_options_, *"usage"*, ~string~, « *"sort"*, *"search"* », *"sort"*).
         1. Set _collator_.[[Usage]] to _usage_.
         1. If _usage_ is *"sort"*, then
           1. Let _localeData_ be %Intl.Collator%.[[SortLocaleData]].
         1. Else,
           1. Let _localeData_ be %Intl.Collator%.[[SearchLocaleData]].
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _collation_ be ? GetOption(_options_, *"collation"*, ~string~, ~empty~, *undefined*).
         1. If _collation_ is not *undefined*, then
@@ -40,7 +40,7 @@
         1. If _numeric_ is not *undefined*, then
           1. Set _numeric_ to ! ToString(_numeric_).
         1. Set _opt_.[[kn]] to _numeric_.
-        1. Let _caseFirst_ be ? GetOption(_options_, *"caseFirst"*, ~string~, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
+        1. Let _caseFirst_ be ? GetOption(_options_, *"caseFirst"*, ~string~, « *"upper"*, *"lower"*, *"false"* », *undefined*).
         1. Set _opt_.[[kf]] to _caseFirst_.
         1. Let _relevantExtensionKeys_ be %Intl.Collator%.[[RelevantExtensionKeys]].
         1. Let _r_ be ResolveLocale(%Intl.Collator%.[[AvailableLocales]], _requestedLocales_, _opt_, _relevantExtensionKeys_, _localeData_).
@@ -53,7 +53,7 @@
         1. If _relevantExtensionKeys_ contains *"kf"*, then
           1. Set _collator_.[[CaseFirst]] to _r_.[[kf]].
         1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
-        1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, ~string~, &laquo; *"base"*, *"accent"*, *"case"*, *"variant"* &raquo;, *undefined*).
+        1. Let _sensitivity_ be ? GetOption(_options_, *"sensitivity"*, ~string~, « *"base"*, *"accent"*, *"case"*, *"variant"* », *undefined*).
         1. If _sensitivity_ is *undefined*, then
           1. If _usage_ is *"sort"*, then
             1. Set _sensitivity_ to *"variant"*.

--- a/spec/colophon.html
+++ b/spec/colophon.html
@@ -1,5 +1,5 @@
 <emu-annex id="sec-colophon">
   <h1>Colophon</h1>
   <p>This specification is authored on <a href="https://github.com/tc39/ecma402">GitHub</a> in a plaintext source format called <a href="https://github.com/bterlson/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMAScript specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/domenic/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this specification are produced by printing the HTML rendering to a PDF.</p>
-  <p>Prior editions of this specification were authored using Word&mdash;the Ecmarkup source text that formed the basis of this edition was produced by converting the ECMAScript 2015 Word document to Ecmarkup using an automated conversion tool.</p>
+  <p>Prior editions of this specification were authored using Word—the Ecmarkup source text that formed the basis of this edition was produced by converting the ECMAScript 2015 Word document to Ecmarkup using an automated conversion tool.</p>
 </emu-annex>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -17,7 +17,7 @@
   </emu-note>
 
   <p>
-    As an extension to the Record Specification Type, the notation &ldquo;[[&lt;_name_&gt;]]&rdquo; denotes a field whose name is given by the variable _name_, which must have a String value. For example, if a variable _s_ has the value *"a"*, then [[&lt;_s_&gt;]] denotes the field [[a]].
+    As an extension to the Record Specification Type, the notation “[[&lt;_name_&gt;]]” denotes a field whose name is given by the variable _name_, which must have a String value. For example, if a variable _s_ has the value *"a"*, then [[&lt;_s_&gt;]] denotes the field [[a]].
   </p>
 
   <p>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -60,11 +60,11 @@
       </dl>
 
       <emu-alg>
-        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.DateTimeFormat.prototype%"*, &laquo; [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[DateTimeFormat]], [[BoundFormat]] &raquo;).
+        1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.DateTimeFormat.prototype%"*, « [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[DateTimeFormat]], [[BoundFormat]] »).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, ~string~, ~empty~, *undefined*).
         1. If _calendar_ is not *undefined*, then
@@ -75,7 +75,7 @@
           1. If _numberingSystem_ cannot be matched by the <code>type</code> Unicode locale nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
         1. Let _hour12_ be ? GetOption(_options_, *"hour12"*, ~boolean~, ~empty~, *undefined*).
-        1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, ~string~, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
+        1. Let _hourCycle_ be ? GetOption(_options_, *"hourCycle"*, ~string~, « *"h11"*, *"h12"*, *"h23"*, *"h24"* », *undefined*).
         1. If _hour12_ is not *undefined*, then
           1. Set _hourCycle_ to *null*.
         1. Set _opt_.[[hc]] to _hourCycle_.
@@ -124,10 +124,10 @@
           1. Set _formatOptions_.[[&lt;_prop_&gt;]] to _value_.
           1. If _value_ is not *undefined*, then
             1. Set _hasExplicitFormatComponents_ to *true*.
-        1. Let _formatMatcher_ be ? GetOption(_options_, *"formatMatcher"*, ~string~, &laquo; *"basic"*, *"best fit"* &raquo;, *"best fit"*).
-        1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, ~string~, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
+        1. Let _formatMatcher_ be ? GetOption(_options_, *"formatMatcher"*, ~string~, « *"basic"*, *"best fit"* », *"best fit"*).
+        1. Let _dateStyle_ be ? GetOption(_options_, *"dateStyle"*, ~string~, « *"full"*, *"long"*, *"medium"*, *"short"* », *undefined*).
         1. Set _dateTimeFormat_.[[DateStyle]] to _dateStyle_.
-        1. Let _timeStyle_ be ? GetOption(_options_, *"timeStyle"*, ~string~, &laquo; *"full"*, *"long"*, *"medium"*, *"short"* &raquo;, *undefined*).
+        1. Let _timeStyle_ be ? GetOption(_options_, *"timeStyle"*, ~string~, « *"full"*, *"long"*, *"medium"*, *"short"* », *undefined*).
         1. Set _dateTimeFormat_.[[TimeStyle]] to _timeStyle_.
         1. If _dateStyle_ is not *undefined* or _timeStyle_ is not *undefined*, then
           1. If _hasExplicitFormatComponents_ is *true*, then
@@ -141,18 +141,18 @@
         1. Else,
           1. Let _needDefaults_ be *true*.
           1. If _required_ is ~date~ or ~any~, then
-            1. For each property name _prop_ of &laquo; *"weekday"*, *"year"*, *"month"*, *"day"* &raquo;, do
+            1. For each property name _prop_ of « *"weekday"*, *"year"*, *"month"*, *"day"* », do
               1. Let _value_ be _formatOptions_.[[&lt;_prop_&gt;]].
               1. If _value_ is not *undefined*, set _needDefaults_ to *false*.
           1. If _required_ is ~time~ or ~any~, then
-            1. For each property name _prop_ of &laquo; *"dayPeriod"*, *"hour"*, *"minute"*, *"second"*, *"fractionalSecondDigits"* &raquo;, do
+            1. For each property name _prop_ of « *"dayPeriod"*, *"hour"*, *"minute"*, *"second"*, *"fractionalSecondDigits"* », do
               1. Let _value_ be _formatOptions_.[[&lt;_prop_&gt;]].
               1. If _value_ is not *undefined*, set _needDefaults_ to *false*.
           1. If _needDefaults_ is *true* and _defaults_ is either ~date~ or ~all~, then
-            1. For each property name _prop_ of &laquo; *"year"*, *"month"*, *"day"* &raquo;, do
+            1. For each property name _prop_ of « *"year"*, *"month"*, *"day"* », do
               1. Set _formatOptions_.[[&lt;_prop_&gt;]] to *"numeric"*.
           1. If _needDefaults_ is *true* and _defaults_ is either ~time~ or ~all~, then
-            1. For each property name _prop_ of &laquo; *"hour"*, *"minute"*, *"second"* &raquo;, do
+            1. For each property name _prop_ of « *"hour"*, *"minute"*, *"second"* », do
               1. Set _formatOptions_.[[&lt;_prop_&gt;]] to *"numeric"*.
           1. Let _formats_ be _resolvedLocaleData_.[[formats]].[[&lt;_resolvedCalendar_&gt;]].
           1. If _formatMatcher_ is *"basic"*, then
@@ -179,7 +179,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. If _offsetMinutes_ &ge; 0, let _sign_ be the code unit 0x002B (PLUS SIGN); otherwise, let _sign_ be the code unit 0x002D (HYPHEN-MINUS).
+        1. If _offsetMinutes_ ≥ 0, let _sign_ be the code unit 0x002B (PLUS SIGN); otherwise, let _sign_ be the code unit 0x002D (HYPHEN-MINUS).
         1. Let _absoluteMinutes_ be abs(_offsetMinutes_).
         1. Let _hours_ be floor(_absoluteMinutes_ / 60).
         1. Let _minutes_ be _absoluteMinutes_ modulo 60.
@@ -228,7 +228,7 @@
       </p>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; *"ca"*, *"hc"*, *"nu"* &raquo;.
+        The value of the [[RelevantExtensionKeys]] internal slot is « *"ca"*, *"hc"*, *"nu"* ».
       </p>
 
       <emu-note>
@@ -244,7 +244,7 @@
           [[LocaleData]].[[&lt;_locale_&gt;]].[[nu]] must be a List that does not include the values *"native"*, *"traditio"*, or *"finance"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_&gt;]].[[hc]] must be &laquo; *null*, *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;.
+          [[LocaleData]].[[&lt;_locale_&gt;]].[[hc]] must be « *null*, *"h11"*, *"h12"*, *"h23"*, *"h24"* ».
         </li>
         <li>
           [[LocaleData]].[[&lt;_locale_&gt;]].[[hourCycle]] must be one of the String values *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
@@ -1322,7 +1322,7 @@
                 1. Else if _formatProp_ is *"longOffset"*, set _score_ to _score_ - (_offsetPenalty_ + _shortMorePenalty_).
                 1. Else if _optionsProp_ is *"short"* and _formatProp_ is *"long"*, set _score_ to _score_ - _shortMorePenalty_.
                 1. Else if _optionsProp_ is *"shortGeneric"* and _formatProp_ is *"longGeneric"*, set _score_ to _score - _shortMorePenalty_.
-                1. Else if _optionsProp_ &ne; _formatProp_, set _score_ to _score_ - _removalPenalty_.
+                1. Else if _optionsProp_ ≠ _formatProp_, set _score_ to _score_ - _removalPenalty_.
               1. Else if _optionsProp_ is *"shortOffset"* and _formatProp_ is *"longOffset"*, then
                 1. Set _score_ to _score_ - _shortMorePenalty_.
               1. Else if _optionsProp_ is *"long"* or *"longGeneric"*, then
@@ -1330,16 +1330,16 @@
                 1. Else if _formatProp_ is *"shortOffset"*, set _score_ to _score_ - (_offsetPenalty_ + _longLessPenalty_).
                 1. Else if _optionsProp_ is *"long"* and _formatProp_ is *"short"*, set _score_ to _score_ - _longLessPenalty_.
                 1. Else if _optionsProp_ is *"longGeneric"* and _formatProp_ is *"shortGeneric"*, set _score_ to _score_ - _longLessPenalty_.
-                1. Else if _optionsProp_ &ne; _formatProp_, set _score_ to _score_ - _removalPenalty_.
+                1. Else if _optionsProp_ ≠ _formatProp_, set _score_ to _score_ - _removalPenalty_.
               1. Else if _optionsProp_ is *"longOffset"* and _formatProp_ is *"shortOffset"*, then
                 1. Set _score_ to _score_ - _longLessPenalty_.
-              1. Else if _optionsProp_ &ne; _formatProp_, then
+              1. Else if _optionsProp_ ≠ _formatProp_, then
                 1. Set _score_ to _score_ - _removalPenalty_.
-            1. Else if _optionsProp_ &ne; _formatProp_, then
+            1. Else if _optionsProp_ ≠ _formatProp_, then
               1. If _property_ is *"fractionalSecondDigits"*, then
-                1. Let _values_ be &laquo; 1, 2, 3 &raquo;.
+                1. Let _values_ be « 1, 2, 3 ».
               1. Else,
-                1. Let _values_ be &laquo; *"2-digit"*, *"numeric"*, *"narrow"*, *"short"*, *"long"* &raquo;.
+                1. Let _values_ be « *"2-digit"*, *"numeric"*, *"narrow"*, *"short"*, *"long"* ».
               1. Let _optionsPropIndex_ be the index of _optionsProp_ within _values_.
               1. Let _formatPropIndex_ be the index of _formatProp_ within _values_.
               1. Let _delta_ be max(min(_formatPropIndex_ - _optionsPropIndex_, 2), -2).
@@ -1405,17 +1405,17 @@
         1. Let _locale_ be _dateTimeFormat_.[[Locale]].
         1. Let _nfOptions_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"useGrouping"*, *false*).
-        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, &laquo; _locale_, _nfOptions_ &raquo;).
+        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _locale_, _nfOptions_ »).
         1. Let _nf2Options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"minimumIntegerDigits"*, *2*<sub>𝔽</sub>).
         1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"useGrouping"*, *false*).
-        1. Let _nf2_ be ! Construct(%Intl.NumberFormat%, &laquo; _locale_, _nf2Options_ &raquo;).
+        1. Let _nf2_ be ! Construct(%Intl.NumberFormat%, « _locale_, _nf2Options_ »).
         1. If _format_ has a field [[fractionalSecondDigits]], then
           1. Let _fractionalSecondDigits_ be _format_.[[fractionalSecondDigits]].
           1. Let _nf3Options_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, 𝔽(_fractionalSecondDigits_)).
           1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
-          1. Let _nf3_ be ! Construct(%Intl.NumberFormat%, &laquo; _locale_, _nf3Options_ &raquo;).
+          1. Let _nf3_ be ! Construct(%Intl.NumberFormat%, « _locale_, _nf3Options_ »).
         1. Let _tm_ be ToLocalTime(_epochNanoseconds_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. Let _result_ be a new empty List.
@@ -1426,7 +1426,7 @@
           1. Else if _p_ is *"fractionalSecondDigits"*, then
             1. Assert: _format_ has a field [[fractionalSecondDigits]].
             1. Let _v_ be _tm_.[[Millisecond]].
-            1. Set _v_ to floor(_v_ &times; 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
+            1. Set _v_ to floor(_v_ × 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
             1. Let _fv_ be FormatNumeric(_nf3_, _v_).
             1. Append the Record { [[Type]]: *"fractionalSecond"*, [[Value]]: _fv_ } to _result_.
           1. Else if _p_ is *"dayPeriod"*, then
@@ -1444,7 +1444,7 @@
             1. Assert: _format_ has a field [[&lt;_p_&gt;]].
             1. Let _f_ be _format_.[[&lt;_p_&gt;]].
             1. Let _v_ be the value of _tm_'s field whose name is the Internal Slot column of the matching row.
-            1. If _p_ is *"year"* and _v_ &le; 0, set _v_ to 1 - _v_.
+            1. If _p_ is *"year"* and _v_ ≤ 0, set _v_ to 1 - _v_.
             1. If _p_ is *"month"*, set _v_ to _v_ + 1.
             1. If _p_ is *"hour"* and _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
               1. Set _v_ to _v_ modulo 12.
@@ -1460,7 +1460,7 @@
               1. If _count_ > 2, then
                 1. Let _tens_ be _codePoints_[_count_ - 2].
                 1. Let _ones_ be _codePoints_[_count_ - 1].
-                1. Set _fv_ to CodePointsToString(&laquo; _tens_, _ones_ &raquo;).
+                1. Set _fv_ to CodePointsToString(« _tens_, _ones_ »).
             1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then
               1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _format_.[[day]] is present. If the implementation does not have a localized representation of _f_, then use the String value of _v_ itself.
             1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
@@ -1504,7 +1504,7 @@
       <emu-alg>
         1. Let _x_ be TimeClip(_x_).
         1. If _x_ is *NaN*, throw a *RangeError* exception.
-        1. Let _epochNanoseconds_ be ℤ(ℝ(_x_) &times; 10<sup>6</sup>).
+        1. Let _epochNanoseconds_ be ℤ(ℝ(_x_) × 10<sup>6</sup>).
         1. Let _format_ be _dateTimeFormat_.[[DateTimeFormat]].
         1. If _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
           1. Let _pattern_ be _format_.[[pattern12]].
@@ -1573,8 +1573,8 @@
         1. If _x_ is *NaN*, throw a *RangeError* exception.
         1. Set _y_ to TimeClip(_y_).
         1. If _y_ is *NaN*, throw a *RangeError* exception.
-        1. Let _xEpochNanoseconds_ be ℤ(ℝ(_x_) &times; 10<sup>6</sup>).
-        1. Let _yEpochNanoseconds_ be ℤ(ℝ(_y_) &times; 10<sup>6</sup>).
+        1. Let _xEpochNanoseconds_ be ℤ(ℝ(_x_) × 10<sup>6</sup>).
+        1. Let _yEpochNanoseconds_ be ℤ(ℝ(_y_) × 10<sup>6</sup>).
         1. Let _tm1_ be ToLocalTime(_xEpochNanoseconds_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _tm2_ be ToLocalTime(_yEpochNanoseconds_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _format_ be _dateTimeFormat_.[[DateTimeFormat]].
@@ -1607,8 +1607,8 @@
               1. Else,
                 1. Let _fractionalSecondDigits_ be 3.
               1. Let _exp_ be _fractionalSecondDigits_ - 3.
-              1. Let _v1_ be floor(_tm1_.[[Millisecond]] &times; 10<sup>_exp_</sup>).
-              1. Let _v2_ be floor(_tm2_.[[Millisecond]] &times; 10<sup>_exp_</sup>).
+              1. Let _v1_ be floor(_tm1_.[[Millisecond]] × 10<sup>_exp_</sup>).
+              1. Let _v2_ be floor(_tm2_.[[Millisecond]] × 10<sup>_exp_</sup>).
             1. Else,
               1. Let _v1_ be _tm1_'s field whose name is _fieldName_.
               1. Let _v2_ be _tm2_'s field whose name is _fieldName_.

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -17,26 +17,26 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _displayNames_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.DisplayNames.prototype%"*, &laquo; [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], [[LanguageDisplay]], [[Fields]] &raquo;).
+        1. Let _displayNames_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.DisplayNames.prototype%"*, « [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], [[LanguageDisplay]], [[Fields]] »).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _r_ be ResolveLocale(%Intl.DisplayNames%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.DisplayNames%.[[RelevantExtensionKeys]], %Intl.DisplayNames%.[[LocaleData]]).
-        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"narrow"*, *"short"*, *"long"* &raquo;, *"long"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"narrow"*, *"short"*, *"long"* », *"long"*).
         1. Set _displayNames_.[[Style]] to _style_.
-        1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* &raquo;, *undefined*).
+        1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, « *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* », *undefined*).
         1. If _type_ is *undefined*, throw a *TypeError* exception.
         1. Set _displayNames_.[[Type]] to _type_.
-        1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, &laquo; *"code"*, *"none"* &raquo;, *"code"*).
+        1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, « *"code"*, *"none"* », *"code"*).
         1. Set _displayNames_.[[Fallback]] to _fallback_.
         1. Set _displayNames_.[[Locale]] to _r_.[[Locale]].
         1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
         1. Let _types_ be _resolvedLocaleData_.[[types]].
         1. Assert: _types_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
-        1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, ~string~, &laquo; *"dialect"*, *"standard"* &raquo;, *"dialect"*).
+        1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, ~string~, « *"dialect"*, *"standard"* », *"dialect"*).
         1. Let _typeFields_ be _types_.[[&lt;_type_&gt;]].
         1. Assert: _typeFields_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. If _type_ is *"language"*, then
@@ -91,7 +91,7 @@
       </p>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; &raquo;.
+        The value of the [[RelevantExtensionKeys]] internal slot is « ».
       </p>
 
       <p>

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -17,17 +17,17 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _listFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.ListFormat.prototype%"*, &laquo; [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[Templates]] &raquo;).
+        1. Let _listFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.ListFormat.prototype%"*, « [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[Templates]] »).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _r_ be ResolveLocale(%Intl.ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.ListFormat%.[[RelevantExtensionKeys]], %Intl.ListFormat%.[[LocaleData]]).
         1. Set _listFormat_.[[Locale]] to _r_.[[Locale]].
-        1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"conjunction"*, *"disjunction"*, *"unit"* &raquo;, *"conjunction"*).
+        1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, « *"conjunction"*, *"disjunction"*, *"unit"* », *"conjunction"*).
         1. Set _listFormat_.[[Type]] to _type_.
-        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"long"*, *"short"*, *"narrow"* », *"long"*).
         1. Set _listFormat_.[[Style]] to _style_.
         1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
         1. Let _dataLocaleTypes_ be _resolvedLocaleData_.[[&lt;_type_&gt;]].
@@ -77,7 +77,7 @@
       </p>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; &raquo;.
+        The value of the [[RelevantExtensionKeys]] internal slot is « ».
       </p>
 
       <emu-note>
@@ -253,13 +253,13 @@ Input:
   })
 
 Output (List of parts Records):
-  &laquo;
+  «
     {[[Type]]: "literal", [[Value]]: "AA"},
     {[[Type]]: "hour", [[Value]]: "15"},
     {[[Type]]: "literal", [[Value]]: "BB"},
     {[[Type]]: "minute", [[Value]]: "06"},
     {[[Type]]: "literal", [[Value]]: "CC"}
-  &raquo;
+  »
           </pre>
         </dd>
       </dl>
@@ -305,9 +305,9 @@ Output (List of parts Records):
           1. Let _placeables_ be the Record { [[0]]: _first_, [[1]]: _second_ }.
           1. Return DeconstructPattern(_pattern_, _placeables_).
         1. Let _last_ be the Record { [[Type]]: *"element"*, [[Value]]: _list_[_size_ - 1] }.
-        1. Let _parts_ be &laquo; _last_ &raquo;.
+        1. Let _parts_ be « _last_ ».
         1. Let _i_ be _size_ - 2.
-        1. Repeat, while _i_ &ge; 0,
+        1. Repeat, while _i_ ≥ 0,
           1. Let _head_ be the Record { [[Type]]: *"element"*, [[Value]]: _list_[_i_] }.
           1. Let _n_ be an implementation-defined index into _listFormat_.[[Templates]] based on _listFormat_.[[Locale]], _head_, and _parts_.
           1. If _i_ is 0, then

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -27,7 +27,7 @@
         1. Let _O_ be ? RequireObjectCoercible(*this* value).
         1. Let _S_ be ? ToString(_O_).
         1. Let _thatValue_ be ? ToString(_that_).
-        1. Let _collator_ be ? Construct(%Intl.Collator%, &laquo; _locales_, _options_ &raquo;).
+        1. Let _collator_ be ? Construct(%Intl.Collator%, « _locales_, _options_ »).
         1. Return CompareStrings(_collator_, _S_, _thatValue_).
       </emu-alg>
 
@@ -84,7 +84,7 @@
           1. Else,
             1. Let _requestedLocale_ be DefaultLocale().
           1. Let _availableLocales_ be an Available Locales List which includes the language tags for which the Unicode Character Database contains language-sensitive case mappings. If the implementation supports additional locale-sensitive case mappings, _availableLocales_ should also include their corresponding language tags.
-          1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, &laquo; _requestedLocale_ &raquo;).
+          1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, « _requestedLocale_ »).
           1. If _match_ is not *undefined*, let _locale_ be _match_.[[locale]]; else let _locale_ be *"und"*.
           1. Let _codePoints_ be StringToCodePoints(_S_).
           1. If _targetCase_ is ~lower~, then
@@ -148,7 +148,7 @@
 
       <emu-alg>
         1. Let _x_ be ? ThisNumberValue(*this* value).
-        1. Let _numberFormat_ be ? Construct(%Intl.NumberFormat%, &laquo; _locales_, _options_ &raquo;).
+        1. Let _numberFormat_ be ? Construct(%Intl.NumberFormat%, « _locales_, _options_ »).
         1. Return FormatNumeric(_numberFormat_, ! ToIntlMathematicalValue(_x_)).
       </emu-alg>
     </emu-clause>
@@ -174,7 +174,7 @@
 
       <emu-alg>
         1. Let _x_ be ? ThisBigIntValue(*this* value).
-        1. Let _numberFormat_ be ? Construct(%Intl.NumberFormat%, &laquo; _locales_, _options_ &raquo;).
+        1. Let _numberFormat_ be ? Construct(%Intl.NumberFormat%, « _locales_, _options_ »).
         1. Return FormatNumeric(_numberFormat_, ℝ(_x_)).
       </emu-alg>
     </emu-clause>
@@ -276,7 +276,7 @@
             1. Set _R_ to the string-concatenation of _R_ and _separator_.
           1. Let _nextElement_ be ? Get(_array_, ! ToString(𝔽(_k_))).
           1. If _nextElement_ is not *undefined* or *null*, then
-            1. Let _S_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*, &laquo; _locales_, _options_ &raquo;)).
+            1. Let _S_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*, « _locales_, _options_ »)).
             1. Set _R_ to the string-concatenation of _R_ and _S_.
           1. Set _k_ to _k_ + 1.
         1. Return _R_.

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -18,7 +18,7 @@
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _localeExtensionKeys_ be %Intl.Locale%.[[LocaleExtensionKeys]].
-        1. Let _internalSlotsList_ be &laquo; [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[NumberingSystem]] &raquo;.
+        1. Let _internalSlotsList_ be « [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[NumberingSystem]] ».
         1. If _localeExtensionKeys_ contains *"kf"*, then
           1. Append [[CaseFirst]] to _internalSlotsList_.
         1. If _localeExtensionKeys_ contains *"kn"*, then
@@ -42,9 +42,9 @@
         1. If _collation_ is not *undefined*, then
           1. If _collation_ cannot be matched by the <code>type</code> Unicode locale nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[co]] to _collation_.
-        1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, ~string~, &laquo; *"h11"*, *"h12"*, *"h23"*, *"h24"* &raquo;, *undefined*).
+        1. Let _hc_ be ? GetOption(_options_, *"hourCycle"*, ~string~, « *"h11"*, *"h12"*, *"h23"*, *"h24"* », *undefined*).
         1. Set _opt_.[[hc]] to _hc_.
-        1. Let _kf_ be ? GetOption(_options_, *"caseFirst"*, ~string~, &laquo; *"upper"*, *"lower"*, *"false"* &raquo;, *undefined*).
+        1. Let _kf_ be ? GetOption(_options_, *"caseFirst"*, ~string~, « *"upper"*, *"lower"*, *"false"* », *undefined*).
         1. Set _opt_.[[kf]] to _kf_.
         1. Let _kn_ be ? GetOption(_options_, *"numeric"*, ~boolean~, ~empty~, *undefined*).
         1. If _kn_ is not *undefined*, set _kn_ to ! ToString(_kn_).
@@ -171,7 +171,7 @@
       <h1>Internal slots</h1>
 
       <p>
-        The value of the [[LocaleExtensionKeys]] internal slot is &laquo; *"ca"*, *"co"*, *"hc"*, *"kf"*, *"kn"*, *"nu"* &raquo;. If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain *"kf"*, then remove *"kf"* from %Intl.Locale%.[[LocaleExtensionKeys]]. If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain *"kn"*, then remove *"kn"* from %Intl.Locale%.[[LocaleExtensionKeys]].
+        The value of the [[LocaleExtensionKeys]] internal slot is « *"ca"*, *"co"*, *"hc"*, *"kf"*, *"kn"*, *"nu"* ». If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain *"kf"*, then remove *"kf"* from %Intl.Locale%.[[LocaleExtensionKeys]]. If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain *"kn"*, then remove *"kn"* from %Intl.Locale%.[[LocaleExtensionKeys]].
       </p>
     </emu-clause>
   </emu-clause>

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -54,7 +54,7 @@
           1. Return a new empty List.
         1. Let _seen_ be a new empty List.
         1. If _locales_ is a String or _locales_ is an Object and _locales_ has an [[InitializedLocale]] internal slot, then
-          1. Let _O_ be CreateArrayFromList(&laquo; _locales_ &raquo;).
+          1. Let _O_ be CreateArrayFromList(« _locales_ »).
         1. Else,
           1. Let _O_ be ? ToObject(_locales_).
         1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -125,7 +125,7 @@
           1. Repeat, while _prefix_ is not the empty String,
             1. If _availableLocales_ contains _prefix_, return the Record { [[locale]]: _prefix_, [[extension]]: _extension_ }.
             1. If _prefix_ contains *"-"* (code unit 0x002D HYPHEN-MINUS), let _pos_ be the index into _prefix_ of the last occurrence of *"-"*; else let _pos_ be 0.
-            1. Repeat, while _pos_ &ge; 2 and the substring of _prefix_ from _pos_ - 2 to _pos_ - 1 is *"-"*,
+            1. Repeat, while _pos_ ≥ 2 and the substring of _prefix_ from _pos_ - 2 to _pos_ - 1 is *"-"*,
               1. Set _pos_ to _pos_ - 2.
             1. Set _prefix_ to the substring of _prefix_ from 0 to _pos_.
         1. Return *undefined*.
@@ -172,8 +172,8 @@
           1. If _e_ is ~not-found~, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
           1. Let _subtag_ be the substring of _extension_ from _k_ to _k_ + _len_.
           1. NOTE: A <emu-not-ref>keyword</emu-not-ref> is a sequence of subtags in which the first is a key of length 2 and any subsequent ones (if present) have length in the inclusive interval from 3 to 8, collectively constituting a value along with their medial *"-"* separators. An attribute is a single subtag with length in the inclusive interval from 3 to 8 that precedes all <emu-not-ref>keywords</emu-not-ref>.
-          1. Assert: _len_ &ge; 2.
-          1. If _keyword_ is *undefined* and _len_ &ne; 2, then
+          1. Assert: _len_ ≥ 2.
+          1. If _keyword_ is *undefined* and _len_ ≠ 2, then
             1. If _subtag_ is not an element of _attributes_, append _subtag_ to _attributes_.
           1. Else if _len_ = 2, then
             1. Set _keyword_ to the Record { [[Key]]: _subtag_, [[Value]]: *""* }.
@@ -303,13 +303,13 @@
       </dl>
       <emu-alg>
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Let _subset_ be a new empty List.
         1. For each element _locale_ of _requestedLocales_, do
           1. If _matcher_ is *"lookup"*, then
-            1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, &laquo; _locale_ &raquo;).
+            1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, « _locale_ »).
           1. Else,
-            1. Let _match_ be LookupMatchingLocaleByBestFit(_availableLocales_, &laquo; _locale_ &raquo;).
+            1. Let _match_ be LookupMatchingLocaleByBestFit(_availableLocales_, « _locale_ »).
           1. If _match_ is not *undefined*, append _locale_ to _subset_.
         1. Return CreateArrayFromList(_subset_).
       </emu-alg>

--- a/spec/normative-references.html
+++ b/spec/normative-references.html
@@ -10,7 +10,7 @@
   </p>
 
   <emu-note>
-    Throughout this document, the phrase &ldquo;es2024, _x_&rdquo; (where x is a sequence of numbers separated by periods) may be used as shorthand for "ECMAScript 2024 Language Specification (ECMA-262 15<sup>th</sup> Edition, sub clause _x_)". Where _x_ is followed by more such sequences of period-separated numbers, separated from each other by commas, each such sequence is also a shorthand for the corresponding sub clause of ECMA-262.
+    Throughout this document, the phrase “es2024, _x_” (where x is a sequence of numbers separated by periods) may be used as shorthand for "ECMAScript 2024 Language Specification (ECMA-262 15<sup>th</sup> Edition, sub clause _x_)". Where _x_ is followed by more such sequences of period-separated numbers, separated from each other by commas, each such sequence is also a shorthand for the corresponding sub clause of ECMA-262.
   </emu-note>
 
   <ul>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -17,11 +17,11 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, let _newTarget_ be the active function object, else let _newTarget_ be NewTarget.
-        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.NumberFormat.prototype%"*, &laquo; [[InitializedNumberFormat]], [[Locale]], [[LocaleData]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] &raquo;).
+        1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.NumberFormat.prototype%"*, « [[InitializedNumberFormat]], [[Locale]], [[LocaleData]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] »).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, ~string~, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
@@ -44,20 +44,20 @@
             1. Let _mxfdDefault_ be 0.
           1. Else,
             1. Let _mxfdDefault_ be 3.
-        1. Let _notation_ be ? GetOption(_options_, *"notation"*, ~string~, &laquo; *"standard"*, *"scientific"*, *"engineering"*, *"compact"* &raquo;, *"standard"*).
+        1. Let _notation_ be ? GetOption(_options_, *"notation"*, ~string~, « *"standard"*, *"scientific"*, *"engineering"*, *"compact"* », *"standard"*).
         1. Set _numberFormat_.[[Notation]] to _notation_.
         1. Perform ? SetNumberFormatDigitOptions(_numberFormat_, _options_, _mnfdDefault_, _mxfdDefault_, _notation_).
-        1. Let _compactDisplay_ be ? GetOption(_options_, *"compactDisplay"*, ~string~, &laquo; *"short"*, *"long"* &raquo;, *"short"*).
+        1. Let _compactDisplay_ be ? GetOption(_options_, *"compactDisplay"*, ~string~, « *"short"*, *"long"* », *"short"*).
         1. Let _defaultUseGrouping_ be *"auto"*.
         1. If _notation_ is *"compact"*, then
           1. Set _numberFormat_.[[CompactDisplay]] to _compactDisplay_.
           1. Set _defaultUseGrouping_ to *"min2"*.
         1. NOTE: For historical reasons, the strings *"true"* and *"false"* are accepted and replaced with the default value.
-        1. Let _useGrouping_ be ? GetBooleanOrStringNumberFormatOption(_options_, *"useGrouping"*, &laquo; *"min2"*, *"auto"*, *"always"*, *"true"*, *"false"* &raquo;, _defaultUseGrouping_).
+        1. Let _useGrouping_ be ? GetBooleanOrStringNumberFormatOption(_options_, *"useGrouping"*, « *"min2"*, *"auto"*, *"always"*, *"true"*, *"false"* », _defaultUseGrouping_).
         1. If _useGrouping_ is *"true"* or _useGrouping_ is *"false"*, set _useGrouping_ to _defaultUseGrouping_.
         1. If _useGrouping_ is *true*, set _useGrouping_ to *"always"*.
         1. Set _numberFormat_.[[UseGrouping]] to _useGrouping_.
-        1. Let _signDisplay_ be ? GetOption(_options_, *"signDisplay"*, ~string~, &laquo; *"auto"*, *"never"*, *"always"*, *"exceptZero"*, *"negative"* &raquo;, *"auto"*).
+        1. Let _signDisplay_ be ? GetOption(_options_, *"signDisplay"*, ~string~, « *"auto"*, *"never"*, *"always"*, *"exceptZero"*, *"negative"* », *"auto"*).
         1. Set _numberFormat_.[[SignDisplay]] to _signDisplay_.
         1. If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then
           1. Let _this_ be the *this* value.
@@ -109,9 +109,9 @@
         1. Set _intlObj_.[[MinimumIntegerDigits]] to _mnid_.
         1. Let _roundingIncrement_ be ? GetNumberOption(_options_, *"roundingIncrement"*, 1, 5000, 1).
         1. If _roundingIncrement_ is not in « 1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000 », throw a *RangeError* exception.
-        1. Let _roundingMode_ be ? GetOption(_options_, *"roundingMode"*, ~string~, &laquo; *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* &raquo;, *"halfExpand"*).
-        1. Let _roundingPriority_ be ? GetOption(_options_, *"roundingPriority"*, ~string~, &laquo; *"auto"*, *"morePrecision"*, *"lessPrecision"* &raquo;, *"auto"*).
-        1. Let _trailingZeroDisplay_ be ? GetOption(_options_, *"trailingZeroDisplay"*, ~string~, &laquo; *"auto"*, *"stripIfInteger"* &raquo;, *"auto"*).
+        1. Let _roundingMode_ be ? GetOption(_options_, *"roundingMode"*, ~string~, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », *"halfExpand"*).
+        1. Let _roundingPriority_ be ? GetOption(_options_, *"roundingPriority"*, ~string~, « *"auto"*, *"morePrecision"*, *"lessPrecision"* », *"auto"*).
+        1. Let _trailingZeroDisplay_ be ? GetOption(_options_, *"trailingZeroDisplay"*, ~string~, « *"auto"*, *"stripIfInteger"* », *"auto"*).
         1. NOTE: All fields required by SetNumberFormatDigitOptions have now been read from _options_. The remainder of this AO interprets the options and may throw exceptions.
         1. If _roundingIncrement_ is not 1, set _mxfdDefault_ to _mnfdDefault_.
         1. Set _intlObj_.[[RoundingIncrement]] to _roundingIncrement_.
@@ -182,21 +182,21 @@
         <dd>It resolves the user-specified options relating to units onto _intlObj_.</dd>
       </dl>
       <emu-alg>
-        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"decimal"*, *"percent"*, *"currency"*, *"unit"* &raquo;, *"decimal"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"decimal"*, *"percent"*, *"currency"*, *"unit"* », *"decimal"*).
         1. Set _intlObj_.[[Style]] to _style_.
         1. Let _currency_ be ? GetOption(_options_, *"currency"*, ~string~, ~empty~, *undefined*).
         1. If _currency_ is *undefined*, then
           1. If _style_ is *"currency"*, throw a *TypeError* exception.
         1. Else,
           1. If IsWellFormedCurrencyCode(_currency_) is *false*, throw a *RangeError* exception.
-        1. Let _currencyDisplay_ be ? GetOption(_options_, *"currencyDisplay"*, ~string~, &laquo; *"code"*, *"symbol"*, *"narrowSymbol"*, *"name"* &raquo;, *"symbol"*).
-        1. Let _currencySign_ be ? GetOption(_options_, *"currencySign"*, ~string~, &laquo; *"standard"*, *"accounting"* &raquo;, *"standard"*).
+        1. Let _currencyDisplay_ be ? GetOption(_options_, *"currencyDisplay"*, ~string~, « *"code"*, *"symbol"*, *"narrowSymbol"*, *"name"* », *"symbol"*).
+        1. Let _currencySign_ be ? GetOption(_options_, *"currencySign"*, ~string~, « *"standard"*, *"accounting"* », *"standard"*).
         1. Let _unit_ be ? GetOption(_options_, *"unit"*, ~string~, ~empty~, *undefined*).
         1. If _unit_ is *undefined*, then
           1. If _style_ is *"unit"*, throw a *TypeError* exception.
         1. Else,
           1. If IsWellFormedUnitIdentifier(_unit_) is *false*, throw a *RangeError* exception.
-        1. Let _unitDisplay_ be ? GetOption(_options_, *"unitDisplay"*, ~string~, &laquo; *"short"*, *"narrow"*, *"long"* &raquo;, *"short"*).
+        1. Let _unitDisplay_ be ? GetOption(_options_, *"unitDisplay"*, ~string~, « *"short"*, *"narrow"*, *"long"* », *"short"*).
         1. If _style_ is *"currency"*, then
           1. Set _intlObj_.[[Currency]] to the ASCII-uppercase of _currency_.
           1. Set _intlObj_.[[CurrencyDisplay]] to _currencyDisplay_.
@@ -249,7 +249,7 @@
       </p>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; *"nu"* &raquo;.
+        The value of the [[RelevantExtensionKeys]] internal slot is « *"nu"* ».
       </p>
 
       <emu-note>
@@ -748,13 +748,13 @@
           1. Let _sResult_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
           1. Let _fResult_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
           1. If _intlObject_.[[RoundingType]] is ~more-precision~, then
-            1. If _sResult_.[[RoundingMagnitude]] &le; _fResult_.[[RoundingMagnitude]], then
+            1. If _sResult_.[[RoundingMagnitude]] ≤ _fResult_.[[RoundingMagnitude]], then
               1. Let _result_ be _sResult_.
             1. Else,
               1. Let _result_ be _fResult_.
           1. Else,
             1. Assert: _intlObject_.[[RoundingType]] is ~less-precision~.
-            1. If _sResult_.[[RoundingMagnitude]] &le; _fResult_.[[RoundingMagnitude]], then
+            1. If _sResult_.[[RoundingMagnitude]] ≤ _fResult_.[[RoundingMagnitude]], then
               1. Let _result_ be _fResult_.
             1. Else,
               1. Let _result_ be _sResult_.
@@ -797,9 +797,9 @@
         1. Else,
           1. If _x_ is not ~negative-zero~, then
             1. Assert: _x_ is a mathematical value.
-            1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ be 100 &times; _x_.
+            1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ be 100 × _x_.
             1. Set _exponent_ to ComputeExponent(_numberFormat_, _x_).
-            1. Set _x_ to _x_ &times; 10<sup>-_exponent_</sup>.
+            1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.
           1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_).
           1. Let _n_ be _formatNumberResult_.[[FormattedString]].
           1. Set _x_ to _formatNumberResult_.[[RoundedNumber]].
@@ -891,10 +891,10 @@
                 1. Let _position_ be 0.
                 1. Repeat, while _position_ &lt; _len_,
                   1. Let _c_ be the code unit at index _position_ within _n_.
-                  1. If 0x0030 &le; _c_ &le; 0x0039, then
+                  1. If 0x0030 ≤ _c_ ≤ 0x0039, then
                     1. NOTE: _c_ is an ASCII digit.
                     1. Let _i_ be _c_ - 0x0030.
-                    1. Set _c_ to CodePointsToString(&laquo; _digits_[_i_] &raquo;).
+                    1. Set _c_ to CodePointsToString(« _digits_[_i_] »).
                   1. Set _transliterated_ to the string-concatenation of _transliterated_ and _c_.
                   1. Set _position_ to _position_ + 1.
                 1. Set _n_ to _transliterated_.
@@ -1322,10 +1322,10 @@
             1. Let _e_ be _e2_.
             1. Let _xFinal_ be _r2_.
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
-        1. If _e_ &ge; (_p_ - 1), then
+        1. If _e_ ≥ (_p_ - 1), then
           1. Set _m_ to the string-concatenation of _m_ and _e_ - _p_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Let _int_ be _e_ + 1.
-        1. Else if _e_ &ge; 0, then
+        1. Else if _e_ ≥ 0, then
           1. Set _m_ to the string-concatenation of the first _e_ + 1 code units of _m_, the code unit 0x002E (FULL STOP), and the remaining _p_ - (_e_ + 1) code units of _m_.
           1. Let _int_ be _e_ + 1.
         1. Else,
@@ -1376,9 +1376,9 @@
           1. Let _n_ be _n2_.
           1. Let _xFinal_ be _r2_.
         1. If _n_ = 0, let _m_ be *"0"*. Otherwise, let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
-        1. If _f_ &ne; 0, then
+        1. If _f_ ≠ 0, then
           1. Let _k_ be the length of _m_.
-          1. If _k_ &le; _f_, then
+          1. If _k_ ≤ _f_, then
             1. Let _z_ be the String value consisting of _f_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Set _m_ to the string-concatenation of _z_ and _m_.
             1. Set _k_ to _f_ + 1.
@@ -1557,7 +1557,7 @@
           1. Let _x_ = -_x_.
         1. Let _magnitude_ be the base 10 logarithm of _x_ rounded down to the nearest integer.
         1. Let _exponent_ be ComputeExponentForMagnitude(_numberFormat_, _magnitude_).
-        1. Let _x_ be _x_ &times; 10<sup>-_exponent_</sup>.
+        1. Let _x_ be _x_ × 10<sup>-_exponent_</sup>.
         1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_).
         1. If _formatNumberResult_.[[RoundedNumber]] = 0, then
           1. Return _exponent_.
@@ -1589,7 +1589,7 @@
           1. Return _magnitude_.
         1. Else if _notation_ is *"engineering"*, then
           1. Let _thousands_ be the greatest integer that is not greater than _magnitude_ / 3.
-          1. Return _thousands_ &times; 3.
+          1. Return _thousands_ × 3.
         1. Else,
           1. Assert: _notation_ is *"compact"*.
           1. Let _exponent_ be an implementation- and locale-dependent (ILD) integer by which to scale a number of the given magnitude in compact notation for the current locale.
@@ -1637,20 +1637,20 @@
           1. Let _b_ be 0.
           1. Let _n_ be 0.
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
-        1. Return (_a_ + (_b_ &times; 10<sup>-_n_</sup>)) &times; 10<sup>_e_</sup>.
+        1. Return (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart?</emu-grammar>
       <emu-alg>
         1. Let _b_ be MV of |DecimalDigits|.
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
         1. Let _n_ be the number of code points in |DecimalDigits|.
-        1. Return _b_ &times; 10<sup>_e_ - _n_</sup>.
+        1. Return _b_ × 10<sup>_e_ - _n_</sup>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart?</emu-grammar>
       <emu-alg>
         1. Let _a_ be MV of |DecimalDigits|.
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
-        1. Return _a_ &times; 10<sup>_e_</sup>.
+        1. Return _a_ × 10<sup>_e_</sup>.
       </emu-alg>
     </emu-clause>
 

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -17,15 +17,15 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.PluralRules.prototype%"*, &laquo; [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]] &raquo;).
+        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.PluralRules.prototype%"*, « [[InitializedPluralRules]], [[Locale]], [[Type]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]] »).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _r_ be ResolveLocale(%Intl.PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.PluralRules%.[[RelevantExtensionKeys]], %Intl.PluralRules%.[[LocaleData]]).
         1. Set _pluralRules_.[[Locale]] to _r_.[[Locale]].
-        1. Let _t_ be ? GetOption(_options_, *"type"*, ~string~, &laquo; *"cardinal"*, *"ordinal"* &raquo;, *"cardinal"*).
+        1. Let _t_ be ? GetOption(_options_, *"type"*, ~string~, « *"cardinal"*, *"ordinal"* », *"cardinal"*).
         1. Set _pluralRules_.[[Type]] to _t_.
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, 0, 3, *"standard"*).
         1. Return _pluralRules_.
@@ -73,7 +73,7 @@
       </p>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; &raquo;.
+        The value of the [[RelevantExtensionKeys]] internal slot is « ».
       </p>
 
       <emu-note>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -17,11 +17,11 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.RelativeTimeFormat.prototype%"*, &laquo; [[InitializedRelativeTimeFormat]], [[Locale]], [[LocaleData]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] &raquo;).
+        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.RelativeTimeFormat.prototype%"*, « [[InitializedRelativeTimeFormat]], [[Locale]], [[LocaleData]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] »).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[LocaleMatcher]] to _matcher_.
         1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, ~string~, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
@@ -32,12 +32,12 @@
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
         1. Set _relativeTimeFormat_.[[LocaleData]] to _r_.[[LocaleData]].
         1. Set _relativeTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"* &raquo;, *"long"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"long"*, *"short"*, *"narrow"* », *"long"*).
         1. Set _relativeTimeFormat_.[[Style]] to _style_.
-        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, ~string~, &laquo; *"always"*, *"auto"* &raquo;, *"always"*).
+        1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, ~string~, « *"always"*, *"auto"* », *"always"*).
         1. Set _relativeTimeFormat_.[[Numeric]] to _numeric_.
-        1. Let _relativeTimeFormat_.[[NumberFormat]] be ! Construct(%Intl.NumberFormat%, &laquo; _locale_ &raquo;).
-        1. Let _relativeTimeFormat_.[[PluralRules]] be ! Construct(%Intl.PluralRules%, &laquo; _locale_ &raquo;).
+        1. Let _relativeTimeFormat_.[[NumberFormat]] be ! Construct(%Intl.NumberFormat%, « _locale_ »).
+        1. Let _relativeTimeFormat_.[[PluralRules]] be ! Construct(%Intl.PluralRules%, « _locale_ »).
         1. Return _relativeTimeFormat_.
       </emu-alg>
     </emu-clause>
@@ -83,7 +83,7 @@
       </p>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; *"nu"* &raquo;.
+        The value of the [[RelevantExtensionKeys]] internal slot is « *"nu"* ».
       </p>
 
       <emu-note>
@@ -287,7 +287,7 @@
       </dl>
 
       <emu-alg>
-        1. If _value_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. If _value_ is *NaN*, *+∞*<sub>𝔽</sub>, or *-∞*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Let _unit_ be ? SingularRelativeTimeUnit(_unit_).
         1. Let _fields_ be _relativeTimeFormat_.[[LocaleData]].
         1. Let _patterns_ be _fields_.[[&lt;_unit_&gt;]].
@@ -339,14 +339,14 @@
 
       <emu-note>
         Example:
-        <emu-alg>1. Return MakePartsList(*"AA{0}BB"*, *"hour"*, &laquo; Record { [[Type]]: *"integer"*, [[Value]]: *"15"* } &raquo;).</emu-alg>
+        <emu-alg>1. Return MakePartsList(*"AA{0}BB"*, *"hour"*, « Record { [[Type]]: *"integer"*, [[Value]]: *"15"* } »).</emu-alg>
         will return a List of Records like
         <kbd style="font: inherit; white-space: pre-wrap">
-          &laquo;
+          «
             { [[Type]]: *"literal"*, [[Value]]: *"AA"*, [[Unit]]: ~empty~},
             { [[Type]]: *"integer"*, [[Value]]: *"15"*, [[Unit]]: *"hour"*},
             { [[Type]]: *"literal"*, [[Value]]: *"BB"*, [[Unit]]: ~empty~}
-          &raquo;
+          »
         </kbd>
       </emu-note>
     </emu-clause>

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -17,16 +17,16 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _internalSlotsList_ be &laquo; [[InitializedSegmenter]], [[Locale]], [[SegmenterGranularity]] &raquo;.
+        1. Let _internalSlotsList_ be « [[InitializedSegmenter]], [[Locale]], [[SegmenterGranularity]] ».
         1. Let _segmenter_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.Segmenter.prototype%"*, _internalSlotsList_).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _r_ be ResolveLocale(%Intl.Segmenter%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.Segmenter%.[[RelevantExtensionKeys]], %Intl.Segmenter%.[[LocaleData]]).
         1. Set _segmenter_.[[Locale]] to _r_.[[Locale]].
-        1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, ~string~, &laquo; *"grapheme"*, *"word"*, *"sentence"* &raquo;, *"grapheme"*).
+        1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, ~string~, « *"grapheme"*, *"word"*, *"sentence"* », *"grapheme"*).
         1. Set _segmenter_.[[SegmenterGranularity]] to _granularity_.
         1. Return _segmenter_.
       </emu-alg>
@@ -73,7 +73,7 @@
       </p>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; &raquo;.
+        The value of the [[RelevantExtensionKeys]] internal slot is « ».
       </p>
       <emu-note>
         Intl.Segmenter does not have any relevant extension keys.
@@ -207,7 +207,7 @@
         <dd>The Segments instance references _segmenter_ and _string_.</dd>
       </dl>
       <emu-alg>
-        1. Let _internalSlotsList_ be &laquo; [[SegmentsSegmenter]], [[SegmentsString]] &raquo;.
+        1. Let _internalSlotsList_ be « [[SegmentsSegmenter]], [[SegmentsString]] ».
         1. Let _segments_ be OrdinaryObjectCreate(%IntlSegmentsPrototype%, _internalSlotsList_).
         1. Set _segments_.[[SegmentsSegmenter]] to _segmenter_.
         1. Set _segments_.[[SegmentsString]] to _string_.
@@ -234,7 +234,7 @@
           1. Let _string_ be _segments_.[[SegmentsString]].
           1. Let _len_ be the length of _string_.
           1. Let _n_ be ? ToIntegerOrInfinity(_index_).
-          1. If _n_ &lt; 0 or _n_ &ge; _len_, return *undefined*.
+          1. If _n_ &lt; 0 or _n_ ≥ _len_, return *undefined*.
           1. Let _startIndex_ be FindBoundary(_segmenter_, _string_, _n_, ~before~).
           1. Let _endIndex_ be FindBoundary(_segmenter_, _string_, _n_, ~after~).
           1. Return CreateSegmentDataObject(_segmenter_, _string_, _startIndex_, _endIndex_).
@@ -290,7 +290,7 @@
         <dd>The Segment Iterator iterates over _string_ using the locale and options of _segmenter_.</dd>
       </dl>
       <emu-alg>
-        1. Let _internalSlotsList_ be &laquo; [[IteratingSegmenter]], [[IteratedString]], [[IteratedStringNextSegmentCodeUnitIndex]] &raquo;.
+        1. Let _internalSlotsList_ be « [[IteratingSegmenter]], [[IteratedString]], [[IteratedStringNextSegmentCodeUnitIndex]] ».
         1. Let _iterator_ be OrdinaryObjectCreate(%IntlSegmentIteratorPrototype%, _internalSlotsList_).
         1. Set _iterator_.[[IteratingSegmenter]] to _segmenter_.
         1. Set _iterator_.[[IteratedString]] to _string_.
@@ -319,7 +319,7 @@
           1. Let _string_ be _iterator_.[[IteratedString]].
           1. Let _startIndex_ be _iterator_.[[IteratedStringNextSegmentCodeUnitIndex]].
           1. Let _len_ be the length of _string_.
-          1. If _startIndex_ &ge; _len_, then
+          1. If _startIndex_ ≥ _len_, then
             1. Return CreateIterResultObject(*undefined*, *true*).
           1. Let _endIndex_ be FindBoundary(_segmenter_, _string_, _startIndex_, ~after~).
           1. Set _iterator_.[[IteratedStringNextSegmentCodeUnitIndex]] to _endIndex_.
@@ -393,7 +393,7 @@
       </dl>
       <emu-alg>
         1. Let _len_ be the length of _string_.
-        1. Assert: _endIndex_ &le; _len_.
+        1. Assert: _endIndex_ ≤ _len_.
         1. Assert: _startIndex_ &lt; _endIndex_.
         1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _segment_ be the substring of _string_ from _startIndex_ to _endIndex_.


### PR DESCRIPTION
https://github.com/tc39/ecma402/issues/634 observed that ECMA-262 had standardized on using HTML character entities rather than non-ASCII characters such as ≤ and ≥. However, in the time since that issue was raised 262 re-standardized on directly using the Unicode characters rather than using HTML entities. 

This PR replaces the relevant HTML character entities with the Unicode characters they represent.