### PR TITLE
Normative: Make DefaultNumberOption truncate before validating range

### DIFF
--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -426,7 +426,7 @@
       <emu-alg>
         1. If _value_ is *undefined*, return _fallback_.
         1. Set _value_ to ? ToNumber(_value_).
-        1. If _value_ is not finite or _value_ is *NaN*, throw a *RangeError* exception.
+        1. If _value_ is not finite, throw a *RangeError* exception.
         1. Set _value_ to truncate(ℝ(_value_)).
         1. If _value_ &lt; _minimum_ or _value_ &gt; _maximum_, throw a *RangeError* exception.
         1. Return _value_.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -426,8 +426,10 @@
       <emu-alg>
         1. If _value_ is *undefined*, return _fallback_.
         1. Set _value_ to ? ToNumber(_value_).
-        1. If _value_ is not finite or ℝ(_value_) &lt; _minimum_ or ℝ(_value_) &gt; _maximum_, throw a *RangeError* exception.
-        1. Return floor(ℝ(_value_)).
+        1. If _value_ is not finite or _value_ is *NaN*, throw a *RangeError* exception.
+        1. Set _value_ to truncate(ℝ(_value_)).
+        1. If _value_ &lt; _minimum_ or _value_ &gt; _maximum_, throw a *RangeError* exception.
+        1. Return _value_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Currently the behaviour of ECMA-402 differs from ECMA-262 in that 402's [`DefaultNumberOption`](https://tc39.es/ecma402/#sec-defaultnumberoption) validates that the value passed in is within the specified range before truncating that value, whereas 262's [`toFixed`](https://tc39.es/ecma262/#sec-number.prototype.tofixed) truncates before range validation. This PR changes 402 to align with 262. See https://github.com/tc39/ecma402/issues/691, also https://github.com/tc39/proposal-temporal/issues/2296