### PR TITLE
Editorial: Add GetLocaleBaseName abstract operation

### DIFF
--- a/spec/locale.html
+++ b/spec/locale.html
@@ -82,21 +82,22 @@
         <dd>It updates the <code>unicode_language_id</code> subtags in _tag_ from the corresponding properties of _options_ and returns the <emu-xref href="#sec-isstructurallyvalidlanguagetag">structurally valid</emu-xref> but non-canonicalized result.</dd>
       </dl>
       <emu-alg>
-        1. Let _languageId_ be the longest prefix of _tag_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
-        1. Let _language_ be ? GetOption(_options_, *"language"*, ~string~, ~empty~, GetLocaleLanguage(_languageId_)).
+        1. Let _baseName_ be GetLocaleBaseName(_tag_).
+        1. Let _language_ be ? GetOption(_options_, *"language"*, ~string~, ~empty~, GetLocaleLanguage(_baseName_)).
         1. If _language_ cannot be matched by the <code>unicode_language_subtag</code> Unicode locale nonterminal, throw a *RangeError* exception.
-        1. Let _script_ be ? GetOption(_options_, *"script"*, ~string~, ~empty~, GetLocaleScript(_languageId_)).
+        1. Let _script_ be ? GetOption(_options_, *"script"*, ~string~, ~empty~, GetLocaleScript(_baseName_)).
         1. If _script_ is not *undefined*, then
           1. If _script_ cannot be matched by the <code>unicode_script_subtag</code> Unicode locale nonterminal, throw a *RangeError* exception.
-        1. Let _region_ be ? GetOption(_options_, *"region"*, ~string~, ~empty~, GetLocaleRegion(_languageId_)).
+        1. Let _region_ be ? GetOption(_options_, *"region"*, ~string~, ~empty~, GetLocaleRegion(_baseName_)).
         1. If _region_ is not *undefined*, then
           1. If _region_ cannot be matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal, throw a *RangeError* exception.
-        1. Let _variants_ be GetLocaleVariants(_languageId_).
-        1. Let _newLanguageId_ be _language_.
-        1. If _script_ is not *undefined*, set _newLanguageId_ to the string-concatenation of _newLanguageId_, *"-"*, and _script_.
-        1. If _region_ is not *undefined*, set _newLanguageId_ to the string-concatenation of _newLanguageId_, *"-"*, and _region_.
-        1. If _variants_ is not *undefined*, set _newLanguageId_ to the string-concatenation of _newLanguageId_, *"-"*, and _variants_.
-        1. Let _newTag_ be _tag_ with the <emu-not-ref>substring</emu-not-ref> matched by the <code>unicode_language_id</code> Unicode locale nonterminal replaced by the string _newLanguageId_.
+        1. Let _variants_ be GetLocaleVariants(_baseName_).
+        1. Let _allExtensions_ be the suffix of _tag_ following _baseName_.
+        1. Let _newTag_ be _language_.
+        1. If _script_ is not *undefined*, set _newTag_ to the string-concatenation of _newTag_, *"-"*, and _script_.
+        1. If _region_ is not *undefined*, set _newTag_ to the string-concatenation of _newTag_, *"-"*, and _region_.
+        1. If _variants_ is not *undefined*, set _newTag_ to the string-concatenation of _newTag_, *"-"*, and _variants_.
+        1. Set _newTag_ to the string-concatenation of _newTag_ and _allExtensions_.
         1. Return _newTag_.
       </emu-alg>
     </emu-clause>
@@ -241,8 +242,7 @@
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
-        1. Let _locale_ be _loc_.[[Locale]].
-        1. Return the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
+        1. Return GetLocaleBaseName(_loc_.[[Locale]]).
       </emu-alg>
     </emu-clause>
 
@@ -368,6 +368,20 @@
   <emu-clause id="sec-intl-locale-abstracts">
     <h1>Abstract Operations for Locale Objects</h1>
 
+    <emu-clause id="sec-getlocalebasename" type="abstract operation">
+      <h1>
+        GetLocaleBaseName (
+          _locale_: a String,
+        ): a String
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Assert: _locale_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
+        1. Return the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-getlocalelanguage" type="abstract operation">
       <h1>
         GetLocaleLanguage (
@@ -377,10 +391,9 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _locale_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
-        1. Let _languageId_ be the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
-        1. Assert: The first subtag of _languageId_ can be matched by the <code>unicode_language_subtag</code> Unicode locale nonterminal.
-        1. Return the first subtag of _languageId_.
+        1. Let _baseName_ be GetLocaleBaseName(_locale_).
+        1. Assert: The first subtag of _baseName_ can be matched by the <code>unicode_language_subtag</code> Unicode locale nonterminal.
+        1. Return the first subtag of _baseName_.
       </emu-alg>
     </emu-clause>
 
@@ -393,10 +406,9 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _locale_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
-        1. Let _languageId_ be the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
-        1. Assert: _languageId_ contains at most one subtag that can be matched by the <code>unicode_script_subtag</code> Unicode locale nonterminal.
-        1. If _languageId_ contains a subtag matched by the <code>unicode_script_subtag</code> Unicode locale nonterminal, return that subtag.
+        1. Let _baseName_ be GetLocaleBaseName(_locale_).
+        1. Assert: _baseName_ contains at most one subtag that can be matched by the <code>unicode_script_subtag</code> Unicode locale nonterminal.
+        1. If _baseName_ contains a subtag matched by the <code>unicode_script_subtag</code> Unicode locale nonterminal, return that subtag.
         1. Return *undefined*.
       </emu-alg>
     </emu-clause>
@@ -410,13 +422,12 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _locale_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
-        1. Let _languageId_ be the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
+        1. Let _baseName_ be GetLocaleBaseName(_locale_).
         1. NOTE: A <code>unicode_region_subtag</code> subtag is only valid immediately after an initial <code>unicode_language_subtag</code> subtag, optionally with a single <code>unicode_script_subtag</code> subtag between them. In that position, <code>unicode_region_subtag</code> cannot be confused with any other valid subtag because all their productions are disjoint.
-        1. Assert: The first subtag of _languageId_ can be matched by the <code>unicode_language_subtag</code> Unicode locale nonterminal.
-        1. Let _languageIdTail_ be the suffix of _languageId_ following the first subtag.
-        1. Assert: _languageIdTail_ contains at most one subtag that can be matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal.
-        1. If _languageIdTail_ contains a subtag matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal, return that subtag.
+        1. Assert: The first subtag of _baseName_ can be matched by the <code>unicode_language_subtag</code> Unicode locale nonterminal.
+        1. Let _baseNameTail_ be the suffix of _baseName_ following the first subtag.
+        1. Assert: _baseNameTail_ contains at most one subtag that can be matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal.
+        1. If _baseNameTail_ contains a subtag matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal, return that subtag.
         1. Return *undefined*.
       </emu-alg>
     </emu-clause>
@@ -430,9 +441,8 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _locale_ can be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal.
-        1. Let _languageId_ be the longest prefix of _locale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
-        1. If there is a non-empty suffix of _languageId_ that is a consecutive sequence of <emu-not-ref>substrings</emu-not-ref> in which each element is a *"-"* followed by a <emu-not-ref>substring</emu-not-ref> that is matched by the <code>unicode_variant_subtag</code> Unicode locale nonterminal, then
+        1. Let _baseName_ be GetLocaleBaseName(_locale_).
+        1. If there is a non-empty suffix of _baseName_ that is a consecutive sequence of <emu-not-ref>substrings</emu-not-ref> in which each element is a *"-"* followed by a <emu-not-ref>substring</emu-not-ref> that is matched by the <code>unicode_variant_subtag</code> Unicode locale nonterminal, then
           1. Let _variants_ be the longest such suffix.
           1. Return the substring of _variants_ from 1.
         1. Return *undefined*.

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -57,11 +57,11 @@
         1. Let _lowerLocale_ be the ASCII-lowercase of _locale_.
         1. If _lowerLocale_ cannot be matched by the <code>unicode_locale_id</code> Unicode locale nonterminal, return *false*.
         1. If _lowerLocale_ uses any of the backwards compatibility syntax described in <a href="https://unicode.org/reports/tr35/#BCP_47_Conformance">Unicode Technical Standard #35 Part 1 Core, Section 3.3 BCP 47 Conformance</a>, return *false*.
-        1. Let _languageId_ be the longest prefix of _lowerLocale_ matched by the <code>unicode_language_id</code> Unicode locale nonterminal.
-        1. Let _variants_ be GetLocaleVariants(_languageId_).
+        1. Let _baseName_ be GetLocaleBaseName(_lowerLocale_).
+        1. Let _variants_ be GetLocaleVariants(_baseName_).
         1. If _variants_ is not *undefined*, then
           1. If _variants_ contains any duplicate subtags, return *false*.
-        1. Let _allExtensions_ be the suffix of _lowerLocale_ following _languageId_.
+        1. Let _allExtensions_ be the suffix of _lowerLocale_ following _baseName_.
         1. If _allExtensions_ contains a <emu-not-ref>substring</emu-not-ref> matched by the <code>pu_extensions</code> Unicode locale nonterminal, let _extensions_ be the prefix of _allExtensions_ preceding the longest such <emu-not-ref>substring</emu-not-ref>. Otherwise, let _extensions_ be _allExtensions_.
         1. If _extensions_ is not the empty String, then
           1. If _extensions_ contains any duplicate singleton subtags, return *false*.


### PR DESCRIPTION
Add `GetLocaleBaseName` to avoid repeating the same steps to extract the `unicode_language_id` parts of a `unicode_locale_id`. The abstract operation is named to `GetLocaleBaseName` to match the accessor property `Intl.Locale.prototype.baseName`.
