### PR TITLE
Normative: Explicitly designate sort order for plural categories returned by Intl.PluralRules.prototype.resolvedOptions

### DIFF
--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -159,7 +159,7 @@
         1. Let _pr_ be the *this* value.
         1. Perform ? RequireInternalSlot(_pr_, [[InitializedPluralRules]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _pluralCategories_ be a List of Strings containing all possible results of <emu-xref href="#sec-pluralruleselect">PluralRuleSelect</emu-xref> for the selected locale _pr_.[[Locale]].
+        1. Let _pluralCategories_ be a List of Strings containing all possible results of <emu-xref href="#sec-pluralruleselect">PluralRuleSelect</emu-xref> for the selected locale _pr_.[[Locale]], sorted according to the following order: *"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, *"other"*.
         1. For each row of <emu-xref href="#table-pluralrules-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
           1. Let _p_ be the Property value of the current row.
           1. If _p_ is *"pluralCategories"*, then


### PR DESCRIPTION
fix https://github.com/tc39/ecma402/issues/578

This change follows the ordering suggested by @zbraniecki in https://github.com/tc39/ecma402/issues/578#issuecomment-873725419