### PR TITLE
Editorial: Note on use of CLDR data for rounding currency values

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -697,6 +697,11 @@
         1. Assert: _currency_ is the ASCII-uppercase of _currency_.
         1. If the ISO 4217 currency and funds code list contains _currency_ as an alphabetic code, return the minor unit value corresponding to the _currency_ from the list; otherwise, return 2.
       </emu-alg>
+
+      <emu-note>
+        Implementations using the locale data provided by the Common Locale Data Repository (available at <a href="https://cldr.unicode.org/">https://cldr.unicode.org/</a>) should determine the number of minor units displayed using the value of the *"digits"* attribute rather than the value of the*"cashDigits"* attribute.
+        Likewise, implementations using CLDR should ignore the *"rounding"* and *"cashRounding"* attributes.
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-number-format-functions">


### PR DESCRIPTION
For some currencies, CLDR gives two values for determining the number of minor digits displayed when formatting those currencies. This note explains that the value of the "cashDigits" attribute, and likewise the value of the "cashRounding" attribute, should not be used when formatting values denominated in those currencies.

fix https://github.com/tc39/ecma402/issues/835 (or at least, close it). 

address https://github.com/tc39/ecma402/issues/134 

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
