### PR TITLE
Normative: Allow use of non-ISO 4217 data in `CurrencyDigits` AO

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -111,6 +111,9 @@
           The patterns used for formatting values as decimal, percent, currency, or unit values per locale, with or without the sign, with or without accounting format for currencies, and in standard, compact, or scientific notation (<emu-xref href="#sec-formatnumber"></emu-xref>)
         </li>
         <li>
+          The number of fractional digits used when formatting currency values (<emu-xref href="#sec-formatnumber"></emu-xref>)
+        </li>
+        <li>
           Localized representations of *NaN* and *Infinity* (<emu-xref href="#sec-formatnumber"></emu-xref>)
         </li>
         <li>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -697,7 +697,6 @@
 
       <emu-alg>
         1. Assert: IsWellFormedCurrencyCode(_currency_) is *true*.
-        1. Assert: _currency_ is the ASCII-uppercase of _currency_.
         1. Return a non-negative integer indicating the number of fractional digits used when formatting quantities of the currency corresponding to _currency_. If there is no available information on the number of digits to be used, return 2.
       </emu-alg>
     </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -684,18 +684,21 @@
   <emu-clause id="sec-numberformat-abstracts">
     <h1>Abstract Operations for NumberFormat Objects</h1>
 
-    <emu-clause id="sec-currencydigits" type="abstract operation">
+    <emu-clause id="sec-currencydigits" type="implementation-defined abstract operation">
       <h1>
         CurrencyDigits (
           _currency_: a String,
         ): a non-negative integer
       </h1>
       <dl class="header">
+        <dt>description</dt>
+        <dd></dd>
       </dl>
+
       <emu-alg>
         1. Assert: IsWellFormedCurrencyCode(_currency_) is *true*.
         1. Assert: _currency_ is the ASCII-uppercase of _currency_.
-        1. If the ISO 4217 currency and funds code list contains _currency_ as an alphabetic code, return the minor unit value corresponding to the _currency_ from the list; otherwise, return 2.
+        1. Return a non-negative integer indicating the number of fractional digits used when formatting quantities of the currency corresponding to _currency_. If there is no available information on the number of digits to be used, return 2.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
This PR allows for locale data other than ISO 4217 for determining the number of fractional digits to be used when formatting currency values.

In some applications ISO 4217 is most appropriate, in some CLDR data, and in some neither is best. See https://github.com/tc39/ecma402/pull/921#issuecomment-2313173054

Resolves #134

This PR makes the `CurrencyDigits` AO implementation-defined.