### PR TITLE
Editorial: Arrange contents consistently

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -216,18 +216,6 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-intl.collator.prototype-%symbol.tostringtag%" oldids="sec-intl.collator.prototype-@@tostringtag">
-      <h1>Intl.Collator.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.Collator"*.
-      </p>
-
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
     <emu-clause id="sec-intl.collator.prototype.compare">
       <h1>get Intl.Collator.prototype.compare</h1>
 
@@ -354,6 +342,18 @@
           Applications should not assume that the behaviour of the CompareStrings abstract operation for Collator instances with the same resolved options will remain the same for different versions of the same implementation.
         </emu-note>
       </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.collator.prototype-%symbol.tostringtag%" oldids="sec-intl.collator.prototype-@@tostringtag">
+      <h1>Intl.Collator.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.Collator"*.
+      </p>
+
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
     </emu-clause>
   </emu-clause>
 

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -144,6 +144,78 @@
       </p>
     </emu-clause>
 
+    <emu-clause id="sec-intl.collator.prototype.resolvedoptions">
+      <h1>Intl.Collator.prototype.resolvedOptions ( )</h1>
+
+      <p>
+        This function provides access to the locale and options computed during initialization of the object.
+      </p>
+
+      <emu-alg>
+        1. Let _collator_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_collator_, [[InitializedCollator]]).
+        1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. For each row of <emu-xref href="#table-collator-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _p_ be the Property value of the current row.
+          1. Let _v_ be the value of _collator_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If the current row has an Extension Key value, then
+            1. Let _extensionKey_ be the Extension Key value of the current row.
+            1. If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain _extensionKey_, then
+              1. Set _v_ to *undefined*.
+          1. If _v_ is not *undefined*, then
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+        1. Return _options_.
+      </emu-alg>
+
+      <emu-table id="table-collator-resolvedoptions-properties">
+        <emu-caption>Resolved Options of Collator Instances</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Internal Slot</th>
+              <th>Property</th>
+              <th>Extension Key</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[Locale]]</td>
+            <td>*"locale"*</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>[[Usage]]</td>
+            <td>*"usage"*</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>[[Sensitivity]]</td>
+            <td>*"sensitivity"*</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>[[IgnorePunctuation]]</td>
+            <td>*"ignorePunctuation"*</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>[[Collation]]</td>
+            <td>*"collation"*</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>[[Numeric]]</td>
+            <td>*"numeric"*</td>
+            <td>*"kn"*</td>
+          </tr>
+          <tr>
+            <td>[[CaseFirst]]</td>
+            <td>*"caseFirst"*</td>
+            <td>*"kf"*</td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
     <emu-clause id="sec-intl.collator.prototype-%symbol.tostringtag%" oldids="sec-intl.collator.prototype-@@tostringtag">
       <h1>Intl.Collator.prototype [ %Symbol.toStringTag% ]</h1>
 
@@ -282,78 +354,6 @@
           Applications should not assume that the behaviour of the CompareStrings abstract operation for Collator instances with the same resolved options will remain the same for different versions of the same implementation.
         </emu-note>
       </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-intl.collator.prototype.resolvedoptions">
-      <h1>Intl.Collator.prototype.resolvedOptions ( )</h1>
-
-      <p>
-        This function provides access to the locale and options computed during initialization of the object.
-      </p>
-
-      <emu-alg>
-        1. Let _collator_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_collator_, [[InitializedCollator]]).
-        1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. For each row of <emu-xref href="#table-collator-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _collator_'s internal slot whose name is the Internal Slot value of the current row.
-          1. If the current row has an Extension Key value, then
-            1. Let _extensionKey_ be the Extension Key value of the current row.
-            1. If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain _extensionKey_, then
-              1. Set _v_ to *undefined*.
-          1. If _v_ is not *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
-        1. Return _options_.
-      </emu-alg>
-
-      <emu-table id="table-collator-resolvedoptions-properties">
-        <emu-caption>Resolved Options of Collator Instances</emu-caption>
-        <table class="real-table">
-          <thead>
-            <tr>
-              <th>Internal Slot</th>
-              <th>Property</th>
-              <th>Extension Key</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>[[Locale]]</td>
-            <td>*"locale"*</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>[[Usage]]</td>
-            <td>*"usage"*</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>[[Sensitivity]]</td>
-            <td>*"sensitivity"*</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>[[IgnorePunctuation]]</td>
-            <td>*"ignorePunctuation"*</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>[[Collation]]</td>
-            <td>*"collation"*</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>[[Numeric]]</td>
-            <td>*"numeric"*</td>
-            <td>*"kn"*</td>
-          </tr>
-          <tr>
-            <td>[[CaseFirst]]</td>
-            <td>*"caseFirst"*</td>
-            <td>*"kf"*</td>
-          </tr>
-        </table>
-      </emu-table>
     </emu-clause>
   </emu-clause>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -894,95 +894,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-intl.datetimeformat.prototype-%symbol.tostringtag%" oldids="sec-intl.datetimeformat.prototype-@@tostringtag">
-      <h1>Intl.DateTimeFormat.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.DateTimeFormat"*.
-      </p>
-
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
-    <emu-clause id="sec-intl.datetimeformat.prototype.format">
-      <h1>get Intl.DateTimeFormat.prototype.format</h1>
-
-      <p>
-        Intl.DateTimeFormat.prototype.format is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:
-      </p>
-
-      <emu-alg>
-        1. Let _dtf_ be the *this* value.
-        1. If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then
-          1. Set _dtf_ to ? UnwrapDateTimeFormat(_dtf_).
-        1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
-        1. If _dtf_.[[BoundFormat]] is *undefined*, then
-          1. Let _F_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-format-functions"></emu-xref>).
-          1. Set _F_.[[DateTimeFormat]] to _dtf_.
-          1. Set _dtf_.[[BoundFormat]] to _F_.
-        1. Return _dtf_.[[BoundFormat]].
-      </emu-alg>
-
-      <emu-note>
-        The returned function is bound to _dtf_ so that it can be passed directly to `Array.prototype.map` or other functions.
-        This is considered a historical artefact, as part of a convention which is no longer followed for new features, but is preserved to maintain compatibility with existing programs.
-      </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DateTimeFormat.prototype.formatToParts">
-      <h1>Intl.DateTimeFormat.prototype.formatToParts ( _date_ )</h1>
-
-      <p>
-        When the `formatToParts` method is called with an argument _date_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _dtf_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
-        1. If _date_ is *undefined*, then
-          1. Let _x_ be ! Call(%Date.now%, *undefined*).
-        1. Else,
-          1. Let _x_ be ? ToNumber(_date_).
-        1. Return ? FormatDateTimeToParts(_dtf_, _x_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-intl.datetimeformat.prototype.formatRange">
-      <h1>Intl.DateTimeFormat.prototype.formatRange ( _startDate_, _endDate_ )</h1>
-
-      <p>
-        When the `formatRange` method is called with arguments _startDate_ and _endDate_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _dtf_ be *this* value.
-        1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
-        1. If _startDate_ is *undefined* or _endDate_ is *undefined*, throw a *TypeError* exception.
-        1. Let _x_ be ? ToNumber(_startDate_).
-        1. Let _y_ be ? ToNumber(_endDate_).
-        1. Return ? FormatDateTimeRange(_dtf_, _x_, _y_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DateTimeFormat.prototype.formatRangeToParts">
-      <h1>Intl.DateTimeFormat.prototype.formatRangeToParts ( _startDate_, _endDate_ )</h1>
-
-      <p>
-        When the `formatRangeToParts` method is called with arguments _startDate_ and _endDate_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _dtf_ be *this* value.
-        1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
-        1. If _startDate_ is *undefined* or _endDate_ is *undefined*, throw a *TypeError* exception.
-        1. Let _x_ be ? ToNumber(_startDate_).
-        1. Let _y_ be ? ToNumber(_endDate_).
-        1. Return ? FormatDateTimeRangeToParts(_dtf_, _x_, _y_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-intl.datetimeformat.prototype.resolvedoptions">
       <h1>Intl.DateTimeFormat.prototype.resolvedOptions ( )</h1>
 
@@ -1137,6 +1048,95 @@
       <emu-note>
         For compatibility with versions prior to the fifth edition, the *"hour12"* property is set in addition to the *"hourCycle"* property.
       </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.datetimeformat.prototype-%symbol.tostringtag%" oldids="sec-intl.datetimeformat.prototype-@@tostringtag">
+      <h1>Intl.DateTimeFormat.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.DateTimeFormat"*.
+      </p>
+
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.datetimeformat.prototype.format">
+      <h1>get Intl.DateTimeFormat.prototype.format</h1>
+
+      <p>
+        Intl.DateTimeFormat.prototype.format is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:
+      </p>
+
+      <emu-alg>
+        1. Let _dtf_ be the *this* value.
+        1. If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then
+          1. Set _dtf_ to ? UnwrapDateTimeFormat(_dtf_).
+        1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
+        1. If _dtf_.[[BoundFormat]] is *undefined*, then
+          1. Let _F_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-format-functions"></emu-xref>).
+          1. Set _F_.[[DateTimeFormat]] to _dtf_.
+          1. Set _dtf_.[[BoundFormat]] to _F_.
+        1. Return _dtf_.[[BoundFormat]].
+      </emu-alg>
+
+      <emu-note>
+        The returned function is bound to _dtf_ so that it can be passed directly to `Array.prototype.map` or other functions.
+        This is considered a historical artefact, as part of a convention which is no longer followed for new features, but is preserved to maintain compatibility with existing programs.
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.datetimeformat.prototype.formatRange">
+      <h1>Intl.DateTimeFormat.prototype.formatRange ( _startDate_, _endDate_ )</h1>
+
+      <p>
+        When the `formatRange` method is called with arguments _startDate_ and _endDate_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _dtf_ be *this* value.
+        1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
+        1. If _startDate_ is *undefined* or _endDate_ is *undefined*, throw a *TypeError* exception.
+        1. Let _x_ be ? ToNumber(_startDate_).
+        1. Let _y_ be ? ToNumber(_endDate_).
+        1. Return ? FormatDateTimeRange(_dtf_, _x_, _y_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DateTimeFormat.prototype.formatRangeToParts">
+      <h1>Intl.DateTimeFormat.prototype.formatRangeToParts ( _startDate_, _endDate_ )</h1>
+
+      <p>
+        When the `formatRangeToParts` method is called with arguments _startDate_ and _endDate_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _dtf_ be *this* value.
+        1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
+        1. If _startDate_ is *undefined* or _endDate_ is *undefined*, throw a *TypeError* exception.
+        1. Let _x_ be ? ToNumber(_startDate_).
+        1. Let _y_ be ? ToNumber(_endDate_).
+        1. Return ? FormatDateTimeRangeToParts(_dtf_, _x_, _y_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DateTimeFormat.prototype.formatToParts">
+      <h1>Intl.DateTimeFormat.prototype.formatToParts ( _date_ )</h1>
+
+      <p>
+        When the `formatToParts` method is called with an argument _date_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _dtf_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
+        1. If _date_ is *undefined*, then
+          1. Let _x_ be ! Call(%Date.now%, *undefined*).
+        1. Else,
+          1. Let _x_ be ? ToNumber(_date_).
+        1. Return ? FormatDateTimeToParts(_dtf_, _x_).
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1050,18 +1050,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-intl.datetimeformat.prototype-%symbol.tostringtag%" oldids="sec-intl.datetimeformat.prototype-@@tostringtag">
-      <h1>Intl.DateTimeFormat.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.DateTimeFormat"*.
-      </p>
-
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
     <emu-clause id="sec-intl.datetimeformat.prototype.format">
       <h1>get Intl.DateTimeFormat.prototype.format</h1>
 
@@ -1137,6 +1125,18 @@
           1. Let _x_ be ? ToNumber(_date_).
         1. Return ? FormatDateTimeToParts(_dtf_, _x_).
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.datetimeformat.prototype-%symbol.tostringtag%" oldids="sec-intl.datetimeformat.prototype-@@tostringtag">
+      <h1>Intl.DateTimeFormat.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.DateTimeFormat"*.
+      </p>
+
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
     </emu-clause>
   </emu-clause>
 

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -184,17 +184,6 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-intl.displaynames.prototype-%symbol.tostringtag%" oldids="sec-Intl.DisplayNames.prototype-@@tostringtag">
-      <h1>Intl.DisplayNames.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.DisplayNames"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
     <emu-clause id="sec-Intl.DisplayNames.prototype.of">
       <h1>Intl.DisplayNames.prototype.of ( _code_ )</h1>
 
@@ -212,6 +201,17 @@
         1. If _displayNames_.[[Fallback]] is *"code"*, return _code_.
         1. Return *undefined*.
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.displaynames.prototype-%symbol.tostringtag%" oldids="sec-Intl.DisplayNames.prototype-@@tostringtag">
+      <h1>Intl.DisplayNames.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.DisplayNames"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
     </emu-clause>
   </emu-clause>
 

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -132,36 +132,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-intl.displaynames.prototype-%symbol.tostringtag%" oldids="sec-Intl.DisplayNames.prototype-@@tostringtag">
-      <h1>Intl.DisplayNames.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.DisplayNames"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DisplayNames.prototype.of">
-      <h1>Intl.DisplayNames.prototype.of ( _code_ )</h1>
-
-      <p>
-        When the `Intl.DisplayNames.prototype.of` is called with an argument _code_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _displayNames_ be *this* value.
-        1. Perform ? RequireInternalSlot(_displayNames_, [[InitializedDisplayNames]]).
-        1. Let _code_ be ? ToString(_code_).
-        1. Set _code_ to ? CanonicalCodeForDisplayNames(_displayNames_.[[Type]], _code_).
-        1. Let _fields_ be _displayNames_.[[Fields]].
-        1. If _fields_ has a field [[&lt;_code_&gt;]], return _fields_.[[&lt;_code_&gt;]].
-        1. If _displayNames_.[[Fallback]] is *"code"*, return _code_.
-        1. Return *undefined*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-Intl.DisplayNames.prototype.resolvedOptions">
       <h1>Intl.DisplayNames.prototype.resolvedOptions ( )</h1>
 
@@ -212,6 +182,36 @@
           </tr>
         </table>
       </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.displaynames.prototype-%symbol.tostringtag%" oldids="sec-Intl.DisplayNames.prototype-@@tostringtag">
+      <h1>Intl.DisplayNames.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.DisplayNames"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DisplayNames.prototype.of">
+      <h1>Intl.DisplayNames.prototype.of ( _code_ )</h1>
+
+      <p>
+        When the `Intl.DisplayNames.prototype.of` is called with an argument _code_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _displayNames_ be *this* value.
+        1. Perform ? RequireInternalSlot(_displayNames_, [[InitializedDisplayNames]]).
+        1. Let _code_ be ? ToString(_code_).
+        1. Set _code_ to ? CanonicalCodeForDisplayNames(_displayNames_.[[Type]], _code_).
+        1. Let _fields_ be _displayNames_.[[Fields]].
+        1. If _fields_ has a field [[&lt;_code_&gt;]], return _fields_.[[&lt;_code_&gt;]].
+        1. If _displayNames_.[[Fallback]] is *"code"*, return _code_.
+        1. Return *undefined*.
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -162,17 +162,6 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.ListFormat.prototype-toStringTag">
-      <h1>Intl.ListFormat.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.ListFormat"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
     <emu-clause id="sec-Intl.ListFormat.prototype.format">
       <h1>Intl.ListFormat.prototype.format ( _list_ )</h1>
 
@@ -201,6 +190,17 @@
         1. Let _stringList_ be ? StringListFromIterable(_list_).
         1. Return FormatListToParts(_lf_, _stringList_).
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.ListFormat.prototype-toStringTag">
+      <h1>Intl.ListFormat.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.ListFormat"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
     </emu-clause>
   </emu-clause>
 

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -118,47 +118,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.ListFormat.prototype-toStringTag">
-      <h1>Intl.ListFormat.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.ListFormat"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.ListFormat.prototype.format">
-      <h1>Intl.ListFormat.prototype.format ( _list_ )</h1>
-
-      <p>
-        When the `format` method is called with an argument _list_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _lf_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_lf_, [[InitializedListFormat]]).
-        1. Let _stringList_ be ? StringListFromIterable(_list_).
-        1. Return FormatList(_lf_, _stringList_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.ListFormat.prototype.formatToParts">
-      <h1>Intl.ListFormat.prototype.formatToParts ( _list_ )</h1>
-
-      <p>
-        When the `formatToParts` method is called with an argument _list_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _lf_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_lf_, [[InitializedListFormat]]).
-        1. Let _stringList_ be ? StringListFromIterable(_list_).
-        1. Return FormatListToParts(_lf_, _stringList_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-Intl.ListFormat.prototype.resolvedoptions">
       <h1>Intl.ListFormat.prototype.resolvedOptions ( )</h1>
 
@@ -201,6 +160,47 @@
           </tr>
         </table>
       </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.ListFormat.prototype-toStringTag">
+      <h1>Intl.ListFormat.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.ListFormat"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.ListFormat.prototype.format">
+      <h1>Intl.ListFormat.prototype.format ( _list_ )</h1>
+
+      <p>
+        When the `format` method is called with an argument _list_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _lf_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_lf_, [[InitializedListFormat]]).
+        1. Let _stringList_ be ? StringListFromIterable(_list_).
+        1. Return FormatList(_lf_, _stringList_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.ListFormat.prototype.formatToParts">
+      <h1>Intl.ListFormat.prototype.formatToParts ( _list_ )</h1>
+
+      <p>
+        When the `formatToParts` method is called with an argument _list_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _lf_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_lf_, [[InitializedListFormat]]).
+        1. Let _stringList_ be ? StringListFromIterable(_list_).
+        1. Return FormatListToParts(_lf_, _stringList_).
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -204,38 +204,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.Locale.prototype.maximize">
-      <h1>Intl.Locale.prototype.maximize ( )</h1>
-
-      <emu-alg>
-      1. Let _loc_ be the *this* value.
-      1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
-      1. Let _maximal_ be the result of the <a href="https://unicode.org/reports/tr35/#Likely_Subtags">Add Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _maximal_ to _loc_.[[Locale]].
-      1. Return ! Construct(%Intl.Locale%, _maximal_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.Locale.prototype.minimize">
-      <h1>Intl.Locale.prototype.minimize ( )</h1>
-
-      <emu-alg>
-      1. Let _loc_ be the *this* value.
-      1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
-      1. Let _minimal_ be the result of the <a href="https://unicode.org/reports/tr35/#Likely_Subtags">Remove Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _minimal_ to _loc_.[[Locale]].
-      1. Return ! Construct(%Intl.Locale%, _minimal_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.Locale.prototype.toString">
-      <h1>Intl.Locale.prototype.toString ( )</h1>
-
-      <emu-alg>
-      1. Let _loc_ be the *this* value.
-      1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
-      1. Return _loc_.[[Locale]].
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-Intl.Locale.prototype.baseName">
       <h1>get Intl.Locale.prototype.baseName</h1>
       <p>`Intl.Locale.prototype.baseName` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -287,14 +255,35 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.Locale.prototype.numeric">
-      <h1>get Intl.Locale.prototype.numeric</h1>
-      <p>This property only exists if %Intl.Locale%.[[LocaleExtensionKeys]] contains *"kn"*.</p>
-      <p>`Intl.Locale.prototype.numeric` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+    <emu-clause id="sec-Intl.Locale.prototype.language">
+      <h1>get Intl.Locale.prototype.language</h1>
+      <p>`Intl.Locale.prototype.language` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
-        1. Return _loc_.[[Numeric]].
+        1. Return GetLocaleLanguage(_loc_.[[Locale]]).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.Locale.prototype.maximize">
+      <h1>Intl.Locale.prototype.maximize ( )</h1>
+
+      <emu-alg>
+      1. Let _loc_ be the *this* value.
+      1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
+      1. Let _maximal_ be the result of the <a href="https://unicode.org/reports/tr35/#Likely_Subtags">Add Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _maximal_ to _loc_.[[Locale]].
+      1. Return ! Construct(%Intl.Locale%, _maximal_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.Locale.prototype.minimize">
+      <h1>Intl.Locale.prototype.minimize ( )</h1>
+
+      <emu-alg>
+      1. Let _loc_ be the *this* value.
+      1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
+      1. Let _minimal_ be the result of the <a href="https://unicode.org/reports/tr35/#Likely_Subtags">Remove Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _minimal_ to _loc_.[[Locale]].
+      1. Return ! Construct(%Intl.Locale%, _minimal_).
       </emu-alg>
     </emu-clause>
 
@@ -308,13 +297,24 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.Locale.prototype.language">
-      <h1>get Intl.Locale.prototype.language</h1>
-      <p>`Intl.Locale.prototype.language` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+    <emu-clause id="sec-Intl.Locale.prototype.numeric">
+      <h1>get Intl.Locale.prototype.numeric</h1>
+      <p>This property only exists if %Intl.Locale%.[[LocaleExtensionKeys]] contains *"kn"*.</p>
+      <p>`Intl.Locale.prototype.numeric` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
-        1. Return GetLocaleLanguage(_loc_.[[Locale]]).
+        1. Return _loc_.[[Numeric]].
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.Locale.prototype.region">
+      <h1>get Intl.Locale.prototype.region</h1>
+      <p>`Intl.Locale.prototype.region` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+      <emu-alg>
+        1. Let _loc_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
+        1. Return GetLocaleRegion(_loc_.[[Locale]]).
       </emu-alg>
     </emu-clause>
 
@@ -328,13 +328,13 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.Locale.prototype.region">
-      <h1>get Intl.Locale.prototype.region</h1>
-      <p>`Intl.Locale.prototype.region` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+    <emu-clause id="sec-Intl.Locale.prototype.toString">
+      <h1>Intl.Locale.prototype.toString ( )</h1>
+
       <emu-alg>
-        1. Let _loc_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
-        1. Return GetLocaleRegion(_loc_.[[Locale]]).
+      1. Let _loc_ be the *this* value.
+      1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
+      1. Return _loc_.[[Locale]].
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -192,18 +192,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-intl.locale.prototype-%symbol.tostringtag%" oldids="sec-Intl.Locale.prototype-@@tostringtag">
-      <h1>Intl.Locale.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.Locale"*.
-      </p>
-
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
     <emu-clause id="sec-Intl.Locale.prototype.baseName">
       <h1>get Intl.Locale.prototype.baseName</h1>
       <p>`Intl.Locale.prototype.baseName` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
@@ -336,6 +324,18 @@
       1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
       1. Return _loc_.[[Locale]].
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.locale.prototype-%symbol.tostringtag%" oldids="sec-Intl.Locale.prototype-@@tostringtag">
+      <h1>Intl.Locale.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.Locale"*.
+      </p>
+
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
     </emu-clause>
   </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -444,17 +444,6 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-intl.numberformat.prototype-%symbol.tostringtag%" oldids="sec-intl.numberformat.prototype-@@tostringtag">
-      <h1>Intl.NumberFormat.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.NumberFormat"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
     <emu-clause id="sec-intl.numberformat.prototype.format">
       <h1>get Intl.NumberFormat.prototype.format</h1>
 
@@ -527,6 +516,17 @@
         1. Let _x_ be ? ToIntlMathematicalValue(_value_).
         1. Return FormatNumericToParts(_nf_, _x_).
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.numberformat.prototype-%symbol.tostringtag%" oldids="sec-intl.numberformat.prototype-@@tostringtag">
+      <h1>Intl.NumberFormat.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.NumberFormat"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
     </emu-clause>
   </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -301,91 +301,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-intl.numberformat.prototype-%symbol.tostringtag%" oldids="sec-intl.numberformat.prototype-@@tostringtag">
-      <h1>Intl.NumberFormat.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.NumberFormat"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
-    <emu-clause id="sec-intl.numberformat.prototype.format">
-      <h1>get Intl.NumberFormat.prototype.format</h1>
-
-      <p>
-        Intl.NumberFormat.prototype.format is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:
-      </p>
-
-      <emu-alg>
-        1. Let _nf_ be the *this* value.
-        1. If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then
-          1. Set _nf_ to ? UnwrapNumberFormat(_nf_).
-        1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
-        1. If _nf_.[[BoundFormat]] is *undefined*, then
-          1. Let _F_ be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions"></emu-xref>).
-          1. Set _F_.[[NumberFormat]] to _nf_.
-          1. Set _nf_.[[BoundFormat]] to _F_.
-        1. Return _nf_.[[BoundFormat]].
-      </emu-alg>
-
-      <emu-note>
-        The returned function is bound to _nf_ so that it can be passed directly to `Array.prototype.map` or other functions.
-        This is considered a historical artefact, as part of a convention which is no longer followed for new features, but is preserved to maintain compatibility with existing programs.
-      </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-intl.numberformat.prototype.formattoparts">
-      <h1>Intl.NumberFormat.prototype.formatToParts ( _value_ )</h1>
-
-      <p>
-        When the `formatToParts` method is called with an optional argument _value_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _nf_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
-        1. Let _x_ be ? ToIntlMathematicalValue(_value_).
-        1. Return FormatNumericToParts(_nf_, _x_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-intl.numberformat.prototype.formatrange">
-      <h1>Intl.NumberFormat.prototype.formatRange ( _start_, _end_ )</h1>
-
-      <p>
-        When the `formatRange` method is called with arguments _start_ and _end_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _nf_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
-        1. If _start_ is *undefined* or _end_ is *undefined*, throw a *TypeError* exception.
-        1. Let _x_ be ? ToIntlMathematicalValue(_start_).
-        1. Let _y_ be ? ToIntlMathematicalValue(_end_).
-        1. Return ? FormatNumericRange(_nf_, _x_, _y_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-intl.numberformat.prototype.formatrangetoparts">
-      <h1>Intl.NumberFormat.prototype.formatRangeToParts ( _start_, _end_ )</h1>
-
-      <p>
-        When the `formatRangeToParts` method is called with arguments _start_ and _end_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _nf_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
-        1. If _start_ is *undefined* or _end_ is *undefined*, throw a *TypeError* exception.
-        1. Let _x_ be ? ToIntlMathematicalValue(_start_).
-        1. Let _y_ be ? ToIntlMathematicalValue(_end_).
-        1. Return ? FormatNumericRangeToParts(_nf_, _x_, _y_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-intl.numberformat.prototype.resolvedoptions">
       <h1>Intl.NumberFormat.prototype.resolvedOptions ( )</h1>
 
@@ -527,6 +442,91 @@
           </tr>
         </table>
       </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.numberformat.prototype-%symbol.tostringtag%" oldids="sec-intl.numberformat.prototype-@@tostringtag">
+      <h1>Intl.NumberFormat.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.NumberFormat"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.numberformat.prototype.format">
+      <h1>get Intl.NumberFormat.prototype.format</h1>
+
+      <p>
+        Intl.NumberFormat.prototype.format is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:
+      </p>
+
+      <emu-alg>
+        1. Let _nf_ be the *this* value.
+        1. If the implementation supports the normative optional constructor mode of <emu-xref href="#legacy-constructor"></emu-xref>, then
+          1. Set _nf_ to ? UnwrapNumberFormat(_nf_).
+        1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
+        1. If _nf_.[[BoundFormat]] is *undefined*, then
+          1. Let _F_ be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions"></emu-xref>).
+          1. Set _F_.[[NumberFormat]] to _nf_.
+          1. Set _nf_.[[BoundFormat]] to _F_.
+        1. Return _nf_.[[BoundFormat]].
+      </emu-alg>
+
+      <emu-note>
+        The returned function is bound to _nf_ so that it can be passed directly to `Array.prototype.map` or other functions.
+        This is considered a historical artefact, as part of a convention which is no longer followed for new features, but is preserved to maintain compatibility with existing programs.
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.numberformat.prototype.formattoparts">
+      <h1>Intl.NumberFormat.prototype.formatToParts ( _value_ )</h1>
+
+      <p>
+        When the `formatToParts` method is called with an optional argument _value_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _nf_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
+        1. Let _x_ be ? ToIntlMathematicalValue(_value_).
+        1. Return FormatNumericToParts(_nf_, _x_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.numberformat.prototype.formatrange">
+      <h1>Intl.NumberFormat.prototype.formatRange ( _start_, _end_ )</h1>
+
+      <p>
+        When the `formatRange` method is called with arguments _start_ and _end_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _nf_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
+        1. If _start_ is *undefined* or _end_ is *undefined*, throw a *TypeError* exception.
+        1. Let _x_ be ? ToIntlMathematicalValue(_start_).
+        1. Let _y_ be ? ToIntlMathematicalValue(_end_).
+        1. Return ? FormatNumericRange(_nf_, _x_, _y_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.numberformat.prototype.formatrangetoparts">
+      <h1>Intl.NumberFormat.prototype.formatRangeToParts ( _start_, _end_ )</h1>
+
+      <p>
+        When the `formatRangeToParts` method is called with arguments _start_ and _end_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _nf_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
+        1. If _start_ is *undefined* or _end_ is *undefined*, throw a *TypeError* exception.
+        1. Let _x_ be ? ToIntlMathematicalValue(_start_).
+        1. Let _y_ be ? ToIntlMathematicalValue(_end_).
+        1. Return ? FormatNumericRangeToParts(_nf_, _x_, _y_).
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -480,21 +480,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-intl.numberformat.prototype.formattoparts">
-      <h1>Intl.NumberFormat.prototype.formatToParts ( _value_ )</h1>
-
-      <p>
-        When the `formatToParts` method is called with an optional argument _value_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _nf_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
-        1. Let _x_ be ? ToIntlMathematicalValue(_value_).
-        1. Return FormatNumericToParts(_nf_, _x_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-intl.numberformat.prototype.formatrange">
       <h1>Intl.NumberFormat.prototype.formatRange ( _start_, _end_ )</h1>
 
@@ -526,6 +511,21 @@
         1. Let _x_ be ? ToIntlMathematicalValue(_start_).
         1. Let _y_ be ? ToIntlMathematicalValue(_end_).
         1. Return ? FormatNumericRangeToParts(_nf_, _x_, _y_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.numberformat.prototype.formattoparts">
+      <h1>Intl.NumberFormat.prototype.formatToParts ( _value_ )</h1>
+
+      <p>
+        When the `formatToParts` method is called with an optional argument _value_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _nf_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
+        1. Let _x_ be ? ToIntlMathematicalValue(_value_).
+        1. Return FormatNumericToParts(_nf_, _x_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -205,17 +205,6 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-intl.pluralrules.prototype-%symbol.tostringtag%" oldids="sec-intl.pluralrules.prototype-tostringtag">
-      <h1>Intl.PluralRules.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.PluralRules"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
     <emu-clause id="sec-intl.pluralrules.prototype.select">
       <h1>Intl.PluralRules.prototype.select ( _value_ )</h1>
 
@@ -246,6 +235,17 @@
         1. Let _y_ be ? ToNumber(_end_).
         1. Return ? ResolvePluralRange(_pr_, _x_, _y_).
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.pluralrules.prototype-%symbol.tostringtag%" oldids="sec-intl.pluralrules.prototype-tostringtag">
+      <h1>Intl.PluralRules.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.PluralRules"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
     </emu-clause>
   </emu-clause>
 

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -105,49 +105,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-intl.pluralrules.prototype-%symbol.tostringtag%" oldids="sec-intl.pluralrules.prototype-tostringtag">
-      <h1>Intl.PluralRules.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.PluralRules"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
-    <emu-clause id="sec-intl.pluralrules.prototype.select">
-      <h1>Intl.PluralRules.prototype.select ( _value_ )</h1>
-
-      <p>
-        When the `select` method is called with an argument _value_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _pr_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_pr_, [[InitializedPluralRules]]).
-        1. Let _n_ be ? ToNumber(_value_).
-        1. Return ResolvePlural(_pr_, _n_).[[PluralCategory]].
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-intl.pluralrules.prototype.selectrange">
-      <h1>Intl.PluralRules.prototype.selectRange ( _start_, _end_ )</h1>
-
-      <p>
-        When the `selectRange` method is called with arguments _start_ and _end_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _pr_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_pr_, [[InitializedPluralRules]]).
-        1. If _start_ is *undefined* or _end_ is *undefined*, throw a *TypeError* exception.
-        1. Let _x_ be ? ToNumber(_start_).
-        1. Let _y_ be ? ToNumber(_end_).
-        1. Return ? ResolvePluralRange(_pr_, _x_, _y_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-intl.pluralrules.prototype.resolvedoptions">
       <h1>Intl.PluralRules.prototype.resolvedOptions ( )</h1>
 
@@ -246,6 +203,49 @@
           </tr>
         </table>
       </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.pluralrules.prototype-%symbol.tostringtag%" oldids="sec-intl.pluralrules.prototype-tostringtag">
+      <h1>Intl.PluralRules.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.PluralRules"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.pluralrules.prototype.select">
+      <h1>Intl.PluralRules.prototype.select ( _value_ )</h1>
+
+      <p>
+        When the `select` method is called with an argument _value_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _pr_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_pr_, [[InitializedPluralRules]]).
+        1. Let _n_ be ? ToNumber(_value_).
+        1. Return ResolvePlural(_pr_, _n_).[[PluralCategory]].
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.pluralrules.prototype.selectrange">
+      <h1>Intl.PluralRules.prototype.selectRange ( _start_, _end_ )</h1>
+
+      <p>
+        When the `selectRange` method is called with arguments _start_ and _end_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _pr_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_pr_, [[InitializedPluralRules]]).
+        1. If _start_ is *undefined* or _end_ is *undefined*, throw a *TypeError* exception.
+        1. Let _x_ be ? ToNumber(_start_).
+        1. Let _y_ be ? ToNumber(_end_).
+        1. Return ? ResolvePluralRange(_pr_, _x_, _y_).
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -129,49 +129,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.RelativeTimeFormat.prototype-toStringTag">
-      <h1>Intl.RelativeTimeFormat.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.RelativeTimeFormat"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.RelativeTimeFormat.prototype.format">
-      <h1>Intl.RelativeTimeFormat.prototype.format ( _value_, _unit_ )</h1>
-
-      <p>
-        When the `format` method is called with arguments _value_ and _unit_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _relativeTimeFormat_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_relativeTimeFormat_, [[InitializedRelativeTimeFormat]]).
-        1. Let _value_ be ? ToNumber(_value_).
-        1. Let _unit_ be ? ToString(_unit_).
-        1. Return ? FormatRelativeTime(_relativeTimeFormat_, _value_, _unit_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.RelativeTimeFormat.prototype.formatToParts">
-      <h1>Intl.RelativeTimeFormat.prototype.formatToParts ( _value_, _unit_ )</h1>
-
-      <p>
-        When the `formatToParts` method is called with arguments _value_ and _unit_, the following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _relativeTimeFormat_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_relativeTimeFormat_, [[InitializedRelativeTimeFormat]]).
-        1. Let _value_ be ? ToNumber(_value_).
-        1. Let _unit_ be ? ToString(_unit_).
-        1. Return ? FormatRelativeTimeToParts(_relativeTimeFormat_, _value_, _unit_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-intl.relativetimeformat.prototype.resolvedoptions">
       <h1>Intl.RelativeTimeFormat.prototype.resolvedOptions ( )</h1>
 
@@ -218,6 +175,49 @@
           </tr>
         </table>
       </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.RelativeTimeFormat.prototype-toStringTag">
+      <h1>Intl.RelativeTimeFormat.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.RelativeTimeFormat"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.RelativeTimeFormat.prototype.format">
+      <h1>Intl.RelativeTimeFormat.prototype.format ( _value_, _unit_ )</h1>
+
+      <p>
+        When the `format` method is called with arguments _value_ and _unit_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _relativeTimeFormat_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_relativeTimeFormat_, [[InitializedRelativeTimeFormat]]).
+        1. Let _value_ be ? ToNumber(_value_).
+        1. Let _unit_ be ? ToString(_unit_).
+        1. Return ? FormatRelativeTime(_relativeTimeFormat_, _value_, _unit_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.RelativeTimeFormat.prototype.formatToParts">
+      <h1>Intl.RelativeTimeFormat.prototype.formatToParts ( _value_, _unit_ )</h1>
+
+      <p>
+        When the `formatToParts` method is called with arguments _value_ and _unit_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _relativeTimeFormat_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_relativeTimeFormat_, [[InitializedRelativeTimeFormat]]).
+        1. Let _value_ be ? ToNumber(_value_).
+        1. Let _unit_ be ? ToString(_unit_).
+        1. Return ? FormatRelativeTimeToParts(_relativeTimeFormat_, _value_, _unit_).
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -177,17 +177,6 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.RelativeTimeFormat.prototype-toStringTag">
-      <h1>Intl.RelativeTimeFormat.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.RelativeTimeFormat"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
     <emu-clause id="sec-Intl.RelativeTimeFormat.prototype.format">
       <h1>Intl.RelativeTimeFormat.prototype.format ( _value_, _unit_ )</h1>
 
@@ -218,6 +207,17 @@
         1. Let _unit_ be ? ToString(_unit_).
         1. Return ? FormatRelativeTimeToParts(_relativeTimeFormat_, _value_, _unit_).
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.RelativeTimeFormat.prototype-toStringTag">
+      <h1>Intl.RelativeTimeFormat.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.RelativeTimeFormat"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
     </emu-clause>
   </emu-clause>
 

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -100,32 +100,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-intl.segmenter.prototype-%symbol.tostringtag%" oldids="sec-intl.segmenter.prototype-@@tostringtag">
-      <h1>Intl.Segmenter.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.Segmenter"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
-    <emu-clause id="sec-intl.segmenter.prototype.segment">
-      <h1>Intl.Segmenter.prototype.segment ( _string_ )</h1>
-
-      <p>
-        The `Intl.Segmenter.prototype.segment` method is called on an Intl.Segmenter instance with argument _string_ to create a Segments instance for the string using the locale and options of the Intl.Segmenter instance. The following steps are taken:
-      </p>
-
-      <emu-alg>
-        1. Let _segmenter_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_segmenter_, [[InitializedSegmenter]]).
-        1. Let _string_ be ? ToString(_string_).
-        1. Return CreateSegmentsObject(_segmenter_, _string_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-intl.segmenter.prototype.resolvedoptions">
       <h1>Intl.Segmenter.prototype.resolvedOptions ( )</h1>
 
@@ -164,6 +138,32 @@
           </tr>
         </table>
       </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.segmenter.prototype-%symbol.tostringtag%" oldids="sec-intl.segmenter.prototype-@@tostringtag">
+      <h1>Intl.Segmenter.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.Segmenter"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.segmenter.prototype.segment">
+      <h1>Intl.Segmenter.prototype.segment ( _string_ )</h1>
+
+      <p>
+        The `Intl.Segmenter.prototype.segment` method is called on an Intl.Segmenter instance with argument _string_ to create a Segments instance for the string using the locale and options of the Intl.Segmenter instance. The following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _segmenter_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_segmenter_, [[InitializedSegmenter]]).
+        1. Let _string_ be ? ToString(_string_).
+        1. Return CreateSegmentsObject(_segmenter_, _string_).
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -140,17 +140,6 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-intl.segmenter.prototype-%symbol.tostringtag%" oldids="sec-intl.segmenter.prototype-@@tostringtag">
-      <h1>Intl.Segmenter.prototype [ %Symbol.toStringTag% ]</h1>
-
-      <p>
-        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.Segmenter"*.
-      </p>
-      <p>
-        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-      </p>
-    </emu-clause>
-
     <emu-clause id="sec-intl.segmenter.prototype.segment">
       <h1>Intl.Segmenter.prototype.segment ( _string_ )</h1>
 
@@ -164,6 +153,17 @@
         1. Let _string_ be ? ToString(_string_).
         1. Return CreateSegmentsObject(_segmenter_, _string_).
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.segmenter.prototype-%symbol.tostringtag%" oldids="sec-intl.segmenter.prototype-@@tostringtag">
+      <h1>Intl.Segmenter.prototype [ %Symbol.toStringTag% ]</h1>
+
+      <p>
+        The initial value of the %Symbol.toStringTag% property is the String value *"Intl.Segmenter"*.
+      </p>
+      <p>
+        This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
+      </p>
     </emu-clause>
   </emu-clause>
 


### PR DESCRIPTION
Resolves the following aspects of #405:

Placed Prototype Object properties in the following order for all Intl Objects:

1. Intl._Foo_.prototype.constructor
2. Intl._Foo_.prototype.resolvedOptions ()
3. Intl._Foo_.prototype [ %Symbol.toStringTag% ]
4. ..._Foo_-specific properties in alphabetic order...

Gathered all Abstract Operations associated with each Object into the Abstract Operations section for that Object. Previously Intl.DateTimeFormat, Intl.Locale, and Intl.NumberFormat had several Abstract Operations appear inside the constructor clauses of those Objects.