### PR TITLE
Normative: Add 8 new numbering systems for Unicode 16

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1006,6 +1006,10 @@
             <td>U+FF10 to U+FF19</td>
           </tr>
           <tr>
+            <td>gara</td>
+            <td>U+10D40 to U+10D49</td>
+          </tr>
+          <tr>
             <td>gong</td>
             <td>U+11DA0 to U+11DA9</td>
           </tr>
@@ -1016,6 +1020,10 @@
           <tr>
             <td>gujr</td>
             <td>U+0AE6 to U+0AEF</td>
+          </tr>
+          <tr>
+            <td>gukh</td>
+            <td>U+16130 to U+16139</td>
           </tr>
           <tr>
             <td>guru</td>
@@ -1052,6 +1060,10 @@
           <tr>
             <td>knda</td>
             <td>U+0CE6 to U+0CEF</td>
+          </tr>
+          <tr>
+            <td>krai</td>
+            <td>U+16D70 to U+16D79</td>
           </tr>
           <tr>
             <td>lana</td>
@@ -1122,6 +1134,14 @@
             <td>U+1040 to U+1049</td>
           </tr>
           <tr>
+            <td>mymrepka</td>
+            <td>U+116DA to U+116E3</td>
+          </tr>
+          <tr>
+            <td>mymrpao</td>
+            <td>U+116D0 to U+116D9</td>
+          </tr>
+          <tr>
             <td>mymrshan</td>
             <td>U+1090 to U+1099</td>
           </tr>
@@ -1146,12 +1166,20 @@
             <td>U+1C50 to U+1C59</td>
           </tr>
           <tr>
+            <td>onao</td>
+            <td>U+1E5F1 to U+1E5FA</td>
+          </tr>
+          <tr>
             <td>orya</td>
             <td>U+0B66 to U+0B6F</td>
           </tr>
           <tr>
             <td>osma</td>
             <td>U+104A0 to U+104A9</td>
+          </tr>
+          <tr>
+            <td>outlined</td>
+            <td>U+1CCF0 to U+1CCF9</td>
           </tr>
           <tr>
             <td>rohg</td>
@@ -1184,6 +1212,10 @@
           <tr>
             <td>sund</td>
             <td>U+1BB0 to U+1BB9</td>
+          </tr>
+          <tr>
+            <td>sunu</td>
+            <td>U+11BF0 to U+11BF9</td>
           </tr>
           <tr>
             <td>takr</td>


### PR DESCRIPTION
Unicode 16 added 8 new numbering systems for the newly added 5,185 new characters, including 3,995 additional Egyptian Hieroglyph characters plus seven new scripts, seven new emoji characters, and over 700 symbols from legacy computing environments. see https://blog.unicode.org/2024/09/announcing-unicode-standard-version-160.html

CLDR add that in https://github.com/unicode-org/cldr/pull/3658 which will be available in ICU 76

This PR update the ECMA402 spec to include that new numbering systems. 

We should consider merging it after ICU 76.1 is wildely available to implementer. We probably should discuss this in TG2 around Nov. or Dec. 2024.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
