### PR TITLE
Editorial: Simplify PR925

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -33,11 +33,10 @@
         1. Set _numberFormat_.[[NumberingSystem]] to _r_.[[nu]].
         1. Perform ? SetNumberFormatUnitOptions(_numberFormat_, _options_).
         1. Let _style_ be _numberFormat_.[[Style]].
-        1. If _style_ is *"currency"*, then
-          1. Let _currency_ be _numberFormat_.[[Currency]].
         1. Let _notation_ be ? GetOption(_options_, *"notation"*, ~string~, « *"standard"*, *"scientific"*, *"engineering"*, *"compact"* », *"standard"*).
         1. Set _numberFormat_.[[Notation]] to _notation_.
         1. If _style_ is *"currency"* and *"notation"* is *"standard"*, then
+          1. Let _currency_ be _numberFormat_.[[Currency]].
           1. Let _cDigits_ be CurrencyDigits(_currency_).
           1. Let _mnfdDefault_ be _cDigits_.
           1. Let _mxfdDefault_ be _cDigits_.


### PR DESCRIPTION
There are no reason we need to put the "Let _currency_ be _numberFormat_.[[Currency]]." line in a separate if block. Move that down

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
