### PR TITLE
Meta: Update ecmarkup and ecma262-biblio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "9.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma402/#sec-copyright-and-software-license",
       "dependencies": {
-        "@tc39/ecma262-biblio": "2.1.2742",
-        "ecmarkup": "^19.0.0"
+        "@tc39/ecma262-biblio": "=2.1.2799",
+        "ecmarkup": "^20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@tc39/ecma262-biblio": {
-      "version": "2.1.2742",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2742.tgz",
-      "integrity": "sha512-nWPDshWKzcEMXpNNzhBud9X39KzP2PLhIoENAIhQsfmXc+jAFzWIY4Z1B3+oChU1U5X46yHcyYd8PZY/pro2BA=="
+      "version": "2.1.2799",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2799.tgz",
+      "integrity": "sha512-8J37sEc7yoXaZJm9JTGaPGONkr6v8rXGry3wxttLuDgzaEPnozXM40eSazEB5B4thmOPllolgwV+t5z3MnnXwQ=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -458,9 +458,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-19.0.0.tgz",
-      "integrity": "sha512-ncn5LXs46jPqcQSO/XdJCOOsdAvC8xT/Yebxted4qgpYWLisY4AEdOdZ4OXKgmPXGgWBqAgCSoV0obvEBEz8Hg==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-20.0.0.tgz",
+      "integrity": "sha512-c5Km5oVo+pZVvfaS1lRvaweVj89lkXxjOKGdW5QfQWFaAxHu/q1sSFCwEIy2bwhtZr5EiijdjonF22D/e75yzQ==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -484,7 +484,7 @@
         "emu-format": "bin/emu-format.js"
       },
       "engines": {
-        "node": ">= 12 || ^11.10.1 || ^10.13 || ^8.10"
+        "node": ">= 18"
       }
     },
     "node_modules/ecmarkup/node_modules/acorn": {
@@ -1472,9 +1472,9 @@
       }
     },
     "@tc39/ecma262-biblio": {
-      "version": "2.1.2742",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2742.tgz",
-      "integrity": "sha512-nWPDshWKzcEMXpNNzhBud9X39KzP2PLhIoENAIhQsfmXc+jAFzWIY4Z1B3+oChU1U5X46yHcyYd8PZY/pro2BA=="
+      "version": "2.1.2799",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2799.tgz",
+      "integrity": "sha512-8J37sEc7yoXaZJm9JTGaPGONkr6v8rXGry3wxttLuDgzaEPnozXM40eSazEB5B4thmOPllolgwV+t5z3MnnXwQ=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -1698,9 +1698,9 @@
       }
     },
     "ecmarkup": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-19.0.0.tgz",
-      "integrity": "sha512-ncn5LXs46jPqcQSO/XdJCOOsdAvC8xT/Yebxted4qgpYWLisY4AEdOdZ4OXKgmPXGgWBqAgCSoV0obvEBEz8Hg==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-20.0.0.tgz",
+      "integrity": "sha512-c5Km5oVo+pZVvfaS1lRvaweVj89lkXxjOKGdW5QfQWFaAxHu/q1sSFCwEIy2bwhtZr5EiijdjonF22D/e75yzQ==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma402/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma402/",
   "dependencies": {
-    "ecmarkup": "^19.0.0",
-    "@tc39/ecma262-biblio": "2.1.2742"
+    "ecmarkup": "^20.0.0",
+    "@tc39/ecma262-biblio": "=2.1.2799"
   }
 }

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -320,11 +320,11 @@
           1. Let _startIndex_ be _iterator_.[[IteratedStringNextSegmentCodeUnitIndex]].
           1. Let _len_ be the length of _string_.
           1. If _startIndex_ ≥ _len_, then
-            1. Return CreateIterResultObject(*undefined*, *true*).
+            1. Return CreateIteratorResultObject(*undefined*, *true*).
           1. Let _endIndex_ be FindBoundary(_segmenter_, _string_, _startIndex_, ~after~).
           1. Set _iterator_.[[IteratedStringNextSegmentCodeUnitIndex]] to _endIndex_.
           1. Let _segmentData_ be CreateSegmentDataObject(_segmenter_, _string_, _startIndex_, _endIndex_).
-          1. Return CreateIterResultObject(_segmentData_, *false*).
+          1. Return CreateIteratorResultObject(_segmentData_, *false*).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
`CreateIterResultObject` has been renamed to `CreateIteratorResultObject`.

