### PR TITLE
Editorial: Handle case when backzone doesn't contain link

### DIFF
--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -282,8 +282,8 @@
                     1. If _backzoneAndLink_[1] is _identifier_, then
                       1. Assert: _backzone_ is *undefined*.
                       1. Set _backzone_ to _backzoneAndLink_[0].
-                  1. Assert: _backzone_ is not *undefined*.
-                  1. Set _primary_ to _backzone_.
+                  1. If _backzone_ is not *undefined*, then
+                    1. Set _primary_ to _backzone_.
           1. If _primary_ is one of *"Etc/UTC"*, *"Etc/GMT"*, or *"GMT"*, set _primary_ to *"UTC"*.
           1. If _primary_ is a replacement time zone identifier and its rename waiting period has not concluded, then
             1. Let _renamedIdentifier_ be the renamed time zone identifier that _primary_ replaced.


### PR DESCRIPTION
A couple of links aren't in `backzone`. Change the assertion to an if-step to correctly handle this case.

List of time zones which weren't correctly handled:
```
Africa/Kinshasa
Africa/Lubumbashi
America/Atikokan
America/Blanc-Sablon
America/Creston
Antarctica/DumontDUrville
Antarctica/McMurdo
Antarctica/Syowa
Asia/Kuala_Lumpur
Europe/Busingen
Pacific/Chuuk
Pacific/Majuro
Pacific/Midway
Pacific/Pohnpei
Pacific/Wake
```

For example "Africa/Kinshasa", which is a zone in `backzone`:
- "Africa/Kinshasa" is a link to "Africa/Lagos" per `backward`.
- The region code for "Africa/Lagos" is "NG", the region code for "Africa/Kinshasa" is "CD". That means the condition in step 5.b.iii.3 evaluates to false.
- There are two entries for the region "CD" in `zone.tab`: "Africa/Kinshasa" and "Africa/Lubumbashi". That means the condition in step 5.b.iii.4.b also evaluates to false.
- "Africa/Kinshasa" is a zone in `backzone`, so the loop in step 5.b.iii.4.c.iii won't find any entries.

All other cases are also zones in `backzone`, except for "Europe/Busingen", which is always a link. "Europe/Busingen" links to "Europe/Zurich" per `backward`, but is still a primary identifier in ECMA-402, because Büsingen is politically a part of Germany, so it shouldn't be merged with the time zone for Zürich (Switzerland).

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
