### PR TITLE
Editorial: Add two more required formats

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -264,12 +264,14 @@
             <li>year, month, day</li>
             <li>year, month</li>
             <li>month, day</li>
+            <li>month</li>
             <li>hour, minute, second, fractionalSecondDigits</li>
             <li>hour, minute, second</li>
             <li>hour, minute</li>
-            <li>dayPeriod, hour</li>
+            <li>dayPeriod, hour, minute, second, fractionalSecondDigits</li>
             <li>dayPeriod, hour, minute, second</li>
             <li>dayPeriod, hour, minute</li>
+            <li>dayPeriod, hour</li>
           </ul>
         </li>
         <li>


### PR DESCRIPTION
This makes format selection in BasicFormatMatcher unambiguous when requesting the following two formats:

1. Standalone "month":

There's currently a tie between "year, month" and "month, day". Adding standalone "month" as a required format resolves this tie.

2. "dayPeriod, hour, minute, second, fractionalSecondDigits":

There's a tie between "hour, minute, second, fractionalSecondDigits" and "dayPeriod, hour, minute, second". Requiring a format which has both "dayPeriod" and "fractionalSecondDigits" resolves this tie.


