### PR TITLE
Editorial: Distinguish 'available time zone identifier'

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1159,7 +1159,7 @@
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
       <li>[[Calendar]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeCalendarIdentifier">Unicode Calendar Identifier</a> used for formatting.</li>
       <li>[[NumberingSystem]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> used for formatting.</li>
-      <li>[[TimeZone]] is a String value used for formatting that is either a time zone identifier from the IANA Time Zone Database or a UTC offset in ISO 8601 extended format.</li>
+      <li>[[TimeZone]] is a String value used for formatting that is an available time zone identifier.</li>
       <li>[[HourCycle]] is a String value indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[DateTimeFormat]] has an [[hour]] field.</li>
       <li>[[DateStyle]], [[TimeStyle]] are each either *undefined*, or a String value with values *"full"*, *"long"*, *"medium"*, or *"short"*.</li>
       <li>[[DateTimeFormat]] is a DateTime Format Record.</li>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -170,7 +170,7 @@
     <h1>Use of the IANA Time Zone Database</h1>
 
     <p>
-      Implementations that adopt this specification must be time zone aware: they must use the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a> to supply time zone identifiers and data used in ECMAScript calculations and formatting.
+      Implementations that adopt this specification must be time zone aware: they must use the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a> to supply available named time zone identifiers and data used in ECMAScript calculations and formatting.
       This section defines how the IANA Time Zone Database should be used by time zone aware implementations.
       No String may be an available named time zone identifier unless it is a Zone name or a Link name in the IANA Time Zone Database.
       Available named time zone identifiers returned by ECMAScript built-in objects must use the casing found in the IANA Time Zone Database.
@@ -196,7 +196,7 @@
 
     <emu-note>
       <p>
-        The IANA Time Zone Database offers build options that affect which time zone identifiers are primary.
+        The IANA Time Zone Database offers build options that affect which available named time zone identifiers are primary.
         The default build options merge different countries' time zones, for example *"Atlantic/Reykjavik"* is built as a Link to the Zone *"Africa/Abidjan"*.
         Geographically and politically distinct locations are likely to introduce divergent time zone rules in a future version of the IANA Time Zone Database.
         The exceptions above serve to mitigate these future-compatibility issues.


### PR DESCRIPTION
Temporal will introduce separate definitions for 'time zone identifier' (string consisting of characters that are legal in time zone identifiers) and 'available time zone identifier' (time zone identifier that is known to the implementation.)

For some usages it's probably more appropriate to speak of available time zone identifiers than time zone identifiers. For others, it's probably more appropriate to use 'available named time zone identifier' which is a definition given in ECMA-262.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
