### PR TITLE
Normative: Update String toLocale{Lower,Upper}Case to ResolveLocale with best-fit matching

### DIFF
--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -79,13 +79,11 @@
         </dl>
         <emu-alg>
           1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-          1. If _requestedLocales_ is not an empty List, then
-            1. Let _requestedLocale_ be _requestedLocales_[0].
-          1. Else,
-            1. Let _requestedLocale_ be DefaultLocale().
           1. Let _availableLocales_ be an Available Locales List which includes the language tags for which the Unicode Character Database contains language-sensitive case mappings. If the implementation supports additional locale-sensitive case mappings, _availableLocales_ should also include their corresponding language tags.
-          1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, « _requestedLocale_ »).
-          1. If _match_ is not *undefined*, let _locale_ be _match_.[[locale]]; else let _locale_ be *"und"*.
+          1. Let _opt_ be the Record { [[localeMatcher]]: *"best fit"* }.
+          1. Let _relevantExtensionKeys_ be a new empty List.
+          1. Let _r_ be ResolveLocale(_availableLocales_, _requestedLocales_, _opt_, _relevantExtensionKeys_).
+          1. Let _locale_ be _r_.[[Locale]].
           1. Let _codePoints_ be StringToCodePoints(_S_).
           1. If _targetCase_ is ~lower~, then
             1. Let _newCodePoints_ be a List whose elements are the result of a lowercase transformation of _codePoints_ according to an implementation-derived algorithm using _locale_ or the Unicode Default Case Conversion algorithm.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -227,7 +227,7 @@
           _requestedLocales_: a Language Priority List,
           _options_: a Record,
           _relevantExtensionKeys_: a List of Strings,
-          _localeData_: a Record,
+          optional _localeData_: a Record,
         ): a Record
       </h1>
       <dl class="header">
@@ -235,6 +235,7 @@
         <dd>It performs "lookup" as defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-3">RFC 4647 section 3</a>, determining the best element of _availableLocales_ for satisfying _requestedLocales_ using either the LookupMatchingLocaleByBestFit algorithm or LookupMatchingLocaleByPrefix algorithm as specified by _options_.[[localeMatcher]], ignoring Unicode locale extension sequences, and returns a representation of the match that also includes corresponding data from _localeData_ and a resolved value for each element of _relevantExtensionKeys_ (defaulting to data from the matched locale, superseded by data from the requested Unicode locale extension sequence if present and then by data from _options_ if present). If the matched element from _requestedLocales_ contains a Unicode locale extension sequence, it is copied onto the language tag in the [[Locale]] field of the returned Record, omitting any <code>keyword</code> Unicode locale nonterminal whose <code>key</code> value is not contained within _relevantExtensionKeys_ or <code>type</code> value is superseded by a different value from _options_.</dd>
       </dl>
       <emu-alg>
+        1. Assert: If _relevantExtensionKeys_ is not empty, then _localeData_ is present.
         1. Let _matcher_ be _options_.[[localeMatcher]].
         1. If _matcher_ is *"lookup"*, then
           1. Let _r_ be LookupMatchingLocaleByPrefix(_availableLocales_, _requestedLocales_).
@@ -242,8 +243,11 @@
           1. Let _r_ be LookupMatchingLocaleByBestFit(_availableLocales_, _requestedLocales_).
         1. If _r_ is *undefined*, set _r_ to the Record { [[locale]]: DefaultLocale(), [[extension]]: ~empty~ }.
         1. Let _foundLocale_ be _r_.[[locale]].
-        1. Let _foundLocaleData_ be _localeData_.[[&lt;_foundLocale_&gt;]].
-        1. Assert: _foundLocaleData_ is a Record.
+        1. If _localeData_ is present, then
+          1. Let _foundLocaleData_ be _localeData_.[[&lt;_foundLocale_&gt;]].
+          1. Assert: _foundLocaleData_ is a Record.
+        1. Else,
+          1. Let _foundLocaleData_ be ~empty~.
         1. Let _result_ be a new Record.
         1. Set _result_.[[LocaleData]] to _foundLocaleData_.
         1. If _r_.[[extension]] is not ~empty~, then


### PR DESCRIPTION
Fixes #896

* Do not ignore locales after the first in the list returned by CanonicalizeLocaleList(_locales_) (observable via e.g. `"I".toLocaleLowerCase(["zzz", "tr"]) === "ı"`).
* Match against the items of that list by best-fit rather than prefix, aligning with the rest of ECMA-402 (although the difference is not necessarily observable).
* When the list is not empty but no matching locale is found, default to DefaultLocale() rather than "und", aligning with empty-list behavior and with the rest of ECMA-402 (observable via e.g. `"I".toLocaleLowerCase("zzz") === "I".toLocaleLowerCase()` regardless of default locale, just like `new Intl.Collator("zzz", { sensitivity: "variant" }).compare("i", "ı") === new Intl.Collator(undefined, { sensitivity: "variant" }).compare("i", "ı")`).