### PR TITLE
Normative: Don't add default formatting to lone timeZoneName

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -145,7 +145,7 @@
               1. Let _value_ be _formatOptions_.[[&lt;_prop_&gt;]].
               1. If _value_ is not *undefined*, set _needDefaults_ to *false*.
           1. If _required_ is ~time~ or ~any~, then
-            1. For each property name _prop_ of « *"dayPeriod"*, *"hour"*, *"minute"*, *"second"*, *"fractionalSecondDigits"* », do
+            1. For each property name _prop_ of « *"dayPeriod"*, *"hour"*, *"minute"*, *"second"*, *"fractionalSecondDigits"*, *"timeZoneName"* », do
               1. Let _value_ be _formatOptions_.[[&lt;_prop_&gt;]].
               1. If _value_ is not *undefined*, set _needDefaults_ to *false*.
           1. If _needDefaults_ is *true* and _defaults_ is either ~date~ or ~all~, then
@@ -261,6 +261,7 @@
             <li>weekday, year, month, day, hour, minute, second, fractionalSecondDigits</li>
             <li>weekday, year, month, day, hour, minute, second</li>
             <li>weekday, year, month, day</li>
+            <li>year, month, day, hour, minute, second, timeZoneName</li>
             <li>year, month, day</li>
             <li>year, month</li>
             <li>month, day</li>


### PR DESCRIPTION
Previously, if `timeZoneName` was given by itself in the formatting options, the default formatting for the other date/time components would be added. This is inconsistent with what we do for `dayPeriod` where a lone `dayPeriod` produces formats such as "in the afternoon".

The use case of obtaining the localized time zone name in all its possible variants such as specific/generic, has been mentioned several times.

This change makes a lone `timeZoneName` be passed to the format matcher algorithm without added date/time components, and requires implementations to have at least a year-month-day-hour-minute-second-timeZoneName format available.

See: #461

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
