### PR TITLE
Editorial: Clean up DurationFormat

### DIFF
--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -1,6 +1,415 @@
 <emu-clause id="durationformat-objects">
   <h1>DurationFormat Objects</h1>
 
+  <emu-clause id="sec-intl-durationformat-constructor">
+    <h1>The Intl.DurationFormat Constructor</h1>
+
+    <p>The DurationFormat constructor is the <dfn>%Intl.DurationFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+
+    <emu-clause id="sec-Intl.DurationFormat">
+      <h1>Intl.DurationFormat ( [ _locales_ [ , _options_ ] ] )</h1>
+
+      <p>When the `Intl.DurationFormat` function is called with optional arguments _locales_ and _options_, the following steps are taken:</p>
+
+      <emu-alg>
+        1. If NewTarget is *undefined*, throw a *TypeError* exception.
+        1. Let _durationFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.DurationFormatPrototype%"*, « [[InitializedDurationFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[YearsStyle]], [[YearsDisplay]], [[MonthsStyle]], [[MonthsDisplay]], [[WeeksStyle]], [[WeeksDisplay]], [[DaysStyle]], [[DaysDisplay]], [[HoursStyle]], [[HoursDisplay]], [[MinutesStyle]], [[MinutesDisplay]], [[SecondsStyle]], [[SecondsDisplay]], [[MillisecondsStyle]], [[MillisecondsDisplay]], [[MicrosecondsStyle]], [[MicrosecondsDisplay]], [[NanosecondsStyle]], [[NanosecondsDisplay]], [[HourMinuteSeparator]], [[MinuteSecondSeparator]], [[FractionalDigits]] »).
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+        1. Let _options_ be ? GetOptionsObject(_options_).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
+        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, ~string~, ~empty~, *undefined*).
+        1. If _numberingSystem_ is not *undefined*, then
+          1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
+        1. Let _opt_ be the Record { [[localeMatcher]]: _matcher_, [[nu]]: _numberingSystem_ }.
+        1. Let _r_ be ResolveLocale(%Intl.DurationFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.DurationFormat%.[[RelevantExtensionKeys]], %Intl.DurationFormat%.[[LocaleData]]).
+        1. Set _durationFormat_.[[Locale]] to _r_.[[Locale]].
+        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
+        1. Let _digitalFormat_ be _resolvedLocaleData_.[[DigitalFormat]].
+        1. Set _durationFormat_.[[HourMinuteSeparator]] to _digitalFormat_.[[HourMinuteSeparator]].
+        1. Set _durationFormat_.[[MinuteSecondSeparator]] to _digitalFormat_.[[MinuteSecondSeparator]].
+        1. Set _durationFormat_.[[NumberingSystem]] to _r_.[[nu]].
+        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"long"*, *"short"*, *"narrow"*, *"digital"* », *"short"*).
+        1. Set _durationFormat_.[[Style]] to _style_.
+        1. Let _prevStyle_ be the empty String.
+        1. For each row of <emu-xref href="#table-durationformat"></emu-xref>, except the header row, in table order, do
+          1. Let _styleSlot_ be the Style Slot value of the current row.
+          1. Let _displaySlot_ be the Display Slot value of the current row.
+          1. Let _unit_ be the Unit value of the current row.
+          1. Let _valueList_ be the Values value of the current row.
+          1. Let _digitalBase_ be the Digital Default value of the current row.
+          1. Let _unitOptions_ be ? GetDurationUnitOptions(_unit_, _options_, _style_, _valueList_, _digitalBase_, _prevStyle_, _digitalFormat_.[[TwoDigitHours]]).
+          1. Set the value of the _styleSlot_ slot of _durationFormat_ to _unitOptions_.[[Style]].
+          1. Set the value of the _displaySlot_ slot of _durationFormat_ to _unitOptions_.[[Display]].
+          1. If _unit_ is one of *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, or *"microseconds"*, then
+            1. Set _prevStyle_ to _unitOptions_.[[Style]].
+        1. Set _durationFormat_.[[FractionalDigits]] to ? GetNumberOption(_options_, *"fractionalDigits"*, 0, 9, *undefined*).
+        1. Return _durationFormat_.
+      </emu-alg>
+      <emu-table id="table-durationformat">
+        <emu-caption>Internal slots and property names of DurationFormat instances relevant to Intl.DurationFormat constructor</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Style Slot</th>
+              <th>Display Slot</th>
+              <th>Unit</th>
+              <th>Values</th>
+              <th>Digital Default</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[YearsStyle]]</td>
+            <td>[[YearsDisplay]]</td>
+            <td>*"years"*</td>
+            <td>« *"long"*, *"short"*, *"narrow"* »</td>
+            <td>*"short"*</td>
+          </tr>
+          <tr>
+            <td>[[MonthsStyle]]</td>
+            <td>[[MonthsDisplay]]</td>
+            <td>*"months"*</td>
+            <td>« *"long"*, *"short"*, *"narrow"* »</td>
+            <td>*"short"*</td>
+          </tr>
+          <tr>
+            <td>[[WeeksStyle]]</td>
+            <td>[[WeeksDisplay]]</td>
+            <td>*"weeks"*</td>
+            <td>« *"long"*, *"short"*, *"narrow"* »</td>
+            <td>*"short"*</td>
+          </tr>
+          <tr>
+            <td>[[DaysStyle]]</td>
+            <td>[[DaysDisplay]]</td>
+            <td>*"days"*</td>
+            <td>« *"long"*, *"short"*, *"narrow"* »</td>
+            <td>*"short"*</td>
+          </tr>
+          <tr>
+            <td>[[HoursStyle]]</td>
+            <td>[[HoursDisplay]]</td>
+            <td>*"hours"*</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"*, *"2-digit"* »</td>
+            <td>*"numeric"*</td>
+          </tr>
+          <tr>
+            <td>[[MinutesStyle]]</td>
+            <td>[[MinutesDisplay]]</td>
+            <td>*"minutes"*</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"*, *"2-digit"* »</td>
+            <td>*"numeric"*</td>
+          </tr>
+          <tr>
+            <td>[[SecondsStyle]]</td>
+            <td>[[SecondsDisplay]]</td>
+            <td>*"seconds"*</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"*, *"2-digit"* »</td>
+            <td>*"numeric"*</td>
+          </tr>
+          <tr>
+            <td>[[MillisecondsStyle]]</td>
+            <td>[[MillisecondsDisplay]]</td>
+            <td>*"milliseconds"*</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"* »</td>
+            <td>*"numeric"*</td>
+          </tr>
+          <tr>
+            <td>[[MicrosecondsStyle]]</td>
+            <td>[[MicrosecondsDisplay]]</td>
+            <td>*"microseconds"*</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"* »</td>
+            <td>*"numeric"*</td>
+          </tr>
+          <tr>
+            <td>[[NanosecondsStyle]]</td>
+            <td>[[NanosecondsDisplay]]</td>
+            <td>*"nanoseconds"*</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"* »</td>
+            <td>*"numeric"*</td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-properties-of-intl-durationformat-constructor">
+    <h1>Properties of the Intl.DurationFormat Constructor</h1>
+
+    <p>The Intl.DurationFormat constructor has the following properties:</p>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype">
+      <h1>Intl.DurationFormat.prototype</h1>
+
+      <p>The value of `Intl.DurationFormat.prototype` is %Intl.DurationFormat.prototype%.</p>
+
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.supportedLocalesOf">
+      <h1>Intl.DurationFormat.supportedLocalesOf ( _locales_ [ , _options_ ] )</h1>
+
+      <p>When the `supportedLocalesOf` method is called with arguments _locales_ and _options_, the following steps are taken:</p>
+
+      <emu-alg>
+        1. Let _availableLocales_ be %Intl.DurationFormat%.[[AvailableLocales]].
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat-internal-slots">
+      <h1>Internal slots</h1>
+
+      <p>The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+
+      <p>The value of the [[RelevantExtensionKeys]] internal slot is « *"nu"* ».</p>
+
+      <p>The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints for all locale values _locale_:</p>
+
+      <ul>
+        <li>[[LocaleData]].[[&lt;_locale_>]].[[nu]] must be a List as specified in <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref> and must not include the values *"native"*, *"traditio"*, or *"finance"**.</li>
+        <li>[[LocaleData]].[[&lt;_locale_>]].[[DigitalFormat]] must be a Record with keys corresponding to each numbering system available for the given locale, with Record values containing the following fields:
+          <ul>
+            <li>[[HourMinuteSeparator]] is a String value that is the appropriate separator between hours and minutes for that combination of locale, numbering system, and unit when using *"numeric"* or *"2-digit"* styles</li>
+            <li>[[MinuteSecondSeparator]] is a String value that is the appropriate separator between minutes and seconds for that combination of locale, numbering system, and unit when using *"numeric"* or *"2-digit"* styles.</li>
+            <li>[[TwoDigitHours]] is a Boolean value indicating whether hours are always displayed using two digits when the *"numeric"* style is used.</li>
+          </ul>
+        </li>
+      </ul>
+
+      <emu-note>It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).</emu-note>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-properties-of-intl-durationformat-prototype-object">
+    <h1>Properties of the Intl.DurationFormat Prototype Object</h1>
+
+    <p>The Intl.DurationFormat prototype object is itself an ordinary object. <dfn>%Intl.DurationFormat.prototype%</dfn> is not an Intl.DurationFormat instance and does not have an [[InitializedDurationFormat]] internal slot or any of the other internal slots of Intl.DurationFormat instance objects.</p>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.constructor">
+      <h1>Intl.DurationFormat.prototype.constructor</h1>
+
+      <p>The initial value of `Intl.DurationFormat.prototype.constructor` is the intrinsic object %Intl.DurationFormat%.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype-@@tostringtag">
+      <h1>Intl.DurationFormat.prototype [ @@toStringTag ]</h1>
+
+      <p>The initial value of the @@toStringTag property is the string value *"Intl.DurationFormat"*.</p>
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.format">
+      <h1>Intl.DurationFormat.prototype.format ( _duration_ )</h1>
+
+      <p>When the `format` method is called with an argument _duration_, the following steps are taken:</p>
+
+      <emu-alg>
+        1. Let _df_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
+        1. Let _record_ be ? ToDurationRecord(_duration_).
+        1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
+        1. Let _result_ be the empty String.
+        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+          1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.formatToParts">
+      <h1>Intl.DurationFormat.prototype.formatToParts ( _duration_ )</h1>
+
+      <p>When the `formatToParts` method is called with an argument _duration_, the following steps are taken:</p>
+
+      <emu-alg>
+        1. Let _df_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
+        1. Let _record_ be ? ToDurationRecord(_duration_).
+        1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
+        1. Let _result_ be ! ArrayCreate(0).
+        1. Let _n_ be 0.
+        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
+          1. If _part_.[[Unit]] is not ~empty~, perform ! CreateDataPropertyOrThrow(_obj_, *"unit"*, _part_.[[Unit]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(_n_), _obj_).
+          1. Set _n_ to _n_ + 1.
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.resolvedOptions">
+      <h1>Intl.DurationFormat.prototype.resolvedOptions ( )</h1>
+
+      <p>This function provides access to the locale and options computed during initialization of the object.</p>
+
+      <emu-alg>
+        1. Let _df_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
+        1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. For each row of <emu-xref href="#table-durationformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _p_ be the Property value of the current row.
+          1. Let _v_ be the value of _df_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If _p_ is *"fractionalDigits"*, then
+            1. If _v_ is not *undefined*, set _v_ to 𝔽(_v_).
+          1. Else,
+            1. Assert: _v_ is not *undefined*.
+          1. If _v_ is *"fractional"*, then
+            1. Assert: The Internal Slot value of the current row is [[MillisecondsStyle]], [[MicrosecondsStyle]], or [[NanosecondsStyle]] .
+            1. Set _v_ to *"numeric"*.
+          1. If _v_ is not *undefined*, then
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+        1. Return _options_.
+      </emu-alg>
+
+      <emu-table id="table-durationformat-resolvedoptions-properties">
+        <emu-caption>Resolved Options of DurationFormat Instances</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Internal Slot</th>
+              <th>Property</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[Locale]]</td>
+            <td>*"locale"*</td>
+          </tr>
+          <tr>
+            <td>[[NumberingSystem]]</td>
+            <td>*"numberingSystem"*</td>
+          </tr>
+          <tr>
+            <td>[[Style]]</td>
+            <td>*"style"*</td>
+          </tr>
+          <tr>
+            <td>[[YearsStyle]]</td>
+            <td>*"years"*</td>
+          </tr>
+          <tr>
+            <td>[[YearsDisplay]]</td>
+            <td>*"yearsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[MonthsStyle]]</td>
+            <td>*"months"*</td>
+          </tr>
+          <tr>
+            <td>[[MonthsDisplay]]</td>
+            <td>*"monthsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[WeeksStyle]]</td>
+            <td>*"weeks"*</td>
+          </tr>
+          <tr>
+            <td>[[WeeksDisplay]]</td>
+            <td>*"weeksDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[DaysStyle]]</td>
+            <td>*"days"*</td>
+          </tr>
+          <tr>
+            <td>[[DaysDisplay]]</td>
+            <td>*"daysDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[HoursStyle]]</td>
+            <td>*"hours"*</td>
+          </tr>
+          <tr>
+            <td>[[HoursDisplay]]</td>
+            <td>*"hoursDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[MinutesStyle]]</td>
+            <td>*"minutes"*</td>
+          </tr>
+          <tr>
+            <td>[[MinutesDisplay]]</td>
+            <td>*"minutesDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[SecondsStyle]]</td>
+            <td>*"seconds"*</td>
+          </tr>
+          <tr>
+            <td>[[SecondsDisplay]]</td>
+            <td>*"secondsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[MillisecondsStyle]]</td>
+            <td>*"milliseconds"*</td>
+          </tr>
+          <tr>
+            <td>[[MillisecondsDisplay]]</td>
+            <td>*"millisecondsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[MicrosecondsStyle]]</td>
+            <td>*"microseconds"*</td>
+          </tr>
+          <tr>
+            <td>[[MicrosecondsDisplay]]</td>
+            <td>*"microsecondsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[NanosecondsStyle]]</td>
+            <td>*"nanoseconds"*</td>
+          </tr>
+          <tr>
+            <td>[[NanosecondsDisplay]]</td>
+            <td>*"nanosecondsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[FractionalDigits]]</td>
+            <td>*"fractionalDigits"*</td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-properties-of-intl-durationformat-instances">
+    <h1>Properties of Intl.DurationFormat Instances</h1>
+
+    <p>Intl.DurationFormat instances inherit properties from %Intl.DurationFormat.prototype%.</p>
+    <p>Intl.DurationFormat instances have an [[InitializedDurationFormat]] internal slot.</p>
+    <p>Intl.DurationFormat instances also have several internal slots that are computed by the constructor:</p>
+
+    <ul>
+      <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
+      <li>[[NumberingSystem]] is a String value with the *"type"* given in Unicode Technical Standard 35 for the numbering system used for formatting.</li>
+      <li>[[Style]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"digital"* identifying the duration formatting style used.</li>
+      <li>[[YearsStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the years field.</li>
+      <li>[[YearsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the years field.</li>
+      <li>[[MonthsStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the months field.</li>
+      <li>[[MonthsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the months field.</li>
+      <li>[[WeeksStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the weeks field.</li>
+      <li>[[WeeksDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the weeks field.</li>
+      <li>[[DaysStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the days field.</li>
+      <li>[[DaysDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the days field.</li>
+      <li>[[HoursStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the hours field.</li>
+      <li>[[HoursDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the hours field.</li>
+      <li>[[MinutesStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the minutes field.</li>
+      <li>[[MinutesDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the minutes field.</li>
+      <li>[[SecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the seconds field.</li>
+      <li>[[SecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the seconds field.</li>
+      <li>[[MillisecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the milliseconds field.</li>
+      <li>[[MillisecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the milliseconds field.</li>
+      <li>[[MicrosecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the microseconds field.</li>
+      <li>[[MicrosecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the microseconds field.</li>
+      <li>[[NanosecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the nanoseconds field.</li>
+      <li>[[NanosecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the nanoseconds field.</li>
+      <li>[[HourMinuteSeparator]] is a String value identifying the separator to be used between hours and minutes when both fields are displayed and both fields are formatted using numeric styles.</li>
+      <li>[[MinuteSecondSeparator]] is a String value identifying the separator to be used between minutes and seconds when both fields are displayed and both fields are formatted using numeric styles.</li>
+      <li>[[FractionalDigits]] is a non-negative integer, identifying the number of fractional digits to be used with numeric styles, or is *undefined*.</li>
+    </ul>
+  </emu-clause>
+
   <emu-clause id="sec-intl-durationformat-abstracts">
     <h1>Abstract Operations for DurationFormat Objects</h1>
 
@@ -668,414 +1077,5 @@
         </table>
       </emu-table>
     </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-intl-durationformat-constructor">
-    <h1>The Intl.DurationFormat Constructor</h1>
-
-    <p>The DurationFormat constructor is the <dfn>%Intl.DurationFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
-
-    <emu-clause id="sec-Intl.DurationFormat">
-      <h1>Intl.DurationFormat ( [ _locales_ [ , _options_ ] ] )</h1>
-
-      <p>When the `Intl.DurationFormat` function is called with optional arguments _locales_ and _options_, the following steps are taken:</p>
-
-      <emu-alg>
-        1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _durationFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.DurationFormatPrototype%"*, « [[InitializedDurationFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[YearsStyle]], [[YearsDisplay]], [[MonthsStyle]], [[MonthsDisplay]], [[WeeksStyle]], [[WeeksDisplay]], [[DaysStyle]], [[DaysDisplay]], [[HoursStyle]], [[HoursDisplay]], [[MinutesStyle]], [[MinutesDisplay]], [[SecondsStyle]], [[SecondsDisplay]], [[MillisecondsStyle]], [[MillisecondsDisplay]], [[MicrosecondsStyle]], [[MicrosecondsDisplay]], [[NanosecondsStyle]], [[NanosecondsDisplay]], [[HourMinuteSeparator]], [[MinuteSecondSeparator]], [[FractionalDigits]] »).
-        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Let _options_ be ? GetOptionsObject(_options_).
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
-        1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, ~string~, ~empty~, *undefined*).
-        1. If _numberingSystem_ is not *undefined*, then
-          1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
-        1. Let _opt_ be the Record { [[localeMatcher]]: _matcher_, [[nu]]: _numberingSystem_ }.
-        1. Let _r_ be ResolveLocale(%Intl.DurationFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %Intl.DurationFormat%.[[RelevantExtensionKeys]], %Intl.DurationFormat%.[[LocaleData]]).
-        1. Set _durationFormat_.[[Locale]] to _r_.[[Locale]].
-        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
-        1. Let _digitalFormat_ be _resolvedLocaleData_.[[DigitalFormat]].
-        1. Set _durationFormat_.[[HourMinuteSeparator]] to _digitalFormat_.[[HourMinuteSeparator]].
-        1. Set _durationFormat_.[[MinuteSecondSeparator]] to _digitalFormat_.[[MinuteSecondSeparator]].
-        1. Set _durationFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"long"*, *"short"*, *"narrow"*, *"digital"* », *"short"*).
-        1. Set _durationFormat_.[[Style]] to _style_.
-        1. Let _prevStyle_ be the empty String.
-        1. For each row of <emu-xref href="#table-durationformat"></emu-xref>, except the header row, in table order, do
-          1. Let _styleSlot_ be the Style Slot value of the current row.
-          1. Let _displaySlot_ be the Display Slot value of the current row.
-          1. Let _unit_ be the Unit value of the current row.
-          1. Let _valueList_ be the Values value of the current row.
-          1. Let _digitalBase_ be the Digital Default value of the current row.
-          1. Let _unitOptions_ be ? GetDurationUnitOptions(_unit_, _options_, _style_, _valueList_, _digitalBase_, _prevStyle_, _digitalFormat_.[[TwoDigitHours]]).
-          1. Set the value of the _styleSlot_ slot of _durationFormat_ to _unitOptions_.[[Style]].
-          1. Set the value of the _displaySlot_ slot of _durationFormat_ to _unitOptions_.[[Display]].
-          1. If _unit_ is one of *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, or *"microseconds"*, then
-            1. Set _prevStyle_ to _unitOptions_.[[Style]].
-        1. Set _durationFormat_.[[FractionalDigits]] to ? GetNumberOption(_options_, *"fractionalDigits"*, 0, 9, *undefined*).
-        1. Return _durationFormat_.
-      </emu-alg>
-      <emu-table id="table-durationformat">
-        <emu-caption>Internal slots and property names of DurationFormat instances relevant to Intl.DurationFormat constructor</emu-caption>
-        <table class="real-table">
-          <thead>
-            <tr>
-              <th>Style Slot</th>
-              <th>Display Slot</th>
-              <th>Unit</th>
-              <th>Values</th>
-              <th>Digital Default</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>[[YearsStyle]]</td>
-            <td>[[YearsDisplay]]</td>
-            <td>*"years"*</td>
-            <td>« *"long"*, *"short"*, *"narrow"* »</td>
-            <td>*"short"*</td>
-          </tr>
-          <tr>
-            <td>[[MonthsStyle]]</td>
-            <td>[[MonthsDisplay]]</td>
-            <td>*"months"*</td>
-            <td>« *"long"*, *"short"*, *"narrow"* »</td>
-            <td>*"short"*</td>
-          </tr>
-          <tr>
-            <td>[[WeeksStyle]]</td>
-            <td>[[WeeksDisplay]]</td>
-            <td>*"weeks"*</td>
-            <td>« *"long"*, *"short"*, *"narrow"* »</td>
-            <td>*"short"*</td>
-          </tr>
-          <tr>
-            <td>[[DaysStyle]]</td>
-            <td>[[DaysDisplay]]</td>
-            <td>*"days"*</td>
-            <td>« *"long"*, *"short"*, *"narrow"* »</td>
-            <td>*"short"*</td>
-          </tr>
-          <tr>
-            <td>[[HoursStyle]]</td>
-            <td>[[HoursDisplay]]</td>
-            <td>*"hours"*</td>
-            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"*, *"2-digit"* »</td>
-            <td>*"numeric"*</td>
-          </tr>
-          <tr>
-            <td>[[MinutesStyle]]</td>
-            <td>[[MinutesDisplay]]</td>
-            <td>*"minutes"*</td>
-            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"*, *"2-digit"* »</td>
-            <td>*"numeric"*</td>
-          </tr>
-          <tr>
-            <td>[[SecondsStyle]]</td>
-            <td>[[SecondsDisplay]]</td>
-            <td>*"seconds"*</td>
-            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"*, *"2-digit"* »</td>
-            <td>*"numeric"*</td>
-          </tr>
-          <tr>
-            <td>[[MillisecondsStyle]]</td>
-            <td>[[MillisecondsDisplay]]</td>
-            <td>*"milliseconds"*</td>
-            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"* »</td>
-            <td>*"numeric"*</td>
-          </tr>
-          <tr>
-            <td>[[MicrosecondsStyle]]</td>
-            <td>[[MicrosecondsDisplay]]</td>
-            <td>*"microseconds"*</td>
-            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"* »</td>
-            <td>*"numeric"*</td>
-          </tr>
-          <tr>
-            <td>[[NanosecondsStyle]]</td>
-            <td>[[NanosecondsDisplay]]</td>
-            <td>*"nanoseconds"*</td>
-            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"* »</td>
-            <td>*"numeric"*</td>
-          </tr>
-        </table>
-      </emu-table>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-properties-of-intl-durationformat-constructor">
-    <h1>Properties of the Intl.DurationFormat Constructor</h1>
-
-    <p>The Intl.DurationFormat constructor has the following properties:</p>
-
-    <emu-clause id="sec-Intl.DurationFormat.prototype">
-      <h1>Intl.DurationFormat.prototype</h1>
-
-      <p>The value of `Intl.DurationFormat.prototype` is %Intl.DurationFormat.prototype%.</p>
-
-      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DurationFormat.supportedLocalesOf">
-      <h1>Intl.DurationFormat.supportedLocalesOf ( _locales_ [ , _options_ ] )</h1>
-
-      <p>When the `supportedLocalesOf` method is called with arguments _locales_ and _options_, the following steps are taken:</p>
-
-      <emu-alg>
-        1. Let _availableLocales_ be %Intl.DurationFormat%.[[AvailableLocales]].
-        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DurationFormat-internal-slots">
-      <h1>Internal slots</h1>
-
-      <p>The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
-
-      <p>The value of the [[RelevantExtensionKeys]] internal slot is « *"nu"* ».</p>
-
-      <p>The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints for all locale values _locale_:</p>
-
-      <ul>
-        <li>[[LocaleData]].[[&lt;_locale_>]].[[nu]] must be a List as specified in <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref> and must not include the values *"native"*, *"traditio"*, or *"finance"**.</li>
-        <li>[[LocaleData]].[[&lt;_locale_>]].[[DigitalFormat]] must be a Record with keys corresponding to each numbering system available for the given locale, with Record values containing the following fields:
-          <ul>
-            <li>[[HourMinuteSeparator]] is a String value that is the appropriate separator between hours and minutes for that combination of locale, numbering system, and unit when using *"numeric"* or *"2-digit"* styles</li>
-            <li>[[MinuteSecondSeparator]] is a String value that is the appropriate separator between minutes and seconds for that combination of locale, numbering system, and unit when using *"numeric"* or *"2-digit"* styles.</li>
-            <li>[[TwoDigitHours]] is a Boolean value indicating whether hours are always displayed using two digits when the *"numeric"* style is used.</li>
-          </ul>
-        </li>
-      </ul>
-
-      <emu-note>It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).</emu-note>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-properties-of-intl-durationformat-prototype-object">
-    <h1>Properties of the Intl.DurationFormat Prototype Object</h1>
-
-    <p>The Intl.DurationFormat prototype object is itself an ordinary object. <dfn>%Intl.DurationFormat.prototype%</dfn> is not an Intl.DurationFormat instance and does not have an [[InitializedDurationFormat]] internal slot or any of the other internal slots of Intl.DurationFormat instance objects.</p>
-
-    <emu-clause id="sec-Intl.DurationFormat.prototype.constructor">
-      <h1>Intl.DurationFormat.prototype.constructor</h1>
-
-      <p>The initial value of `Intl.DurationFormat.prototype.constructor` is the intrinsic object %Intl.DurationFormat%.</p>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DurationFormat.prototype-@@tostringtag">
-      <h1>Intl.DurationFormat.prototype [ @@toStringTag ]</h1>
-
-      <p>The initial value of the @@toStringTag property is the string value *"Intl.DurationFormat"*.</p>
-      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DurationFormat.prototype.format">
-      <h1>Intl.DurationFormat.prototype.format ( _duration_ )</h1>
-
-      <p>When the `format` method is called with an argument _duration_, the following steps are taken:</p>
-
-      <emu-alg>
-        1. Let _df_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
-        1. Let _record_ be ? ToDurationRecord(_duration_).
-        1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
-        1. Let _result_ be the empty String.
-        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
-          1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DurationFormat.prototype.formatToParts">
-      <h1>Intl.DurationFormat.prototype.formatToParts ( _duration_ )</h1>
-
-      <p>When the `formatToParts` method is called with an argument _duration_, the following steps are taken:</p>
-
-      <emu-alg>
-        1. Let _df_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
-        1. Let _record_ be ? ToDurationRecord(_duration_).
-        1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
-        1. Let _result_ be ! ArrayCreate(0).
-        1. Let _n_ be 0.
-        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
-          1. If _part_.[[Unit]] is not ~empty~, perform ! CreateDataPropertyOrThrow(_obj_, *"unit"*, _part_.[[Unit]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(_n_), _obj_).
-          1. Set _n_ to _n_ + 1.
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DurationFormat.prototype.resolvedOptions">
-      <h1>Intl.DurationFormat.prototype.resolvedOptions ( )</h1>
-
-      <p>This function provides access to the locale and options computed during initialization of the object.</p>
-
-      <emu-alg>
-        1. Let _df_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
-        1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. For each row of <emu-xref href="#table-durationformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _df_'s internal slot whose name is the Internal Slot value of the current row.
-          1. If _p_ is *"fractionalDigits"*, then
-            1. If _v_ is not *undefined*, set _v_ to 𝔽(_v_).
-          1. Else,
-            1. Assert: _v_ is not *undefined*.
-          1. If _v_ is *"fractional"*, then
-            1. Assert: The Internal Slot value of the current row is [[MillisecondsStyle]], [[MicrosecondsStyle]], or [[NanosecondsStyle]] .
-            1. Set _v_ to *"numeric"*.
-          1. If _v_ is not *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
-        1. Return _options_.
-      </emu-alg>
-
-      <emu-table id="table-durationformat-resolvedoptions-properties">
-        <emu-caption>Resolved Options of DurationFormat Instances</emu-caption>
-        <table class="real-table">
-          <thead>
-            <tr>
-              <th>Internal Slot</th>
-              <th>Property</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>[[Locale]]</td>
-            <td>*"locale"*</td>
-          </tr>
-          <tr>
-            <td>[[NumberingSystem]]</td>
-            <td>*"numberingSystem"*</td>
-          </tr>
-          <tr>
-            <td>[[Style]]</td>
-            <td>*"style"*</td>
-          </tr>
-          <tr>
-            <td>[[YearsStyle]]</td>
-            <td>*"years"*</td>
-          </tr>
-          <tr>
-            <td>[[YearsDisplay]]</td>
-            <td>*"yearsDisplay"*</td>
-          </tr>
-          <tr>
-            <td>[[MonthsStyle]]</td>
-            <td>*"months"*</td>
-          </tr>
-          <tr>
-            <td>[[MonthsDisplay]]</td>
-            <td>*"monthsDisplay"*</td>
-          </tr>
-          <tr>
-            <td>[[WeeksStyle]]</td>
-            <td>*"weeks"*</td>
-          </tr>
-          <tr>
-            <td>[[WeeksDisplay]]</td>
-            <td>*"weeksDisplay"*</td>
-          </tr>
-          <tr>
-            <td>[[DaysStyle]]</td>
-            <td>*"days"*</td>
-          </tr>
-          <tr>
-            <td>[[DaysDisplay]]</td>
-            <td>*"daysDisplay"*</td>
-          </tr>
-          <tr>
-            <td>[[HoursStyle]]</td>
-            <td>*"hours"*</td>
-          </tr>
-          <tr>
-            <td>[[HoursDisplay]]</td>
-            <td>*"hoursDisplay"*</td>
-          </tr>
-          <tr>
-            <td>[[MinutesStyle]]</td>
-            <td>*"minutes"*</td>
-          </tr>
-          <tr>
-            <td>[[MinutesDisplay]]</td>
-            <td>*"minutesDisplay"*</td>
-          </tr>
-          <tr>
-            <td>[[SecondsStyle]]</td>
-            <td>*"seconds"*</td>
-          </tr>
-          <tr>
-            <td>[[SecondsDisplay]]</td>
-            <td>*"secondsDisplay"*</td>
-          </tr>
-          <tr>
-            <td>[[MillisecondsStyle]]</td>
-            <td>*"milliseconds"*</td>
-          </tr>
-          <tr>
-            <td>[[MillisecondsDisplay]]</td>
-            <td>*"millisecondsDisplay"*</td>
-          </tr>
-          <tr>
-            <td>[[MicrosecondsStyle]]</td>
-            <td>*"microseconds"*</td>
-          </tr>
-          <tr>
-            <td>[[MicrosecondsDisplay]]</td>
-            <td>*"microsecondsDisplay"*</td>
-          </tr>
-          <tr>
-            <td>[[NanosecondsStyle]]</td>
-            <td>*"nanoseconds"*</td>
-          </tr>
-          <tr>
-            <td>[[NanosecondsDisplay]]</td>
-            <td>*"nanosecondsDisplay"*</td>
-          </tr>
-          <tr>
-            <td>[[FractionalDigits]]</td>
-            <td>*"fractionalDigits"*</td>
-          </tr>
-        </table>
-      </emu-table>
-    </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-properties-of-intl-durationformat-instances">
-    <h1>Properties of Intl.DurationFormat Instances</h1>
-
-    <p>Intl.DurationFormat instances inherit properties from %Intl.DurationFormat.prototype%.</p>
-    <p>Intl.DurationFormat instances have an [[InitializedDurationFormat]] internal slot.</p>
-    <p>Intl.DurationFormat instances also have several internal slots that are computed by the constructor:</p>
-
-    <ul>
-      <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[NumberingSystem]] is a String value with the *"type"* given in Unicode Technical Standard 35 for the numbering system used for formatting.</li>
-      <li>[[Style]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"digital"* identifying the duration formatting style used.</li>
-      <li>[[YearsStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the years field.</li>
-      <li>[[YearsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the years field.</li>
-      <li>[[MonthsStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the months field.</li>
-      <li>[[MonthsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the months field.</li>
-      <li>[[WeeksStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the weeks field.</li>
-      <li>[[WeeksDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the weeks field.</li>
-      <li>[[DaysStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the days field.</li>
-      <li>[[DaysDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the days field.</li>
-      <li>[[HoursStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the hours field.</li>
-      <li>[[HoursDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the hours field.</li>
-      <li>[[MinutesStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the minutes field.</li>
-      <li>[[MinutesDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the minutes field.</li>
-      <li>[[SecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the seconds field.</li>
-      <li>[[SecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the seconds field.</li>
-      <li>[[MillisecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the milliseconds field.</li>
-      <li>[[MillisecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the milliseconds field.</li>
-      <li>[[MicrosecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the microseconds field.</li>
-      <li>[[MicrosecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the microseconds field.</li>
-      <li>[[NanosecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the nanoseconds field.</li>
-      <li>[[NanosecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the nanoseconds field.</li>
-      <li>[[HourMinuteSeparator]] is a String value identifying the separator to be used between hours and minutes when both fields are displayed and both fields are formatted using numeric styles.</li>
-      <li>[[MinuteSecondSeparator]] is a String value identifying the separator to be used between minutes and seconds when both fields are displayed and both fields are formatted using numeric styles.</li>
-      <li>[[FractionalDigits]] is a non-negative integer, identifying the number of fractional digits to be used with numeric styles, or is *undefined*.</li>
-    </ul>
   </emu-clause>
 </emu-clause>

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -365,10 +365,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.DurationFormat.prototype-@@tostringtag">
-      <h1>Intl.DurationFormat.prototype [ @@toStringTag ]</h1>
+    <emu-clause id="sec-Intl.DurationFormat.prototype-%symbol.tostringtag%">
+      <h1>Intl.DurationFormat.prototype [ %Symbol.toStringTag% ]</h1>
 
-      <p>The initial value of the @@toStringTag property is the string value *"Intl.DurationFormat"*.</p>
+      <p>The initial value of the %Symbol.toStringTag% property is the String value *"Intl.DurationFormat"*.</p>
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
   </emu-clause>

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -491,7 +491,7 @@
       <h1>
         ToIntegerIfIntegral (
           _argument_: an ECMAScript language value,
-        ): either a normal completion containing an integer, or an abrupt completion
+        ): either a normal completion containing an integer, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -508,7 +508,7 @@
       <h1>
         ToDurationRecord (
           _input_: an ECMAScript language value,
-        ): either a normal completion containing a Duration Record, or an abrupt completion
+        ): either a normal completion containing a Duration Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -614,7 +614,7 @@
           _digitalBase_: a String,
           _prevStyle_: a String,
           _twoDigitHours_: a Boolean,
-        ): either a normal completion containing a Record with [[Style]] and [[Display]] fields, or an abrupt completion
+        ): either a normal completion containing a Record with [[Style]] and [[Display]] fields, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -164,15 +164,16 @@
 
       <p>The value of the [[RelevantExtensionKeys]] internal slot is « *"nu"* ».</p>
 
-      <p>The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints for all locale values _locale_:</p>
+      <p>The value of the [[LocaleData]] internal slot is implementation-defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints for all locale values _locale_:</p>
 
       <ul>
-        <li>[[LocaleData]].[[&lt;_locale_>]].[[nu]] must be a List as specified in <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref> and must not include the values *"native"*, *"traditio"*, or *"finance"**.</li>
-        <li>[[LocaleData]].[[&lt;_locale_>]].[[DigitalFormat]] must be a Record with keys corresponding to each numbering system available for the given locale, with Record values containing the following fields:
+        <li>[[LocaleData]].[[&lt;_locale_>]] must be a Record with fields [[nu]] and [[DigitalFormat]].</li>
+        <li>[[LocaleData]].[[&lt;_locale_>]].[[nu]] must be a List as specified in <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref> and must not include the values *"native"*, *"traditio"*, or *"finance"*.</li>
+        <li>[[LocaleData]].[[&lt;_locale_>]].[[DigitalFormat]] must be a Record with keys corresponding to each numbering system available for _locale_. Each value associated with one of those keys must be a Record containing the following fields:
           <ul>
-            <li>[[HourMinuteSeparator]] is a String value that is the appropriate separator between hours and minutes for that combination of locale, numbering system, and unit when using *"numeric"* or *"2-digit"* styles</li>
-            <li>[[MinuteSecondSeparator]] is a String value that is the appropriate separator between minutes and seconds for that combination of locale, numbering system, and unit when using *"numeric"* or *"2-digit"* styles.</li>
-            <li>[[TwoDigitHours]] is a Boolean value indicating whether hours are always displayed using two digits when the *"numeric"* style is used.</li>
+            <li>[[HourMinuteSeparator]] must be a String value that is the appropriate separator between hours and minutes for that combination of locale and numbering system when using style *"numeric"* or *"2-digit"*.</li>
+            <li>[[MinuteSecondSeparator]] must be a String value that is the appropriate separator between minutes and seconds for that combination of locale and numbering system when using style *"numeric"* or *"2-digit"*.</li>
+            <li>[[TwoDigitHours]] must be a Boolean value indicating whether hours are always displayed using two digits when using style *"numeric"*.</li>
           </ul>
         </li>
       </ul>

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -602,7 +602,6 @@
         1. If abs(_normalizedSeconds_) ≥ 2<sup>53</sup>, return *false*.
         1. Return *true*.
       </emu-alg>
-      <emu-note>The abstract operations ToIntegerIfIntegral, DurationSign, and IsValidDuration take the same parameters as the abstract operations of the same name in the Temporal proposal's specification, aside from the use of a Duration Record instead of a Temporal.Duration instance. They will be removed in favor of the equivalent Temporal abstract operations if the Temporal proposal becomes part of ECMAScript before this proposal does.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-getdurationunitoptions" type="abstract operation">

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -206,13 +206,12 @@
           1. Let _p_ be the Property value of the current row.
           1. Let _v_ be the value of _df_'s internal slot whose name is the Internal Slot value of the current row.
           1. If _p_ is *"fractionalDigits"*, then
-            1. If _v_ is not *undefined*, set _v_ to 𝔽(_v_).
+            1. If _v_ is not *undefined*, perform ! CreateDataPropertyOrThrow(_options_, _p_, 𝔽(_v_)).
           1. Else,
             1. Assert: _v_ is not *undefined*.
-          1. If _v_ is *"fractional"*, then
-            1. Assert: The Internal Slot value of the current row is [[MillisecondsStyle]], [[MicrosecondsStyle]], or [[NanosecondsStyle]] .
-            1. Set _v_ to *"numeric"*.
-          1. If _v_ is not *undefined*, then
+            1. If _v_ is *"fractional"*, then
+              1. Assert: The Internal Slot value of the current row is [[MillisecondsStyle]], [[MicrosecondsStyle]], or [[NanosecondsStyle]] .
+              1. Set _v_ to *"numeric"*.
             1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
         1. Return _options_.
       </emu-alg>

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -192,53 +192,6 @@
       <p>The initial value of `Intl.DurationFormat.prototype.constructor` is the intrinsic object %Intl.DurationFormat%.</p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.DurationFormat.prototype-@@tostringtag">
-      <h1>Intl.DurationFormat.prototype [ @@toStringTag ]</h1>
-
-      <p>The initial value of the @@toStringTag property is the string value *"Intl.DurationFormat"*.</p>
-      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DurationFormat.prototype.format">
-      <h1>Intl.DurationFormat.prototype.format ( _duration_ )</h1>
-
-      <p>When the `format` method is called with an argument _duration_, the following steps are taken:</p>
-
-      <emu-alg>
-        1. Let _df_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
-        1. Let _record_ be ? ToDurationRecord(_duration_).
-        1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
-        1. Let _result_ be the empty String.
-        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
-          1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-Intl.DurationFormat.prototype.formatToParts">
-      <h1>Intl.DurationFormat.prototype.formatToParts ( _duration_ )</h1>
-
-      <p>When the `formatToParts` method is called with an argument _duration_, the following steps are taken:</p>
-
-      <emu-alg>
-        1. Let _df_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
-        1. Let _record_ be ? ToDurationRecord(_duration_).
-        1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
-        1. Let _result_ be ! ArrayCreate(0).
-        1. Let _n_ be 0.
-        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
-          1. If _part_.[[Unit]] is not ~empty~, perform ! CreateDataPropertyOrThrow(_obj_, *"unit"*, _part_.[[Unit]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(_n_), _obj_).
-          1. Set _n_ to _n_ + 1.
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-Intl.DurationFormat.prototype.resolvedOptions">
       <h1>Intl.DurationFormat.prototype.resolvedOptions ( )</h1>
 
@@ -370,6 +323,53 @@
           </tr>
         </table>
       </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.format">
+      <h1>Intl.DurationFormat.prototype.format ( _duration_ )</h1>
+
+      <p>When the `format` method is called with an argument _duration_, the following steps are taken:</p>
+
+      <emu-alg>
+        1. Let _df_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
+        1. Let _record_ be ? ToDurationRecord(_duration_).
+        1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
+        1. Let _result_ be the empty String.
+        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+          1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.formatToParts">
+      <h1>Intl.DurationFormat.prototype.formatToParts ( _duration_ )</h1>
+
+      <p>When the `formatToParts` method is called with an argument _duration_, the following steps are taken:</p>
+
+      <emu-alg>
+        1. Let _df_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
+        1. Let _record_ be ? ToDurationRecord(_duration_).
+        1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
+        1. Let _result_ be ! ArrayCreate(0).
+        1. Let _n_ be 0.
+        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
+          1. If _part_.[[Unit]] is not ~empty~, perform ! CreateDataPropertyOrThrow(_obj_, *"unit"*, _part_.[[Unit]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(_n_), _obj_).
+          1. Set _n_ to _n_ + 1.
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype-@@tostringtag">
+      <h1>Intl.DurationFormat.prototype [ @@toStringTag ]</h1>
+
+      <p>The initial value of the @@toStringTag property is the string value *"Intl.DurationFormat"*.</p>
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
   </emu-clause>
 

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -98,7 +98,7 @@
     <emu-clause id="sec-todurationrecord" type="abstract operation">
       <h1>
         ToDurationRecord (
-          _input_: an ECMAScript language value
+          _input_: an ECMAScript language value,
         ): either a normal completion containing a Duration Record, or an abrupt completion
       </h1>
       <dl class="header">
@@ -234,9 +234,9 @@
             1. Set _style_ to *"fractional"*.
             1. Set _displayDefault_ to *"auto"*.
         1. Let _displayField_ be the string-concatenation of _unit_ and *"Display"*.
-        1. Let _display_ be ? GetOption(_options_, _displayField_, ~string~, &laquo; *"auto"*, *"always"* &raquo;, _displayDefault_).
+        1. Let _display_ be ? GetOption(_options_, _displayField_, ~string~, « *"auto"*, *"always"* », _displayDefault_).
         1. If _display_ is *"always"* and _style_ is *"fractional"*, then
-            1. Throw a *RangeError* exception.
+          1. Throw a *RangeError* exception.
         1. If _prevStyle_ is *"fractional"*, then
           1. If _style_ is not *"fractional"*, then
             1. Throw a *RangeError* exception.
@@ -248,9 +248,9 @@
         1. If _unit_ is *"hours"* and _twoDigitHours_ is *true*, then
           1. Set _style_ to *"2-digit"*.
         1. Return the Record {
-          [[Style]]: _style_,
-          [[Display]]: _display_
-        }.
+            [[Style]]: _style_,
+            [[Display]]: _display_
+          }.
       </emu-alg>
     </emu-clause>
 
@@ -308,7 +308,7 @@
           _durationFormat_: a DurationFormat object,
           _hoursValue_: an integer,
           _signDisplayed_: a Boolean,
-          ) : a List of Records
+        ): a List of Records
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -327,7 +327,7 @@
         1. If _signDisplayed_ is *false*, then
           1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"signDisplay"*, *"never"*).
         1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"useGrouping"*, *false*).
-        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, &laquo; _durationFormat_.[[Locale]], _nfOpts_ &raquo;).
+        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOpts_ »).
         1. Let _hoursParts_ be PartitionNumberPattern(_nf_, _hoursValue_).
         1. For each Record { [[Type]], [[Value]] } _part_ of _hoursParts_, do
           1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: *"hour"* } to _result_.
@@ -342,7 +342,7 @@
           _minutesValue_: an integer,
           _hoursDisplayed_: a Boolean,
           _signDisplayed_: a Boolean,
-          ) : a List of Records
+        ): a List of Records
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -364,7 +364,7 @@
         1. If _signDisplayed_ is *false*, then
           1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"signDisplay"*, *"never"*).
         1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"useGrouping"*, *false*).
-        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, &laquo; _durationFormat_.[[Locale]], _nfOpts_ &raquo;).
+        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOpts_ »).
         1. Let _minutesParts_ be PartitionNumberPattern(_nf_, _minutesValue_).
         1. For each Record { [[Type]], [[Value]] } _part_ of _minutesParts_, do
           1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: *"minute"* } to _result_.
@@ -377,9 +377,9 @@
         FormatNumericSeconds (
           _durationFormat_: a DurationFormat Object,
           _secondsValue_: a mathematical value,
-          _minutesDisplayed_ : a Boolean,
+          _minutesDisplayed_: a Boolean,
           _signDisplayed_: a Boolean,
-          ) : a List of Records
+        ): a List of Records
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -410,12 +410,12 @@
         1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"maximumFractionDigits"*, _maximumFractionDigits_).
         1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"minimumFractionDigits"*, _minimumFractionDigits_).
         1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"roundingMode"*, *"trunc"*).
-        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, &laquo; _durationFormat_.[[Locale]], _nfOpts_ &raquo;).
+        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOpts_ »).
         1. Let _secondsParts_ be PartitionNumberPattern(_nf_, _secondsValue_).
         1. For each Record { [[Type]], [[Value]] } _part_ of _secondsParts_, do
           1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: *"second"* } to _result_.
         1. Return _result_.
-        </emu-alg>
+      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-formatnumericunits" type="abstract operation">
@@ -479,10 +479,11 @@
     </emu-clause>
 
     <emu-clause id="sec-listformatparts" type="abstract operation">
-      <h1>ListFormatParts (
-          _durationFormat_: a DurationFormat Object
+      <h1>
+        ListFormatParts (
+          _durationFormat_: a DurationFormat Object,
           _partitionedPartsList_: a List of Lists of Records,
-          ): a List
+        ): a List
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -495,7 +496,7 @@
         1. If _listStyle_ is *"digital"*, then
           1. Set _listStyle_ to *"short"*.
         1. Perform ! CreateDataPropertyOrThrow(_lfOpts_, *"style"*, _listStyle_).
-        1. Let _lf_ be ! Construct(%Intl.ListFormat%, &laquo; _durationFormat_.[[Locale]], _lfOpts_ &raquo;).
+        1. Let _lf_ be ! Construct(%Intl.ListFormat%, « _durationFormat_.[[Locale]], _lfOpts_ »).
         1. Let _strings_ be a new empty List.
         1. For each element _parts_ of _partitionedPartsList_, do
           1. Let _string_ be the empty String.
@@ -542,9 +543,9 @@
           1. Let _display_ be the value of _durationFormat_'s internal slot whose name is the Display Slot value of the current row.
           1. Let _unit_ be the Unit value of the current row.
           1. If _style_ is *"numeric"* or *"2-digit"*, then
-              1. Let _numericPartsList_ be FormatNumericUnits(_durationFormat_, _duration_, _unit_, _signDisplayed_).
-              1. If _numericPartsList_ is not empty, append _numericPartsList_ to _result_.
-              1. Set _numericUnitFound_ to *true*.
+            1. Let _numericPartsList_ be FormatNumericUnits(_durationFormat_, _duration_, _unit_, _signDisplayed_).
+            1. If _numericPartsList_ is not empty, append _numericPartsList_ to _result_.
+            1. Set _numericUnitFound_ to *true*.
           1. Else,
             1. Let _nfOpts_ be OrdinaryObjectCreate(*null*).
             1. If _unit_ is *"seconds"*, *"milliseconds"*, or *"microseconds"*, then
@@ -573,7 +574,7 @@
               1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"style"*, *"unit"*).
               1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"unit"*, _numberFormatUnit_).
               1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"unitDisplay"*, _style_).
-              1. Let _nf_ be ! Construct(%Intl.NumberFormat%, &laquo; _durationFormat_.[[Locale]], _nfOpts_ &raquo;).
+              1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOpts_ »).
               1. Let _parts_ be PartitionNumberPattern(_nf_, _value_).
               1. Let _list_ be a new empty List.
               1. For each Record { [[Type]], [[Value]] } _part_ of _parts_, do
@@ -582,8 +583,8 @@
         1. Return ListFormatParts(_durationFormat_, _result_).
       </emu-alg>
 
-    <emu-table id="table-partition-duration-format-pattern">
-      <emu-caption>DurationFormat instance internal slots and properties relevant to PartitionDurationFormatPattern</emu-caption>
+      <emu-table id="table-partition-duration-format-pattern">
+        <emu-caption>DurationFormat instance internal slots and properties relevant to PartitionDurationFormatPattern</emu-caption>
         <table class="real-table">
           <thead>
             <tr>
@@ -681,10 +682,10 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _durationFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.DurationFormatPrototype%"*, &laquo; [[InitializedDurationFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[YearsStyle]], [[YearsDisplay]], [[MonthsStyle]], [[MonthsDisplay]], [[WeeksStyle]], [[WeeksDisplay]], [[DaysStyle]], [[DaysDisplay]], [[HoursStyle]], [[HoursDisplay]], [[MinutesStyle]], [[MinutesDisplay]], [[SecondsStyle]], [[SecondsDisplay]], [[MillisecondsStyle]], [[MillisecondsDisplay]], [[MicrosecondsStyle]], [[MicrosecondsDisplay]], [[NanosecondsStyle]], [[NanosecondsDisplay]], [[HourMinuteSeparator]], [[MinuteSecondSeparator]], [[FractionalDigits]] &raquo;).
+        1. Let _durationFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.DurationFormatPrototype%"*, « [[InitializedDurationFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[YearsStyle]], [[YearsDisplay]], [[MonthsStyle]], [[MonthsDisplay]], [[WeeksStyle]], [[WeeksDisplay]], [[DaysStyle]], [[DaysDisplay]], [[HoursStyle]], [[HoursDisplay]], [[MinutesStyle]], [[MinutesDisplay]], [[SecondsStyle]], [[SecondsDisplay]], [[MillisecondsStyle]], [[MillisecondsDisplay]], [[MicrosecondsStyle]], [[MicrosecondsDisplay]], [[NanosecondsStyle]], [[NanosecondsDisplay]], [[HourMinuteSeparator]], [[MinuteSecondSeparator]], [[FractionalDigits]] »).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Let _options_ be ? GetOptionsObject(_options_).
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, ~string~, ~empty~, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
@@ -696,7 +697,7 @@
         1. Set _durationFormat_.[[HourMinuteSeparator]] to _digitalFormat_.[[HourMinuteSeparator]].
         1. Set _durationFormat_.[[MinuteSecondSeparator]] to _digitalFormat_.[[MinuteSecondSeparator]].
         1. Set _durationFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, &laquo; *"long"*, *"short"*, *"narrow"*, *"digital"* &raquo;, *"short"*).
+        1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"long"*, *"short"*, *"narrow"*, *"digital"* », *"short"*).
         1. Set _durationFormat_.[[Style]] to _style_.
         1. Let _prevStyle_ be the empty String.
         1. For each row of <emu-xref href="#table-durationformat"></emu-xref>, except the header row, in table order, do
@@ -709,12 +710,12 @@
           1. Set the value of the _styleSlot_ slot of _durationFormat_ to _unitOptions_.[[Style]].
           1. Set the value of the _displaySlot_ slot of _durationFormat_ to _unitOptions_.[[Display]].
           1. If _unit_ is one of *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, or *"microseconds"*, then
-             1. Set _prevStyle_ to _unitOptions_.[[Style]].
+            1. Set _prevStyle_ to _unitOptions_.[[Style]].
         1. Set _durationFormat_.[[FractionalDigits]] to ? GetNumberOption(_options_, *"fractionalDigits"*, 0, 9, *undefined*).
         1. Return _durationFormat_.
       </emu-alg>
       <emu-table id="table-durationformat">
-      <emu-caption>Internal slots and property names of DurationFormat instances relevant to Intl.DurationFormat constructor</emu-caption>
+        <emu-caption>Internal slots and property names of DurationFormat instances relevant to Intl.DurationFormat constructor</emu-caption>
         <table class="real-table">
           <thead>
             <tr>
@@ -729,350 +730,352 @@
             <td>[[YearsStyle]]</td>
             <td>[[YearsDisplay]]</td>
             <td>*"years"*</td>
-            <td>&laquo; *"long"*, *"short"*, *"narrow"* &raquo;</td>
+            <td>« *"long"*, *"short"*, *"narrow"* »</td>
             <td>*"short"*</td>
           </tr>
           <tr>
             <td>[[MonthsStyle]]</td>
             <td>[[MonthsDisplay]]</td>
             <td>*"months"*</td>
-            <td>&laquo; *"long"*, *"short"*, *"narrow"* &raquo;</td>
+            <td>« *"long"*, *"short"*, *"narrow"* »</td>
             <td>*"short"*</td>
           </tr>
           <tr>
             <td>[[WeeksStyle]]</td>
             <td>[[WeeksDisplay]]</td>
             <td>*"weeks"*</td>
-            <td>&laquo; *"long"*, *"short"*, *"narrow"* &raquo;</td>
+            <td>« *"long"*, *"short"*, *"narrow"* »</td>
             <td>*"short"*</td>
           </tr>
           <tr>
             <td>[[DaysStyle]]</td>
             <td>[[DaysDisplay]]</td>
             <td>*"days"*</td>
-            <td>&laquo; *"long"*, *"short"*, *"narrow"* &raquo;</td>
+            <td>« *"long"*, *"short"*, *"narrow"* »</td>
             <td>*"short"*</td>
           </tr>
           <tr>
             <td>[[HoursStyle]]</td>
             <td>[[HoursDisplay]]</td>
             <td>*"hours"*</td>
-            <td>&laquo; *"long"*, *"short"*, *"narrow"*, <br/>*"numeric"*, *"2-digit"* &raquo;</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"*, *"2-digit"* »</td>
             <td>*"numeric"*</td>
           </tr>
           <tr>
             <td>[[MinutesStyle]]</td>
             <td>[[MinutesDisplay]]</td>
             <td>*"minutes"*</td>
-            <td>&laquo; *"long"*, *"short"*, *"narrow"*, <br/>*"numeric"*, *"2-digit"* &raquo;</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"*, *"2-digit"* »</td>
             <td>*"numeric"*</td>
           </tr>
           <tr>
             <td>[[SecondsStyle]]</td>
             <td>[[SecondsDisplay]]</td>
             <td>*"seconds"*</td>
-            <td>&laquo; *"long"*, *"short"*, *"narrow"*, <br/>*"numeric"*, *"2-digit"* &raquo;</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"*, *"2-digit"* »</td>
             <td>*"numeric"*</td>
           </tr>
           <tr>
             <td>[[MillisecondsStyle]]</td>
             <td>[[MillisecondsDisplay]]</td>
             <td>*"milliseconds"*</td>
-            <td>&laquo; *"long"*, *"short"*, *"narrow"*, <br/>*"numeric"* &raquo;</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"* »</td>
             <td>*"numeric"*</td>
           </tr>
           <tr>
             <td>[[MicrosecondsStyle]]</td>
             <td>[[MicrosecondsDisplay]]</td>
             <td>*"microseconds"*</td>
-            <td>&laquo; *"long"*, *"short"*, *"narrow"*, <br/>*"numeric"* &raquo;</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"* »</td>
             <td>*"numeric"*</td>
           </tr>
           <tr>
             <td>[[NanosecondsStyle]]</td>
             <td>[[NanosecondsDisplay]]</td>
             <td>*"nanoseconds"*</td>
-            <td>&laquo; *"long"*, *"short"*, *"narrow"*, <br/>*"numeric"* &raquo;</td>
+            <td>« *"long"*, *"short"*, *"narrow"*, *"numeric"* »</td>
             <td>*"numeric"*</td>
           </tr>
         </table>
-    </emu-table>
-        </emu-clause>
-      </emu-clause>
-
-      <emu-clause id="sec-properties-of-intl-durationformat-constructor">
-        <h1>Properties of the Intl.DurationFormat Constructor</h1>
-
-        <p>The Intl.DurationFormat constructor has the following properties:</p>
-
-        <emu-clause id="sec-Intl.DurationFormat.prototype">
-          <h1>Intl.DurationFormat.prototype</h1>
-
-          <p>The value of `Intl.DurationFormat.prototype` is %Intl.DurationFormat.prototype%.</p>
-
-          <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-        </emu-clause>
-
-        <emu-clause id="sec-Intl.DurationFormat.supportedLocalesOf">
-          <h1>Intl.DurationFormat.supportedLocalesOf ( _locales_ [ , _options_ ] )</h1>
-
-          <p>When the `supportedLocalesOf` method is called with arguments _locales_ and _options_, the following steps are taken:</p>
-
-          <emu-alg>
-            1. Let _availableLocales_ be %Intl.DurationFormat%.[[AvailableLocales]].
-            1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-            1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-Intl.DurationFormat-internal-slots">
-          <h1>Internal slots</h1>
-
-          <p>The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
-
-          <p>The value of the [[RelevantExtensionKeys]] internal slot is &laquo; *"nu"* &raquo;.</p>
-
-          <p>The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints for all locale values _locale_:</p>
-
-          <ul>
-            <li>[[LocaleData]].[[&lt;_locale_&gt;]].[[nu]] must be a List as specified in <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref> and must not include the values *"native"*, *"traditio"*, or *"finance"**.</li>
-            <li>[[LocaleData]].[[&lt;_locale_&gt;]].[[DigitalFormat]] must be a Record with keys corresponding to each numbering system available for the given locale, with Record values containing the following fields:
-              <ul>
-                <li>[[HourMinuteSeparator]] is a String value that is the appropriate separator between hours and minutes for that combination of locale, numbering system, and unit when using *"numeric"* or *"2-digit"* styles</li>
-                <li>[[MinuteSecondSeparator]] is a String value that is the appropriate separator between minutes and seconds for that combination of locale, numbering system, and unit when using *"numeric"* or *"2-digit"* styles.</li>
-                <li>[[TwoDigitHours]] is a Boolean value indicating whether hours are always displayed using two digits when the *"numeric"* style is used.</li>
-              </ul>
-            </li>
-          </ul>
-
-          <emu-note>It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).</emu-note>
-        </emu-clause>
-      </emu-clause>
-
-      <emu-clause id="sec-properties-of-intl-durationformat-prototype-object">
-        <h1>Properties of the Intl.DurationFormat Prototype Object</h1>
-
-        <p>The Intl.DurationFormat prototype object is itself an ordinary object. <dfn>%Intl.DurationFormat.prototype%</dfn> is not an Intl.DurationFormat instance and does not have an [[InitializedDurationFormat]] internal slot or any of the other internal slots of Intl.DurationFormat instance objects.</p>
-
-        <emu-clause id="sec-Intl.DurationFormat.prototype.constructor">
-          <h1>Intl.DurationFormat.prototype.constructor</h1>
-
-          <p>The initial value of `Intl.DurationFormat.prototype.constructor` is the intrinsic object %Intl.DurationFormat%.</p>
-        </emu-clause>
-
-        <emu-clause id="sec-Intl.DurationFormat.prototype-@@tostringtag">
-          <h1>Intl.DurationFormat.prototype [ @@toStringTag ]</h1>
-
-          <p>The initial value of the @@toStringTag property is the string value *"Intl.DurationFormat"*.</p>
-          <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-        </emu-clause>
-
-        <emu-clause id="sec-Intl.DurationFormat.prototype.format">
-          <h1>Intl.DurationFormat.prototype.format ( _duration_ )</h1>
-
-          <p>When the `format` method is called with an argument _duration_, the following steps are taken:</p>
-
-          <emu-alg>
-            1. Let _df_ be the *this* value.
-            1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
-            1. Let _record_ be ? ToDurationRecord(_duration_).
-            1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
-            1. Let _result_ be the empty String.
-            1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
-              1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
-            1. Return _result_.
-          </emu-alg>
-        </emu-clause>
-        <emu-clause id="sec-Intl.DurationFormat.prototype.formatToParts">
-          <h1>Intl.DurationFormat.prototype.formatToParts ( _duration_ )</h1>
-
-          <p>When the `formatToParts` method is called with an argument _duration_, the following steps are taken:</p>
-
-          <emu-alg>
-            1. Let _df_ be the *this* value.
-            1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
-            1. Let _record_ be ? ToDurationRecord(_duration_).
-            1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
-            1. Let _result_ be ! ArrayCreate(0).
-            1. Let _n_ be 0.
-            1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
-              1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-              1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
-              1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
-              1. If _part_.[[Unit]] is not ~empty~, perform ! CreateDataPropertyOrThrow(_obj_, *"unit"*, _part_.[[Unit]]).
-              1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(_n_), _obj_).
-              1. Set _n_ to _n_ + 1.
-            1. Return _result_.
-          </emu-alg>
-        </emu-clause>
-        <emu-clause id="sec-Intl.DurationFormat.prototype.resolvedOptions">
-          <h1>Intl.DurationFormat.prototype.resolvedOptions ( )</h1>
-
-          <p>This function provides access to the locale and options computed during initialization of the object.</p>
-
-          <emu-alg>
-            1. Let _df_ be the *this* value.
-            1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
-            1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
-            1. For each row of <emu-xref href="#table-durationformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-              1. Let _p_ be the Property value of the current row.
-              1. Let _v_ be the value of _df_'s internal slot whose name is the Internal Slot value of the current row.
-              1. If _p_ is *"fractionalDigits"*, then
-                1. If _v_ is not *undefined*, set _v_ to 𝔽(_v_).
-              1. Else,
-                1. Assert: _v_ is not *undefined*.
-              1. If _v_ is *"fractional"*, then
-                1. Assert: The Internal Slot value of the current row is [[MillisecondsStyle]], [[MicrosecondsStyle]], or [[NanosecondsStyle]] .
-                1. Set _v_ to *"numeric"*.
-              1. If _v_ is not *undefined*, then
-                1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
-            1. Return _options_.
-          </emu-alg>
-
-          <emu-table id="table-durationformat-resolvedoptions-properties">
-            <emu-caption>Resolved Options of DurationFormat Instances</emu-caption>
-            <table class="real-table">
-              <thead>
-                <tr>
-                  <th>Internal Slot</th>
-                  <th>Property</th>
-                </tr>
-              </thead>
-              <tr>
-                <td>[[Locale]]</td>
-                <td>*"locale"*</td>
-              </tr>
-              <tr>
-                <td>[[NumberingSystem]]</td>
-                <td>*"numberingSystem"*</td>
-              </tr>
-              <tr>
-                <td>[[Style]]</td>
-                <td>*"style"*</td>
-              </tr>
-              <tr>
-                <td>[[YearsStyle]]</td>
-                <td>*"years"*</td>
-              </tr>
-              <tr>
-                <td>[[YearsDisplay]]</td>
-                <td>*"yearsDisplay"*</td>
-              </tr>
-              <tr>
-                <td>[[MonthsStyle]]</td>
-                <td>*"months"*</td>
-              </tr>
-              <tr>
-                <td>[[MonthsDisplay]]</td>
-                <td>*"monthsDisplay"*</td>
-              </tr>
-              <tr>
-                <td>[[WeeksStyle]]</td>
-                <td>*"weeks"*</td>
-              </tr>
-              <tr>
-                <td>[[WeeksDisplay]]</td>
-                <td>*"weeksDisplay"*</td>
-              </tr>
-              <tr>
-                <td>[[DaysStyle]]</td>
-                <td>*"days"*</td>
-              </tr>
-              <tr>
-                <td>[[DaysDisplay]]</td>
-                <td>*"daysDisplay"*</td>
-              </tr>
-              <tr>
-                <td>[[HoursStyle]]</td>
-                <td>*"hours"*</td>
-              </tr>
-              <tr>
-                <td>[[HoursDisplay]]</td>
-                <td>*"hoursDisplay"*</td>
-              </tr>
-              <tr>
-                <td>[[MinutesStyle]]</td>
-                <td>*"minutes"*</td>
-              </tr>
-              <tr>
-                <td>[[MinutesDisplay]]</td>
-                <td>*"minutesDisplay"*</td>
-              </tr>
-              <tr>
-                <td>[[SecondsStyle]]</td>
-                <td>*"seconds"*</td>
-              </tr>
-              <tr>
-                <td>[[SecondsDisplay]]</td>
-                <td>*"secondsDisplay"*</td>
-              </tr>
-              <tr>
-                <td>[[MillisecondsStyle]]</td>
-                <td>*"milliseconds"*</td>
-              </tr>
-              <tr>
-                <td>[[MillisecondsDisplay]]</td>
-                <td>*"millisecondsDisplay"*</td>
-              </tr>
-              <tr>
-                <td>[[MicrosecondsStyle]]</td>
-                <td>*"microseconds"*</td>
-              </tr>
-              <tr>
-                <td>[[MicrosecondsDisplay]]</td>
-                <td>*"microsecondsDisplay"*</td>
-              </tr>
-              <tr>
-                <td>[[NanosecondsStyle]]</td>
-                <td>*"nanoseconds"*</td>
-              </tr>
-              <tr>
-                <td>[[NanosecondsDisplay]]</td>
-                <td>*"nanosecondsDisplay"*</td>
-              </tr>
-              <tr>
-                <td>[[FractionalDigits]]</td>
-                <td>*"fractionalDigits"*</td>
-              </tr>
-           </table>
-          </emu-table>
-        </emu-clause>
-      </emu-clause>
-
-      <emu-clause id="sec-properties-of-intl-durationformat-instances">
-        <h1>Properties of Intl.DurationFormat Instances</h1>
-
-        <p>Intl.DurationFormat instances inherit properties from %Intl.DurationFormat.prototype%.</p>
-        <p>Intl.DurationFormat instances have an [[InitializedDurationFormat]] internal slot.</p>
-        <p>Intl.DurationFormat instances also have several internal slots that are computed by the constructor:</p>
-
-        <ul>
-          <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-          <li>[[NumberingSystem]] is a String value with the *"type"* given in Unicode Technical Standard 35 for the numbering system used for formatting.</li>
-          <li>[[Style]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"digital"* identifying the duration formatting style used.</li>
-          <li>[[YearsStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the years field.</li>
-          <li>[[YearsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the years field.</li>
-          <li>[[MonthsStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the months field.</li>
-          <li>[[MonthsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the months field.</li>
-          <li>[[WeeksStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the weeks field.</li>
-          <li>[[WeeksDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the weeks field.</li>
-          <li>[[DaysStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the days field.</li>
-          <li>[[DaysDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the days field.</li>
-          <li>[[HoursStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the hours field.</li>
-          <li>[[HoursDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the hours field.</li>
-          <li>[[MinutesStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the minutes field.</li>
-          <li>[[MinutesDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the minutes field.</li>
-          <li>[[SecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the seconds field.</li>
-          <li>[[SecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the seconds field.</li>
-          <li>[[MillisecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the milliseconds field.</li>
-          <li>[[MillisecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the milliseconds field.</li>
-          <li>[[MicrosecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the microseconds field.</li>
-          <li>[[MicrosecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the microseconds field.</li>
-          <li>[[NanosecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the nanoseconds field.</li>
-          <li>[[NanosecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the nanoseconds field.</li>
-          <li>[[HourMinuteSeparator]] is a String value identifying the separator to be used between hours and minutes when both fields are displayed and both fields are formatted using numeric styles.</li>
-          <li>[[MinuteSecondSeparator]] is a String value identifying the separator to be used between minutes and seconds when both fields are displayed and both fields are formatted using numeric styles.</li>
-          <li>[[FractionalDigits]] is a non-negative integer, identifying the number of fractional digits to be used with numeric styles, or is *undefined*.</li>
-        </ul>
-      </emu-clause>
+      </emu-table>
     </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-properties-of-intl-durationformat-constructor">
+    <h1>Properties of the Intl.DurationFormat Constructor</h1>
+
+    <p>The Intl.DurationFormat constructor has the following properties:</p>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype">
+      <h1>Intl.DurationFormat.prototype</h1>
+
+      <p>The value of `Intl.DurationFormat.prototype` is %Intl.DurationFormat.prototype%.</p>
+
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.supportedLocalesOf">
+      <h1>Intl.DurationFormat.supportedLocalesOf ( _locales_ [ , _options_ ] )</h1>
+
+      <p>When the `supportedLocalesOf` method is called with arguments _locales_ and _options_, the following steps are taken:</p>
+
+      <emu-alg>
+        1. Let _availableLocales_ be %Intl.DurationFormat%.[[AvailableLocales]].
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+        1. Return ? FilterLocales(_availableLocales_, _requestedLocales_, _options_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat-internal-slots">
+      <h1>Internal slots</h1>
+
+      <p>The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+
+      <p>The value of the [[RelevantExtensionKeys]] internal slot is « *"nu"* ».</p>
+
+      <p>The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints for all locale values _locale_:</p>
+
+      <ul>
+        <li>[[LocaleData]].[[&lt;_locale_>]].[[nu]] must be a List as specified in <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref> and must not include the values *"native"*, *"traditio"*, or *"finance"**.</li>
+        <li>[[LocaleData]].[[&lt;_locale_>]].[[DigitalFormat]] must be a Record with keys corresponding to each numbering system available for the given locale, with Record values containing the following fields:
+          <ul>
+            <li>[[HourMinuteSeparator]] is a String value that is the appropriate separator between hours and minutes for that combination of locale, numbering system, and unit when using *"numeric"* or *"2-digit"* styles</li>
+            <li>[[MinuteSecondSeparator]] is a String value that is the appropriate separator between minutes and seconds for that combination of locale, numbering system, and unit when using *"numeric"* or *"2-digit"* styles.</li>
+            <li>[[TwoDigitHours]] is a Boolean value indicating whether hours are always displayed using two digits when the *"numeric"* style is used.</li>
+          </ul>
+        </li>
+      </ul>
+
+      <emu-note>It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).</emu-note>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-properties-of-intl-durationformat-prototype-object">
+    <h1>Properties of the Intl.DurationFormat Prototype Object</h1>
+
+    <p>The Intl.DurationFormat prototype object is itself an ordinary object. <dfn>%Intl.DurationFormat.prototype%</dfn> is not an Intl.DurationFormat instance and does not have an [[InitializedDurationFormat]] internal slot or any of the other internal slots of Intl.DurationFormat instance objects.</p>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.constructor">
+      <h1>Intl.DurationFormat.prototype.constructor</h1>
+
+      <p>The initial value of `Intl.DurationFormat.prototype.constructor` is the intrinsic object %Intl.DurationFormat%.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype-@@tostringtag">
+      <h1>Intl.DurationFormat.prototype [ @@toStringTag ]</h1>
+
+      <p>The initial value of the @@toStringTag property is the string value *"Intl.DurationFormat"*.</p>
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.format">
+      <h1>Intl.DurationFormat.prototype.format ( _duration_ )</h1>
+
+      <p>When the `format` method is called with an argument _duration_, the following steps are taken:</p>
+
+      <emu-alg>
+        1. Let _df_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
+        1. Let _record_ be ? ToDurationRecord(_duration_).
+        1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
+        1. Let _result_ be the empty String.
+        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+          1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.formatToParts">
+      <h1>Intl.DurationFormat.prototype.formatToParts ( _duration_ )</h1>
+
+      <p>When the `formatToParts` method is called with an argument _duration_, the following steps are taken:</p>
+
+      <emu-alg>
+        1. Let _df_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
+        1. Let _record_ be ? ToDurationRecord(_duration_).
+        1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
+        1. Let _result_ be ! ArrayCreate(0).
+        1. Let _n_ be 0.
+        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
+          1. If _part_.[[Unit]] is not ~empty~, perform ! CreateDataPropertyOrThrow(_obj_, *"unit"*, _part_.[[Unit]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(_n_), _obj_).
+          1. Set _n_ to _n_ + 1.
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.resolvedOptions">
+      <h1>Intl.DurationFormat.prototype.resolvedOptions ( )</h1>
+
+      <p>This function provides access to the locale and options computed during initialization of the object.</p>
+
+      <emu-alg>
+        1. Let _df_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
+        1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. For each row of <emu-xref href="#table-durationformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _p_ be the Property value of the current row.
+          1. Let _v_ be the value of _df_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If _p_ is *"fractionalDigits"*, then
+            1. If _v_ is not *undefined*, set _v_ to 𝔽(_v_).
+          1. Else,
+            1. Assert: _v_ is not *undefined*.
+          1. If _v_ is *"fractional"*, then
+            1. Assert: The Internal Slot value of the current row is [[MillisecondsStyle]], [[MicrosecondsStyle]], or [[NanosecondsStyle]] .
+            1. Set _v_ to *"numeric"*.
+          1. If _v_ is not *undefined*, then
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+        1. Return _options_.
+      </emu-alg>
+
+      <emu-table id="table-durationformat-resolvedoptions-properties">
+        <emu-caption>Resolved Options of DurationFormat Instances</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Internal Slot</th>
+              <th>Property</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[Locale]]</td>
+            <td>*"locale"*</td>
+          </tr>
+          <tr>
+            <td>[[NumberingSystem]]</td>
+            <td>*"numberingSystem"*</td>
+          </tr>
+          <tr>
+            <td>[[Style]]</td>
+            <td>*"style"*</td>
+          </tr>
+          <tr>
+            <td>[[YearsStyle]]</td>
+            <td>*"years"*</td>
+          </tr>
+          <tr>
+            <td>[[YearsDisplay]]</td>
+            <td>*"yearsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[MonthsStyle]]</td>
+            <td>*"months"*</td>
+          </tr>
+          <tr>
+            <td>[[MonthsDisplay]]</td>
+            <td>*"monthsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[WeeksStyle]]</td>
+            <td>*"weeks"*</td>
+          </tr>
+          <tr>
+            <td>[[WeeksDisplay]]</td>
+            <td>*"weeksDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[DaysStyle]]</td>
+            <td>*"days"*</td>
+          </tr>
+          <tr>
+            <td>[[DaysDisplay]]</td>
+            <td>*"daysDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[HoursStyle]]</td>
+            <td>*"hours"*</td>
+          </tr>
+          <tr>
+            <td>[[HoursDisplay]]</td>
+            <td>*"hoursDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[MinutesStyle]]</td>
+            <td>*"minutes"*</td>
+          </tr>
+          <tr>
+            <td>[[MinutesDisplay]]</td>
+            <td>*"minutesDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[SecondsStyle]]</td>
+            <td>*"seconds"*</td>
+          </tr>
+          <tr>
+            <td>[[SecondsDisplay]]</td>
+            <td>*"secondsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[MillisecondsStyle]]</td>
+            <td>*"milliseconds"*</td>
+          </tr>
+          <tr>
+            <td>[[MillisecondsDisplay]]</td>
+            <td>*"millisecondsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[MicrosecondsStyle]]</td>
+            <td>*"microseconds"*</td>
+          </tr>
+          <tr>
+            <td>[[MicrosecondsDisplay]]</td>
+            <td>*"microsecondsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[NanosecondsStyle]]</td>
+            <td>*"nanoseconds"*</td>
+          </tr>
+          <tr>
+            <td>[[NanosecondsDisplay]]</td>
+            <td>*"nanosecondsDisplay"*</td>
+          </tr>
+          <tr>
+            <td>[[FractionalDigits]]</td>
+            <td>*"fractionalDigits"*</td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-properties-of-intl-durationformat-instances">
+    <h1>Properties of Intl.DurationFormat Instances</h1>
+
+    <p>Intl.DurationFormat instances inherit properties from %Intl.DurationFormat.prototype%.</p>
+    <p>Intl.DurationFormat instances have an [[InitializedDurationFormat]] internal slot.</p>
+    <p>Intl.DurationFormat instances also have several internal slots that are computed by the constructor:</p>
+
+    <ul>
+      <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
+      <li>[[NumberingSystem]] is a String value with the *"type"* given in Unicode Technical Standard 35 for the numbering system used for formatting.</li>
+      <li>[[Style]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"digital"* identifying the duration formatting style used.</li>
+      <li>[[YearsStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the years field.</li>
+      <li>[[YearsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the years field.</li>
+      <li>[[MonthsStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the months field.</li>
+      <li>[[MonthsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the months field.</li>
+      <li>[[WeeksStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the weeks field.</li>
+      <li>[[WeeksDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the weeks field.</li>
+      <li>[[DaysStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the days field.</li>
+      <li>[[DaysDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the days field.</li>
+      <li>[[HoursStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the hours field.</li>
+      <li>[[HoursDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the hours field.</li>
+      <li>[[MinutesStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the minutes field.</li>
+      <li>[[MinutesDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the minutes field.</li>
+      <li>[[SecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, *"2-digit"*, or *"numeric"* identifying the formatting style used for the seconds field.</li>
+      <li>[[SecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the seconds field.</li>
+      <li>[[MillisecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the milliseconds field.</li>
+      <li>[[MillisecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the milliseconds field.</li>
+      <li>[[MicrosecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the microseconds field.</li>
+      <li>[[MicrosecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the microseconds field.</li>
+      <li>[[NanosecondsStyle]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"fractional"* identifying the formatting style used for the nanoseconds field.</li>
+      <li>[[NanosecondsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the nanoseconds field.</li>
+      <li>[[HourMinuteSeparator]] is a String value identifying the separator to be used between hours and minutes when both fields are displayed and both fields are formatted using numeric styles.</li>
+      <li>[[MinuteSecondSeparator]] is a String value identifying the separator to be used between minutes and seconds when both fields are displayed and both fields are formatted using numeric styles.</li>
+      <li>[[FractionalDigits]] is a non-negative integer, identifying the number of fractional digits to be used with numeric styles, or is *undefined*.</li>
+    </ul>
+  </emu-clause>
+</emu-clause>

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -626,40 +626,46 @@
         1. Let _displayDefault_ be *"always"*.
         1. If _style_ is *undefined*, then
           1. If _baseStyle_ is *"digital"*, then
-            1. If _unit_ is not one of *"hours"*, *"minutes"*, or *"seconds"*, then
-              1. Set _displayDefault_ to *"auto"*.
             1. Set _style_ to _digitalBase_.
+            1. If _unit_ is not one of *"hours"*, *"minutes"*, or *"seconds"*, set _displayDefault_ to *"auto"*.
+          1. Else if _prevStyle_ is one of *"fractional"*, *"numeric"* or *"2-digit"*, then
+            1. Set _style_ to *"numeric"*.
+            1. If _unit_ is not *"minutes"* or *"seconds"*, set _displayDefault_ to *"auto"*.
           1. Else,
-            1. If _prevStyle_ is *"fractional"*, *"numeric"* or *"2-digit"*, then
-              1. If _unit_ is not one of *"minutes"* or *"seconds"*, then
-                1. Set _displayDefault_ to *"auto"*.
-              1. Set _style_ to *"numeric"*.
-            1. Else,
-              1. Set _displayDefault_ to *"auto"*.
-              1. Set _style_ to _baseStyle_.
-        1. If _style_ is *"numeric"*, then
-          1. If _unit_ is one of *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*, then
-            1. Set _style_ to *"fractional"*.
+            1. Set _style_ to _baseStyle_.
             1. Set _displayDefault_ to *"auto"*.
+        1. If _style_ is *"numeric"* and _unit_ is one of *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*, then
+          1. Set _style_ to *"fractional"*.
+          1. Set _displayDefault_ to *"auto"*.
         1. Let _displayField_ be the string-concatenation of _unit_ and *"Display"*.
         1. Let _display_ be ? GetOption(_options_, _displayField_, ~string~, « *"auto"*, *"always"* », _displayDefault_).
-        1. If _display_ is *"always"* and _style_ is *"fractional"*, then
-          1. Throw a *RangeError* exception.
-        1. If _prevStyle_ is *"fractional"*, then
-          1. If _style_ is not *"fractional"*, then
-            1. Throw a *RangeError* exception.
-        1. If _prevStyle_ is *"numeric"* or *"2-digit"*, then
-          1. If _style_ is not *"fractional"*, *"numeric"* or *"2-digit"*, then
-            1. Throw a *RangeError* exception.
-          1. If _unit_ is *"minutes"* or *"seconds"*, then
-            1. Set _style_ to *"2-digit"*.
-        1. If _unit_ is *"hours"* and _twoDigitHours_ is *true*, then
-          1. Set _style_ to *"2-digit"*.
+        1. Perform ? ValidateDurationUnitStyle(_unit_, _style_, _display_, _prevStyle_).
+        1. If _unit_ is *"hours"* and _twoDigitHours_ is *true*, set _style_ to *"2-digit"*.
+        1. If _unit_ is *"minutes"* or *"seconds"* and _prevStyle_ is *"numeric"* or *"2-digit"*, set _style_ to *"2-digit"*.
         1. Return the Record {
             [[Style]]: _style_,
             [[Display]]: _display_
           }.
       </emu-alg>
+
+      <emu-clause id="sec-stringpaddingbuiltinsimpl" type="abstract operation">
+        <h1>
+          ValidateDurationUnitStyle (
+            _unit_: a String,
+            _style_: a String,
+            _display_: a String,
+            _prevStyle_: a String,
+          ): either a normal completion containing ~unused~ or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If _display_ is *"always"* and _style_ is *"fractional"*, throw a *RangeError* exception.
+          1. If _prevStyle_ is *"fractional"* and _style_ is not *"fractional"*, throw a *RangeError* exception.
+          1. If _prevStyle_ is *"numeric"* or *"2-digit"* and _style_ is not one of *"fractional"*, *"numeric"* or *"2-digit"*, throw a *RangeError* exception.
+          1. Return ~unused~.
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-computefractionaldigits" oldids="sec-addfractionaldigits" type="abstract operation">


### PR DESCRIPTION
* `emu-format`
* align section order with #923
* replace outdated use of `@@toStringTag` and "abrupt completion"
* improve documentation of internal slots
* simplify `resolvedOptions` and `GetDurationUnitOptions`