### PR TITLE
Editorial: Update "Properties of $Type Instances" sections

### DIFF
--- a/spec/annexes.html
+++ b/spec/annexes.html
@@ -189,7 +189,7 @@
 
   <ul>
     <li>
-      <emu-xref href="#sec-the-intl-collator-constructor"></emu-xref>, <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref>, <emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref> In ECMA-402, 1<sup>st</sup> Edition, constructors could be used to create Intl objects from arbitrary objects. This is no longer possible in 2nd Edition.
+      <emu-xref href="#sec-intl-collator-constructor"></emu-xref>, <emu-xref href="#sec-intl-numberformat-constructor"></emu-xref>, <emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref> In ECMA-402, 1<sup>st</sup> Edition, constructors could be used to create Intl objects from arbitrary objects. This is no longer possible in 2nd Edition.
     </li>
     <li>
       <emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref> In ECMA-402, 1<sup>st</sup> Edition, the *"length"* property of the function object _F_ was set to *+0*<sub>𝔽</sub>. In 2nd Edition, *"length"* is set to *1*<sub>𝔽</sub>.

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -1,7 +1,7 @@
 <emu-clause id="collator-objects">
   <h1>Collator Objects</h1>
 
-  <emu-clause id="sec-the-intl-collator-constructor">
+  <emu-clause id="sec-intl-collator-constructor" oldids="sec-the-intl-collator-constructor">
     <h1>The Intl.Collator Constructor</h1>
     <p>The Intl.Collator constructor is the <dfn>%Intl.Collator%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
 

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -326,7 +326,7 @@
 
     <p>Intl.Collator instances have an [[InitializedCollator]] internal slot.</p>
 
-    <p>Intl.Collator instances also have several internal slots that are computed by the constructor:</p>
+    <p>Intl.Collator instances also have several internal slots that are computed by <emu-xref href="#sec-intl-collator-constructor" title></emu-xref>:</p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for collation.</li>

--- a/spec/collator.html
+++ b/spec/collator.html
@@ -333,7 +333,7 @@
       <li>[[Usage]] is one of the String values *"sort"* or *"search"*, identifying the collator usage.</li>
       <li>[[Sensitivity]] is one of the String values *"base"*, *"accent"*, *"case"*, or *"variant"*, identifying the collator's sensitivity.</li>
       <li>[[IgnorePunctuation]] is a Boolean value, specifying whether punctuation should be ignored in comparisons.</li>
-      <li>[[Collation]] is a String value with the *"type"* given in <a href="https://unicode.org/reports/tr35/#Key_And_Type_Definitions_">Unicode Technical Standard #35 Part 1 Core, Section 3.6.1 Key and Type Definitions</a> for the collation, except that the values *"standard"* and *"search"* are not allowed, while the value *"default"* is allowed.</li>
+      <li>[[Collation]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeCollationIdentifier">Unicode Collation Identifier</a> used for collation, except that the values *"standard"* and *"search"* are not allowed, while the value *"default"* is allowed.</li>
     </ul>
 
     <p>Intl.Collator instances also have the following internal slots if the key corresponding to the name of the internal slot in <emu-xref href="#table-collator-resolvedoptions-properties"></emu-xref> is included in the [[RelevantExtensionKeys]] internal slot of Intl.Collator:</p>

--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -41,7 +41,7 @@
         <tr>
           <td>%Intl.Collator%</td>
           <td>`Intl.Collator`</td>
-          <td>The `Intl.Collator` constructor (<emu-xref href="#sec-the-intl-collator-constructor"></emu-xref>)</td>
+          <td>The `Intl.Collator` constructor (<emu-xref href="#sec-intl-collator-constructor"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%Intl.DateTimeFormat%</td>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1105,7 +1105,7 @@
 
     <p>Intl.DateTimeFormat instances have an [[InitializedDateTimeFormat]] internal slot.</p>
 
-    <p>Intl.DateTimeFormat instances also have several internal slots that are computed by the constructor:</p>
+    <p>Intl.DateTimeFormat instances also have several internal slots that are computed by <emu-xref href="#sec-intl-datetimeformat-constructor" title></emu-xref>:</p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -192,7 +192,7 @@
 
     <p>Intl.DisplayNames instances have an [[InitializedDisplayNames]] internal slot.</p>
 
-    <p>Intl.DisplayNames instances also have several internal slots that are computed by the constructor:</p>
+    <p>Intl.DisplayNames instances also have several internal slots that are computed by <emu-xref href="#sec-intl-displaynames-constructor" title></emu-xref>:</p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -378,7 +378,7 @@
 
     <p>Intl.DurationFormat instances inherit properties from %Intl.DurationFormat.prototype%.</p>
     <p>Intl.DurationFormat instances have an [[InitializedDurationFormat]] internal slot.</p>
-    <p>Intl.DurationFormat instances also have several internal slots that are computed by the constructor:</p>
+    <p>Intl.DurationFormat instances also have several internal slots that are computed by <emu-xref href="#sec-intl-durationformat-constructor" title></emu-xref>:</p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -382,7 +382,7 @@
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[NumberingSystem]] is a String value with the *"type"* given in Unicode Technical Standard 35 for the numbering system used for formatting.</li>
+      <li>[[NumberingSystem]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> used for formatting.</li>
       <li>[[Style]] is one of the String values *"long"*, *"short"*, *"narrow"*, or *"digital"* identifying the duration formatting style used.</li>
       <li>[[YearsStyle]] is one of the String values *"long"*, *"short"*, or *"narrow"* identifying the formatting style used for the years field.</li>
       <li>[[YearsDisplay]] is one of the String values *"auto"* or *"always"* identifying when to display the years field.</li>

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -179,7 +179,7 @@
 
     <p>Intl.ListFormat instances have an [[InitializedListFormat]] internal slot.</p>
 
-    <p>Intl.ListFormat instances also have several internal slots that are computed by the constructor:</p>
+    <p>Intl.ListFormat instances also have several internal slots that are computed by <emu-xref href="#sec-intl-listformat-constructor" title></emu-xref>:</p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used by the list format styles.</li>

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -330,12 +330,12 @@
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[Calendar]] is a String value that is a syntactically valid type value as given in <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">Unicode Technical Standard #35 Part 1 Core, Section 3.2 Unicode Locale Identifier</a>, or is *undefined*.</li>
-      <li>[[Collation]] is a String value that is a syntactically valid type value as given in <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">Unicode Technical Standard #35 Part 1 Core, Section 3.2 Unicode Locale Identifier</a>, or is *undefined*.</li>
-      <li>[[HourCycle]] is a String value that is a syntactically valid type value as given in <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">Unicode Technical Standard #35 Part 1 Core, Section 3.2 Unicode Locale Identifier</a>, or is *undefined*.</li>
-      <li>[[NumberingSystem]] is a String value that is a syntactically valid type value as given in <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">Unicode Technical Standard #35 Part 1 Core, Section 3.2 Unicode Locale Identifier</a>, or is *undefined*.</li>
-      <li>[[CaseFirst]] is a String value that is a syntactically valid type value as given in <a href="https://unicode.org/reports/tr35/#Unicode_locale_identifier">Unicode Technical Standard #35 Part 1 Core, Section 3.2 Unicode Locale Identifier</a>, or is *undefined*. This internal slot only exists if the [[LocaleExtensionKeys]] internal slot of %Intl.Locale% contains *"kf"*.</li>
-      <li>[[Numeric]] is a Boolean value specifying whether numeric sorting is used by the locale, or is *undefined*. This internal slot only exists if the [[LocaleExtensionKeys]] internal slot of %Intl.Locale% contains *"kn"*.</li>
+      <li>[[Calendar]] is either *undefined* or a String value that is a well-formed <a href="https://unicode.org/reports/tr35/#UnicodeCalendarIdentifier">Unicode Calendar Identifier</a> in canonical form.</li>
+      <li>[[Collation]] is either *undefined* or a String value that is a well-formed <a href="https://unicode.org/reports/tr35/#UnicodeCollationIdentifier">Unicode Collation Identifier</a> in canonical form.</li>
+      <li>[[HourCycle]] is either *undefined* or a String value that is a valid <a href="https://unicode.org/reports/tr35/#UnicodeHourCycleIdentifier">Unicode Hour Cycle Identifier</a> in canonical form.</li>
+      <li>[[NumberingSystem]] is either *undefined* or a String value that is a well-formed <a href="https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> in canonical form.</li>
+      <li>[[CaseFirst]] is either *undefined* or one of the String values *"upper"*, *"lower"*, or *"false"*. This internal slot only exists if the [[LocaleExtensionKeys]] internal slot of %Intl.Locale% contains *"kf"*.</li>
+      <li>[[Numeric]] is either *undefined* or a Boolean value specifying whether numeric sorting is used by the locale. This internal slot only exists if the [[LocaleExtensionKeys]] internal slot of %Intl.Locale% contains *"kn"*.</li>
     </ul>
   </emu-clause>
 

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -326,7 +326,7 @@
 
     <p>Intl.Locale instances have an [[InitializedLocale]] internal slot.</p>
 
-    <p>Intl.Locale instances also have several internal slots that are computed by the constructor:</p>
+    <p>Intl.Locale instances also have several internal slots that are computed by <emu-xref href="#sec-intl-locale-constructor" title></emu-xref>:</p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -502,7 +502,7 @@
 
     <p>Intl.NumberFormat instances have an [[InitializedNumberFormat]] internal slot.</p>
 
-    <p>Intl.NumberFormat instances also have several internal slots that are computed by the constructor:</p>
+    <p>Intl.NumberFormat instances also have several internal slots that are computed by <emu-xref href="#sec-intl-numberformat-constructor" title></emu-xref>:</p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -507,7 +507,7 @@
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
       <li>[[LocaleData]] is a Record representing the data available to the implementation for formatting. It is the value of an entry in %Intl.NumberFormat%.[[LocaleData]] associated with either the value of [[Locale]] or a prefix thereof.</li>
-      <li>[[NumberingSystem]] is a String value with the "type" given in <a href="https://unicode.org/reports/tr35/#Key_And_Type_Definitions_">Unicode Technical Standard #35 Part 1 Core, Section 3.6.1 Key and Type Definitions</a> for the numbering system used for formatting.</li>
+      <li>[[NumberingSystem]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> used for formatting.</li>
       <li>[[Style]] is one of the String values *"decimal"*, *"currency"*, *"percent"*, or *"unit"*, identifying the type of quantity being measured.</li>
       <li>[[Currency]] is a String value with the currency code identifying the currency to be used if formatting with the *"currency"* unit type. It is only used when [[Style]] has the value *"currency"*.</li>
       <li>[[CurrencyDisplay]] is one of the String values *"code"*, *"symbol"*, *"narrowSymbol"*, or *"name"*, specifying whether to display the currency as an ISO 4217 alphabetic currency code, a localized currency symbol, or a localized currency name if formatting with the *"currency"* style. It is only used when [[Style]] has the value *"currency"*.</li>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -224,7 +224,7 @@
 
     <p>Intl.PluralRules instances have an [[InitializedPluralRules]] internal slot.</p>
 
-    <p>Intl.PluralRules instances also have several internal slots that are computed by the constructor:</p>
+    <p>Intl.PluralRules instances also have several internal slots that are computed by <emu-xref href="#sec-intl-pluralrules-constructor" title></emu-xref>:</p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used by the plural rules.</li>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -196,7 +196,7 @@
 
     <p>Intl.RelativeTimeFormat instances have an [[InitializedRelativeTimeFormat]] internal slot.</p>
 
-    <p>Intl.RelativeTimeFormat instances also have several internal slots that are computed by the constructor:</p>
+    <p>Intl.RelativeTimeFormat instances also have several internal slots that are computed by <emu-xref href="#sec-intl-relativetimeformat-constructor" title></emu-xref>:</p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -204,7 +204,7 @@
       <li>[[Style]] is one of the String values *"long"*, *"short"*, or *"narrow"*, identifying the relative time format style used.</li>
       <li>[[Numeric]] is one of the String values *"always"* or *"auto"*, identifying whether numerical descriptions are always used, or used only when no more specific version is available (e.g., "1 day ago" vs "yesterday").</li>
       <li>[[NumberFormat]] is an Intl.NumberFormat object used for formatting.</li>
-      <li>[[NumberingSystem]] is a String value with the *"type"* given in <a href="https://unicode.org/reports/tr35/#Key_And_Type_Definitions_">Unicode Technical Standard #35 Part 1 Core, Section 3.6.1 Key and Type Definitions</a> for the numbering system used for formatting.</li>
+      <li>[[NumberingSystem]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> used for formatting.</li>
       <li>[[PluralRules]] is an Intl.PluralRules object used for formatting.</li>
     </ul>
   </emu-clause>

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -144,7 +144,7 @@
 
     <p>Intl.Segmenter instances have an [[InitializedSegmenter]] internal slot.</p>
 
-    <p>Intl.Segmenter instances also have internal slots that are computed by the constructor:</p>
+    <p>Intl.Segmenter instances also have internal slots that are computed by <emu-xref href="#sec-intl-segmenter-constructor" title></emu-xref>:</p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for segmentation.</li>


### PR DESCRIPTION
* link to the respective $Type constructor section
* link directly to any appropriate [UTS 35 Key And Type Definition](https://unicode.org/reports/tr35/#Key_And_Type_Definitions_)