### PR TITLE
Editorial: Simplify NumberFormat

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -36,6 +36,14 @@ emu-normative-optional:before {
 #ecma-logo {
   width: 500px;
 }
+#spec-container {
+  container: spec-container / inline-size;
+}
+@container spec-container (width >= 768px) {
+  .c-md-width {
+    width: var(--c-md-width);
+  }
+}
 </style>
 <pre class="metadata">
   title: ECMAScript&reg; 2025 Internationalization API Specification

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -643,7 +643,6 @@
         </tr>
       </table>
       <emu-note>
-        The Negation column is used by GetUnsignedRoundingMode.
         When the rounding mode in the Identifier column produces outputs of the same magnitude for all inputs of the same magnitude, it is its own negation and the Negation column is blank (e.g., abs(truncate(-1.5)) = abs(truncate(1.5)) = 1).
         Otherwise, the Negation column contains the rounding mode that should be applied to the absolute value of a negative number to produce a result of the same magnitude as application of the rounding mode in the Identifier column to its signed value (e.g., abs(ceiling(-1.5)) ≠ abs(floor(1.5)), but abs(ceiling(-1.5)) = abs(floor(1.5)) = 1).
       </emu-note>
@@ -709,16 +708,15 @@
         1. Else,
           1. Assert: _x_ is a mathematical value.
           1. If _x_ &lt; 0, let _sign_ be ~negative~; else let _sign_ be ~positive~.
-          1. If _sign_ is ~negative~, then
-            1. Set _x_ to -_x_.
-        1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_intlObject_.[[RoundingMode]], _sign_).
+          1. Set _x_ to abs(x).
+        1. Let _roundingMode_ be _intlObject_.[[RoundingMode]].
         1. If _intlObject_.[[RoundingType]] is ~significant-digits~, then
-          1. Let _result_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
+          1. Let _result_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _roundingMode_, _sign_).
         1. Else if _intlObject_.[[RoundingType]] is ~fraction-digits~, then
-          1. Let _result_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
+          1. Let _result_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _roundingMode_, _sign_).
         1. Else,
-          1. Let _sResult_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
-          1. Let _fResult_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
+          1. Let _sResult_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _roundingMode_, _sign_).
+          1. Let _fResult_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _roundingMode_, _sign_).
           1. If _fResult_.[[RoundingMagnitude]] &lt; _sResult_.[[RoundingMagnitude]], let _fixedIsMorePrecise_ be *true*; else let _fixedIsMorePrecise_ be *false*.
           1. If _intlObject_.[[RoundingType]] is ~more-precision~ and _fixedIsMorePrecise_ is *true*, then
             1. Let _result_ be _fResult_.
@@ -904,7 +902,7 @@
                 1. Let _minusSignSymbol_ be the ILND String representing the minus sign.
                 1. Append the Record { [[Type]]: *"exponentMinusSign"*, [[Value]]: _minusSignSymbol_ } to _result_.
                 1. Let _exponent_ be -_exponent_.
-              1. Let _exponentResult_ be ToRawFixed(_exponent_, 0, 0, 1, *undefined*).
+              1. Let _exponentResult_ be ToRawFixed(_exponent_, 0, 0, 1, *undefined*, ~positive~).
               1. Append the Record { [[Type]]: *"exponentInteger"*, [[Value]]: _exponentResult_.[[FormattedString]] } to _result_.
             1. Else,
               1. Let _unknown_ be an ILND String based on _x_ and _p_.
@@ -1288,7 +1286,8 @@
           _x_: a non-negative mathematical value,
           _minPrecision_: an integer in the inclusive interval from 1 to 21,
           _maxPrecision_: an integer in the inclusive interval from 1 to 21,
-          _unsignedRoundingMode_: a rounding mode or *undefined*,
+          _roundingMode_: a rounding mode or *undefined*,
+          _originalSign_: ~negative~ or ~positive~,
         ): a Record with fields [[FormattedString]] (a String), [[RoundedNumber]] (a mathematical value), [[IntegerDigitsCount]] (an integer), and [[RoundingMagnitude]] (an integer)
       </h1>
       <dl class="header">
@@ -1310,7 +1309,7 @@
         1. Else,
           1. [declared="n1,e1,r1"] Let _n1_ and _e1_ each be an integer and _r1_ a mathematical value, with <emu-eqn>_r1_ = ToRawPrecisionFn(_n1_, _e1_, _p_)</emu-eqn>, such that <emu-eqn>_r1_ ≤ _x_</emu-eqn> and _r1_ is maximized.
           1. [declared="n2,e2,r2"] Let _n2_ and _e2_ each be an integer and _r2_ a mathematical value, with <emu-eqn>_r2_ = ToRawPrecisionFn(_n2_, _e2_, _p_)</emu-eqn>, such that <emu-eqn>_r2_ ≥ _x_</emu-eqn> and _r2_ is minimized.
-          1. Let _xFinal_ be ApplyUnsignedRoundingMode(_x_, _r1_, _r2_, _unsignedRoundingMode_).
+          1. Let _xFinal_ be ApplyUnsignedRoundingMode(_x_, _r1_, _r2_, _roundingMode_, _originalSign_).
           1. If _xFinal_ is _r1_, then
             1. Let _n_ be _n1_.
             1. Let _e_ be _e1_.
@@ -1346,7 +1345,8 @@
           _minFraction_: an integer in the inclusive interval from 0 to 100,
           _maxFraction_: an integer in the inclusive interval from 0 to 100,
           _roundingIncrement_: an integer,
-          _unsignedRoundingMode_: a rounding mode or *undefined*,
+          _roundingMode_: a rounding mode or *undefined*,
+          _originalSign_: ~negative~ or ~positive~,
         ): a Record with fields [[FormattedString]] (a String), [[RoundedNumber]] (a mathematical value), [[IntegerDigitsCount]] (an integer), and [[RoundingMagnitude]] (an integer)
       </h1>
       <dl class="header">
@@ -1362,7 +1362,7 @@
         1. Let _f_ be _maxFraction_.
         1. [declared="n1,r1"] Let _n1_ be an integer and _r1_ a mathematical value, with <emu-eqn>_r1_ = ToRawFixedFn(_n1_, _f_)</emu-eqn>, such that <emu-eqn>_n1_ modulo _roundingIncrement_ = 0</emu-eqn>, <emu-eqn>_r1_ ≤ _x_</emu-eqn>, and _r1_ is maximized.
         1. [declared="n2,r2"] Let _n2_ be an integer and _r2_ a mathematical value, with <emu-eqn>_r2_ = ToRawFixedFn(_n2_, _f_)</emu-eqn>, such that <emu-eqn>_n2_ modulo _roundingIncrement_ = 0</emu-eqn>, <emu-eqn>_r2_ ≥ _x_</emu-eqn>, and _r2_ is minimized.
-        1. Let _xFinal_ be ApplyUnsignedRoundingMode(_x_, _r1_, _r2_, _unsignedRoundingMode_).
+        1. Let _xFinal_ be ApplyUnsignedRoundingMode(_x_, _r1_, _r2_, _roundingMode_, _originalSign_).
         1. If _xFinal_ is _r1_, let _n_ be _n1_. Otherwise, let _n_ be _n2_.
         1. If _n_ = 0, let _m_ be *"0"*. Otherwise, let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
         1. If _f_ ≠ 0, then
@@ -1680,51 +1680,36 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getunsignedroundingmode" oldids="table-intl-unsigned-rounding-modes" type="abstract operation">
-      <h1>
-        GetUnsignedRoundingMode (
-          _roundingMode_: a rounding mode,
-          _sign_: ~negative~ or ~positive~,
-        ): a rounding mode
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns the rounding mode that should be applied to the absolute value of a number to produce the same result as if _roundingMode_ were applied to the signed value of the number (negative if _sign_ is ~negative~, or positive otherwise).</dd>
-      </dl>
-      <emu-alg>
-        1. If _sign_ is ~positive~, return _roundingMode_.
-        1. Let _negatedMode_ be the value in the Negation column of <emu-xref href="#table-intl-rounding-modes"></emu-xref> for the row where the value in the Identifier column is _roundingMode_. If there is no such value, return _roundingMode_.
-        1. Return _negatedMode_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-applyunsignedroundingmode" type="abstract operation">
+    <emu-clause id="sec-applyunsignedroundingmode" oldids="sec-getunsignedroundingmode,table-intl-unsigned-rounding-modes" type="abstract operation">
       <h1>
         ApplyUnsignedRoundingMode (
           _x_: a mathematical value,
           _r1_: a mathematical value,
           _r2_: a mathematical value,
-          _unsignedRoundingMode_: a rounding mode or *undefined*,
+          _roundingMode_: a rounding mode or *undefined*,
+          _sign_: ~negative~ or ~positive~,
         ): a mathematical value
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It considers _x_, bracketed below by _r1_ and above by _r2_, and returns either _r1_ or _r2_ according to _unsignedRoundingMode_.</dd>
+        <dd>It considers _x_, bracketed below by _r1_ and above by _r2_, and returns either _r1_ or _r2_ according to _roundingMode_ and _originalSign_ (the original sign of the number for which _x_ is the absolute value).</dd>
       </dl>
       <emu-alg>
         1. If _x_ is _r1_, return _r1_.
         1. Assert: _r1_ &lt; _x_ &lt; _r2_.
-        1. Assert: _unsignedRoundingMode_ is not *undefined*.
-        1. If _unsignedRoundingMode_ is *"floor"* or *"trunc"*, return _r1_.
-        1. If _unsignedRoundingMode_ is *"ceil"* or *"expand"*, return _r2_.
+        1. Assert: _roundingMode_ is not *undefined*.
+        1. If _sign_ is ~negative~, then
+          1. If the row of <emu-xref href="#table-intl-rounding-modes"></emu-xref> where the value in the Identifier column is _roundingMode_ has a value in the Negation column, set _roundingMode_ to that value.
+        1. If _roundingMode_ is *"floor"* or *"trunc"*, return _r1_.
+        1. If _roundingMode_ is *"ceil"* or *"expand"*, return _r2_.
         1. Let _d1_ be <emu-eqn>_x_ – _r1_</emu-eqn>.
         1. Let _d2_ be <emu-eqn>_r2_ – _x_</emu-eqn>.
         1. If _d1_ &lt; _d2_, return _r1_.
         1. If _d2_ &lt; _d1_, return _r2_.
         1. Assert: _d1_ is _d2_.
-        1. If _unsignedRoundingMode_ is *"halfFloor"* or *"halfTrunc"*, return _r1_.
-        1. If _unsignedRoundingMode_ is *"halfCeil"* or *"halfExpand"*, return _r2_.
-        1. Assert: _unsignedRoundingMode_ is *"halfEven"*.
+        1. If _roundingMode_ is *"halfFloor"* or *"halfTrunc"*, return _r1_.
+        1. If _roundingMode_ is *"halfCeil"* or *"halfExpand"*, return _r2_.
+        1. Assert: _roundingMode_ is *"halfEven"*.
         1. Let _cardinality_ be <emu-eqn>(_r1_ / (_r2_ – _r1_)) modulo 2</emu-eqn>.
         1. If _cardinality_ is 0, return _r1_.
         1. Return _r2_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -538,6 +538,7 @@
           <tr>
             <th rowspan="2">Identifier</th>
             <th rowspan="2">Description</th>
+            <th rowspan="2">Negation</th>
             <th colspan="5">Examples: Round to 0 fraction digits</th>
           </tr>
           <tr>
@@ -551,6 +552,7 @@
         <tr>
           <td>*"ceil"*</td>
           <td>Toward positive infinity</td>
+          <td>*"floor"*</td>
           <td>⬆️ [-1]</td>
           <td>⬆️ [1]</td>
           <td>⬆️ [1]</td>
@@ -560,6 +562,7 @@
         <tr>
           <td>*"floor"*</td>
           <td>Toward negative infinity</td>
+          <td>*"ceil"*</td>
           <td>⬇️ [-2]</td>
           <td>⬇️ [0]</td>
           <td>⬇️ [0]</td>
@@ -569,6 +572,7 @@
         <tr>
           <td>*"expand"*</td>
           <td>Away from zero</td>
+          <td></td>
           <td>⬇️ [-2]</td>
           <td>⬆️ [1]</td>
           <td>⬆️ [1]</td>
@@ -578,6 +582,7 @@
         <tr>
           <td>*"trunc"*</td>
           <td>Toward zero</td>
+          <td></td>
           <td>⬆️ [-1]</td>
           <td>⬇️ [0]</td>
           <td>⬇️ [0]</td>
@@ -587,6 +592,7 @@
         <tr>
           <td>*"halfCeil"*</td>
           <td>Ties toward positive infinity</td>
+          <td>*"halfFloor"*</td>
           <td>⬆️ [-1]</td>
           <td>⬇️ [0]</td>
           <td>⬆️ [1]</td>
@@ -596,6 +602,7 @@
         <tr>
           <td>*"halfFloor"*</td>
           <td>Ties toward negative infinity</td>
+          <td>*"halfCeil"*</td>
           <td>⬇️ [-2]</td>
           <td>⬇️ [0]</td>
           <td>⬇️ [0]</td>
@@ -605,6 +612,7 @@
         <tr>
           <td>*"halfExpand"*</td>
           <td>Ties away from zero</td>
+          <td></td>
           <td>⬇️ [-2]</td>
           <td>⬇️ [0]</td>
           <td>⬆️ [1]</td>
@@ -614,6 +622,7 @@
         <tr>
           <td>*"halfTrunc"*</td>
           <td>Ties toward zero</td>
+          <td></td>
           <td>⬆️ [-1]</td>
           <td>⬇️ [0]</td>
           <td>⬇️ [0]</td>
@@ -623,6 +632,7 @@
         <tr>
           <td>*"halfEven"*</td>
           <td>Ties toward an even rounding increment multiple</td>
+          <td></td>
           <td>⬇️ [-2]</td>
           <td>⬇️ [0]</td>
           <td>⬇️ [0]</td>
@@ -630,6 +640,11 @@
           <td>⬆️ [2]</td>
         </tr>
       </table>
+      <emu-note>
+        The Negation column is used by GetUnsignedRoundingMode.
+        When the rounding mode in the Identifier column produces outputs of the same magnitude for all inputs of the same magnitude, it is its own negation and the Negation column is blank (e.g., abs(truncate(-1.5)) = abs(truncate(1.5)) = 1).
+        Otherwise, the Negation column contains the rounding mode that should be applied to the absolute value of a negative number to produce a result of the same magnitude as application of the rounding mode in the Identifier column to its signed value (e.g., abs(ceiling(-1.5)) ≠ abs(floor(1.5)), but abs(ceiling(-1.5)) = abs(floor(1.5)) = 1).
+      </emu-note>
       <emu-note>The examples are illustrative of the unique behaviour of each option. ⬆️ means "resolves toward positive infinity"; ⬇️ means "resolves toward negative infinity".</emu-note>
     </emu-table>
 
@@ -1271,7 +1286,7 @@
           _x_: a non-negative mathematical value,
           _minPrecision_: an integer in the inclusive interval from 1 to 21,
           _maxPrecision_: an integer in the inclusive interval from 1 to 21,
-          _unsignedRoundingMode_: a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref>, or *undefined*,
+          _unsignedRoundingMode_: a rounding mode or *undefined*,
         ): a Record with fields [[FormattedString]] (a String), [[RoundedNumber]] (a mathematical value), [[IntegerDigitsCount]] (an integer), and [[RoundingMagnitude]] (an integer)
       </h1>
       <dl class="header">
@@ -1329,7 +1344,7 @@
           _minFraction_: an integer in the inclusive interval from 0 to 100,
           _maxFraction_: an integer in the inclusive interval from 0 to 100,
           _roundingIncrement_: an integer,
-          _unsignedRoundingMode_: a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref>, or *undefined*,
+          _unsignedRoundingMode_: a rounding mode or *undefined*,
         ): a Record with fields [[FormattedString]] (a String), [[RoundedNumber]] (a mathematical value), [[IntegerDigitsCount]] (an integer), and [[RoundingMagnitude]] (an integer)
       </h1>
       <dl class="header">
@@ -1663,113 +1678,22 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-getunsignedroundingmode" type="abstract operation">
+    <emu-clause id="sec-getunsignedroundingmode" oldids="table-intl-unsigned-rounding-modes" type="abstract operation">
       <h1>
         GetUnsignedRoundingMode (
           _roundingMode_: a rounding mode,
           _sign_: ~negative~ or ~positive~,
-        ): a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref>
+        ): a rounding mode
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the <emu-not-ref>rounding mode</emu-not-ref> that should be applied to the absolute value of a number to produce the same result as if _roundingMode_ were applied to the signed value of the number (negative if _sign_ is ~negative~, or positive otherwise).</dd>
+        <dd>It returns the rounding mode that should be applied to the absolute value of a number to produce the same result as if _roundingMode_ were applied to the signed value of the number (negative if _sign_ is ~negative~, or positive otherwise).</dd>
       </dl>
       <emu-alg>
-        1. Return the specification type in the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref> for the row where the value in the Identifier column is _roundingMode_ and the value in the Sign column is _sign_.
+        1. If _sign_ is ~positive~, return _roundingMode_.
+        1. Let _negatedMode_ be the value in the Negation column of <emu-xref href="#table-intl-rounding-modes"></emu-xref> for the row where the value in the Identifier column is _roundingMode_. If there is no such value, return _roundingMode_.
+        1. Return _negatedMode_.
       </emu-alg>
-      <emu-table id="table-intl-unsigned-rounding-modes">
-        <emu-caption>Conversion from rounding mode to unsigned rounding mode</emu-caption>
-        <table class="real-table">
-          <thead>
-            <tr>
-              <th>Identifier</th>
-              <th>Sign</th>
-              <th>Unsigned Rounding Mode</th>
-            </tr>
-          </thead>
-          <tr>
-            <td rowspan="2">*"ceil"*</td>
-            <td>~positive~</td>
-            <td>~infinity~</td>
-          </tr>
-          <tr>
-            <td>~negative~</td>
-            <td>~zero~</td>
-          </tr>
-          <tr>
-            <td rowspan="2">*"floor"*</td>
-            <td>~positive~</td>
-            <td>~zero~</td>
-          </tr>
-          <tr>
-            <td>~negative~</td>
-            <td>~infinity~</td>
-          </tr>
-          <tr>
-            <td rowspan="2">*"expand"*</td>
-            <td>~positive~</td>
-            <td>~infinity~</td>
-          </tr>
-          <tr>
-            <td>~negative~</td>
-            <td>~infinity~</td>
-          </tr>
-          <tr>
-            <td rowspan="2">*"trunc"*</td>
-            <td>~positive~</td>
-            <td>~zero~</td>
-          </tr>
-          <tr>
-            <td>~negative~</td>
-            <td>~zero~</td>
-          </tr>
-          <tr>
-            <td rowspan="2">*"halfCeil"*</td>
-            <td>~positive~</td>
-            <td>~half-infinity~</td>
-          </tr>
-          <tr>
-            <td>~negative~</td>
-            <td>~half-zero~</td>
-          </tr>
-          <tr>
-            <td rowspan="2">*"halfFloor"*</td>
-            <td>~positive~</td>
-            <td>~half-zero~</td>
-          </tr>
-          <tr>
-            <td>~negative~</td>
-            <td>~half-infinity~</td>
-          </tr>
-          <tr>
-            <td rowspan="2">*"halfExpand"*</td>
-            <td>~positive~</td>
-            <td>~half-infinity~</td>
-          </tr>
-          <tr>
-            <td>~negative~</td>
-            <td>~half-infinity~</td>
-          </tr>
-          <tr>
-            <td rowspan="2">*"halfTrunc"*</td>
-            <td>~positive~</td>
-            <td>~half-zero~</td>
-          </tr>
-          <tr>
-            <td>~negative~</td>
-            <td>~half-zero~</td>
-          </tr>
-          <tr>
-            <td rowspan="2">*"halfEven"*</td>
-            <td>~positive~</td>
-            <td>~half-even~</td>
-          </tr>
-          <tr>
-            <td>~negative~</td>
-            <td>~half-even~</td>
-          </tr>
-        </table>
-      </emu-table>
     </emu-clause>
 
     <emu-clause id="sec-applyunsignedroundingmode" type="abstract operation">
@@ -1778,7 +1702,7 @@
           _x_: a mathematical value,
           _r1_: a mathematical value,
           _r2_: a mathematical value,
-          _unsignedRoundingMode_: a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref>, or *undefined*,
+          _unsignedRoundingMode_: a rounding mode or *undefined*,
         ): a mathematical value
       </h1>
       <dl class="header">
@@ -1789,16 +1713,16 @@
         1. If _x_ is _r1_, return _r1_.
         1. Assert: _r1_ &lt; _x_ &lt; _r2_.
         1. Assert: _unsignedRoundingMode_ is not *undefined*.
-        1. If _unsignedRoundingMode_ is ~zero~, return _r1_.
-        1. If _unsignedRoundingMode_ is ~infinity~, return _r2_.
+        1. If _unsignedRoundingMode_ is *"floor"* or *"trunc"*, return _r1_.
+        1. If _unsignedRoundingMode_ is *"ceil"* or *"expand"*, return _r2_.
         1. Let _d1_ be <emu-eqn>_x_ – _r1_</emu-eqn>.
         1. Let _d2_ be <emu-eqn>_r2_ – _x_</emu-eqn>.
         1. If _d1_ &lt; _d2_, return _r1_.
         1. If _d2_ &lt; _d1_, return _r2_.
         1. Assert: _d1_ is _d2_.
-        1. If _unsignedRoundingMode_ is ~half-zero~, return _r1_.
-        1. If _unsignedRoundingMode_ is ~half-infinity~, return _r2_.
-        1. Assert: _unsignedRoundingMode_ is ~half-even~.
+        1. If _unsignedRoundingMode_ is *"halfFloor"* or *"halfTrunc"*, return _r1_.
+        1. If _unsignedRoundingMode_ is *"halfCeil"* or *"halfExpand"*, return _r2_.
+        1. Assert: _unsignedRoundingMode_ is *"halfEven"*.
         1. Let _cardinality_ be <emu-eqn>(_r1_ / (_r2_ – _r1_)) modulo 2</emu-eqn>.
         1. If _cardinality_ is 0, return _r1_.
         1. Return _r2_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -95,7 +95,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It populates the internal slots of _intlObj_ that affect locale-independent number rounding (see <emu-xref href="#sec-formatnumberstring"></emu-xref>).</dd>
+        <dd>It populates the internal slots of _intlObj_ that affect locale-independent number rounding (see <emu-xref href="#sec-formatnumerictostring"></emu-xref>).</dd>
       </dl>
       <emu-alg>
         1. Let _mnid_ be ? GetNumberOption(_options_, *"minimumIntegerDigits,"*, 1, 21, 1).
@@ -673,7 +673,7 @@
       <p>The *"length"* property of a Number format function is *1*<sub>𝔽</sub>.</p>
     </emu-clause>
 
-    <emu-clause id="sec-formatnumberstring" type="abstract operation">
+    <emu-clause id="sec-formatnumerictostring" oldids="sec-formatnumberstring" type="abstract operation">
       <h1>
         FormatNumericToString (
           _intlObject_: an Object,
@@ -702,17 +702,13 @@
         1. Else,
           1. Let _sResult_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
           1. Let _fResult_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
-          1. If _intlObject_.[[RoundingType]] is ~more-precision~, then
-            1. If _sResult_.[[RoundingMagnitude]] ≤ _fResult_.[[RoundingMagnitude]], then
-              1. Let _result_ be _sResult_.
-            1. Else,
-              1. Let _result_ be _fResult_.
+          1. If _fResult_.[[RoundingMagnitude]] &lt; _sResult_.[[RoundingMagnitude]], let _fixedIsMorePrecise_ be *true*; else let _fixedIsMorePrecise_ be *false*.
+          1. If _intlObject_.[[RoundingType]] is ~more-precision~ and _fixedIsMorePrecise_ is *true*, then
+            1. Let _result_ be _fResult_.
+          1. Else if _intlObject_.[[RoundingType]] is ~less-precision~ and _fixedIsMorePrecise_ is *false*, then
+            1. Let _result_ be _fResult_.
           1. Else,
-            1. Assert: _intlObject_.[[RoundingType]] is ~less-precision~.
-            1. If _sResult_.[[RoundingMagnitude]] ≤ _fResult_.[[RoundingMagnitude]], then
-              1. Let _result_ be _fResult_.
-            1. Else,
-              1. Let _result_ be _sResult_.
+            1. Let _result_ be _sResult_.
         1. Set _x_ to _result_.[[RoundedNumber]].
         1. Let _string_ be _result_.[[FormattedString]].
         1. If _intlObject_.[[TrailingZeroDisplay]] is *"stripIfInteger"* and <emu-eqn>_x_ modulo 1 = 0</emu-eqn>, then

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1272,7 +1272,7 @@
     <emu-clause id="sec-torawprecision" type="abstract operation">
       <h1>
         ToRawPrecision (
-          _x_: non-negative mathematical value,
+          _x_: a non-negative mathematical value,
           _minPrecision_: an integer in the inclusive interval from 1 to 21,
           _maxPrecision_: an integer in the inclusive interval from 1 to 21,
           _unsignedRoundingMode_: a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref>, or *undefined*,
@@ -1297,15 +1297,13 @@
         1. Else,
           1. [declared="n1,e1,r1"] Let _n1_ and _e1_ each be an integer and _r1_ a mathematical value, with <emu-eqn>_r1_ = ToRawPrecisionFn(_n1_, _e1_, _p_)</emu-eqn>, such that <emu-eqn>_r1_ ≤ _x_</emu-eqn> and _r1_ is maximized.
           1. [declared="n2,e2,r2"] Let _n2_ and _e2_ each be an integer and _r2_ a mathematical value, with <emu-eqn>_r2_ = ToRawPrecisionFn(_n2_, _e2_, _p_)</emu-eqn>, such that <emu-eqn>_r2_ ≥ _x_</emu-eqn> and _r2_ is minimized.
-          1. Let _r_ be ApplyUnsignedRoundingMode(_x_, _r1_, _r2_, _unsignedRoundingMode_).
-          1. If _r_ is _r1_, then
+          1. Let _xFinal_ be ApplyUnsignedRoundingMode(_x_, _r1_, _r2_, _unsignedRoundingMode_).
+          1. If _xFinal_ is _r1_, then
             1. Let _n_ be _n1_.
             1. Let _e_ be _e1_.
-            1. Let _xFinal_ be _r1_.
           1. Else,
             1. Let _n_ be _n2_.
             1. Let _e_ be _e2_.
-            1. Let _xFinal_ be _r2_.
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
         1. If _e_ ≥ (_p_ - 1), then
           1. Set _m_ to the string-concatenation of _m_ and _e_ - _p_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
@@ -1331,7 +1329,7 @@
     <emu-clause id="sec-torawfixed" type="abstract operation">
       <h1>
         ToRawFixed (
-          _x_: non-negative mathematical value,
+          _x_: a non-negative mathematical value,
           _minFraction_: an integer in the inclusive interval from 0 to 100,
           _maxFraction_: an integer in the inclusive interval from 0 to 100,
           _roundingIncrement_: an integer,
@@ -1351,13 +1349,8 @@
         1. Let _f_ be _maxFraction_.
         1. [declared="n1,r1"] Let _n1_ be an integer and _r1_ a mathematical value, with <emu-eqn>_r1_ = ToRawFixedFn(_n1_, _f_)</emu-eqn>, such that <emu-eqn>_n1_ modulo _roundingIncrement_ = 0</emu-eqn>, <emu-eqn>_r1_ ≤ _x_</emu-eqn>, and _r1_ is maximized.
         1. [declared="n2,r2"] Let _n2_ be an integer and _r2_ a mathematical value, with <emu-eqn>_r2_ = ToRawFixedFn(_n2_, _f_)</emu-eqn>, such that <emu-eqn>_n2_ modulo _roundingIncrement_ = 0</emu-eqn>, <emu-eqn>_r2_ ≥ _x_</emu-eqn>, and _r2_ is minimized.
-        1. Let _r_ be ApplyUnsignedRoundingMode(_x_, _r1_, _r2_, _unsignedRoundingMode_).
-        1. If _r_ is _r1_, then
-          1. Let _n_ be _n1_.
-          1. Let _xFinal_ be _r1_.
-        1. Else,
-          1. Let _n_ be _n2_.
-          1. Let _xFinal_ be _r2_.
+        1. Let _xFinal_ be ApplyUnsignedRoundingMode(_x_, _r1_, _r2_, _unsignedRoundingMode_).
+        1. If _xFinal_ is _r1_, let _n_ be _n1_. Otherwise, let _n_ be _n2_.
         1. If _n_ = 0, let _m_ be *"0"*. Otherwise, let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
         1. If _f_ ≠ 0, then
           1. Let _k_ be the length of _m_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -527,7 +527,7 @@
         In scientific notation, this slot affects the sign display of the mantissa but not the exponent.
       </li>
       <li>[[RoundingIncrement]] is an integer that evenly divides 10, 100, 1000, or 10000 into tenths, fifths, quarters, or halves. It indicates the increment at which rounding should take place relative to the calculated rounding magnitude. For example, if [[MaximumFractionDigits]] is 2 and [[RoundingIncrement]] is 5, then formatted numbers are rounded to the nearest 0.05 ("nickel rounding").</li>
-      <li>[[RoundingMode]] is one of the String values in the Identifier column of <emu-xref href="#table-intl-rounding-modes"></emu-xref>, specifying which rounding mode to use.</li>
+      <li>[[RoundingMode]] is a <dfn id="rounding-mode">rounding mode</dfn>, one of the String values in the Identifier column of <emu-xref href="#table-intl-rounding-modes"></emu-xref>.</li>
       <li>[[TrailingZeroDisplay]] is one of the String values *"auto"* or *"stripIfInteger"*, indicating whether to strip trailing zeros if the formatted number is an integer (i.e., has no non-zero fraction digit).</li>
     </ul>
 
@@ -1666,13 +1666,13 @@
     <emu-clause id="sec-getunsignedroundingmode" type="abstract operation">
       <h1>
         GetUnsignedRoundingMode (
-          _roundingMode_: a String,
+          _roundingMode_: a rounding mode,
           _sign_: ~negative~ or ~positive~,
         ): a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref>
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the rounding mode that should be applied to the absolute value of a number to produce the same result as if _roundingMode_, one of the String values in the Identifier column of <emu-xref href="#table-intl-rounding-modes"></emu-xref>, were applied to the signed value of the number (negative if _sign_ is ~negative~, or positive otherwise).</dd>
+        <dd>It returns the <emu-not-ref>rounding mode</emu-not-ref> that should be applied to the absolute value of a number to produce the same result as if _roundingMode_ were applied to the signed value of the number (negative if _sign_ is ~negative~, or positive otherwise).</dd>
       </dl>
       <emu-alg>
         1. Return the specification type in the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref> for the row where the value in the Identifier column is _roundingMode_ and the value in the Sign column is _sign_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -710,13 +710,14 @@
           1. If _x_ &lt; 0, let _sign_ be ~negative~; else let _sign_ be ~positive~.
           1. Set _x_ to abs(x).
         1. Let _roundingMode_ be _intlObject_.[[RoundingMode]].
+        1. Let _roundingIncrement_ be _intlObject_.[[RoundingIncrement]].
         1. If _intlObject_.[[RoundingType]] is ~significant-digits~, then
           1. Let _result_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _roundingMode_, _sign_).
         1. Else if _intlObject_.[[RoundingType]] is ~fraction-digits~, then
-          1. Let _result_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _roundingMode_, _sign_).
+          1. Let _result_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _roundingIncrement_, _roundingMode_, _sign_).
         1. Else,
           1. Let _sResult_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _roundingMode_, _sign_).
-          1. Let _fResult_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _roundingMode_, _sign_).
+          1. Let _fResult_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _roundingIncrement_, _roundingMode_, _sign_).
           1. If _fResult_.[[RoundingMagnitude]] &lt; _sResult_.[[RoundingMagnitude]], let _fixedIsMorePrecise_ be *true*; else let _fixedIsMorePrecise_ be *false*.
           1. If _intlObject_.[[RoundingType]] is ~more-precision~ and _fixedIsMorePrecise_ is *true*, then
             1. Let _result_ be _fResult_.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -534,6 +534,8 @@
     <emu-table id="table-intl-rounding-modes">
       <emu-caption>Rounding modes in Intl.NumberFormat</emu-caption>
       <table class="real-table">
+        <colgroup span="3"></colgroup>
+        <colgroup span="5" class="c-md-width" style="--c-md-width: 4em;"></colgroup>
         <thead>
           <tr>
             <th rowspan="2">Identifier</th>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -83,7 +83,7 @@
       </emu-normative-optional>
     </emu-clause>
 
-    <emu-clause id="sec-setnfdigitoptions" type="abstract operation">
+    <emu-clause id="sec-setnumberformatdigitoptions" oldids="sec-setnfdigitoptions" type="abstract operation">
       <h1>
         SetNumberFormatDigitOptions (
           _intlObj_: an Object,

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -235,7 +235,7 @@
       <li>[[RoundingType]] is one of the values ~fraction-digits~, ~significant-digits~, ~more-precision~, or ~less-precision~, indicating which rounding strategy to use, as discussed in <emu-xref href="#sec-properties-of-intl-numberformat-instances"></emu-xref>.</li>
       <li>[[ComputedRoundingPriority]] is one of the String values *"auto"*, *"morePrecision"*, or *"lessPrecision"*. It is only used in <emu-xref href="#sec-intl.pluralrules.prototype.resolvedoptions"></emu-xref> to convert [[RoundingType]] back to a valid *"roundingPriority"* option.</li>
       <li>[[RoundingIncrement]] is an integer that evenly divides 10, 100, 1000, or 10000 into tenths, fifths, quarters, or halves. It indicates the increment at which rounding should take place relative to the calculated rounding magnitude. For example, if [[MaximumFractionDigits]] is 2 and [[RoundingIncrement]] is 5, then formatted numbers are rounded to the nearest 0.05 ("nickel rounding").</li>
-      <li>[[RoundingMode]] is one of the String values in the Identifier column of <emu-xref href="#table-intl-rounding-modes"></emu-xref>, specifying which rounding mode to use.</li>
+      <li>[[RoundingMode]] identifies the rounding mode to use.</li>
       <li>[[TrailingZeroDisplay]] is one of the String values *"auto"* or *"stripIfInteger"*, indicating whether to strip trailing zeros if the formatted number is an integer (i.e., has no non-zero fraction digit).</li>
     </ul>
   </emu-clause>


### PR DESCRIPTION
* Fix `id` values to align with operation names.
* Refactor spec aliases and parameter types for readability.
* Collapse rounding mode negation data into one table.
* Fold GetUnsignedRoundingMode into ApplyUnsignedRoundingMode

