### PR TITLE
Meta: fix watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build-only -- --lint-spec --strict",
     "build-for-pdf": "npm run build -- --old-toc",
     "test": "npm run build-to -- --lint-spec /dev/null",
-    "watch": "npm run build -- --watch"
+    "watch": "npm run build-only -- --lint-spec --watch"
   },
   "repository": "tc39/ecma402",
   "author": "ECMA TC39",


### PR DESCRIPTION
At some point, ecmarkup stopped supporting --watch and --strict at the same time. This commit updates the watch script to not use --strict to make it work again.
