### PR TITLE
Editorial: Pass `%Intl.Segmenter%` to its invocation of `ResolveOptions`

### DIFF
--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -15,7 +15,7 @@
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _internalSlotsList_ be « [[InitializedSegmenter]], [[Locale]], [[SegmenterGranularity]] ».
         1. Let _segmenter_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.Segmenter.prototype%"*, _internalSlotsList_).
-        1. Let _optionsResolution_ be ? ResolveOptions(%Intl.NumberFormat%, %Intl.NumberFormat%.[[LocaleData]], _locales_, _options_).
+        1. Let _optionsResolution_ be ? ResolveOptions(%Intl.Segmenter%, %Intl.Segmenter%.[[LocaleData]], _locales_, _options_).
         1. Set _options_ to _optionsResolution_.[[Options]].
         1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
         1. Set _segmenter_.[[Locale]] to _r_.[[Locale]].


### PR DESCRIPTION
We do not want to use Intl.NumberFormat's internal slots here.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
