### PR TITLE
Editorial: Refer to language tags as "well-formed" rather than "structurally valid"

### DIFF
--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -235,7 +235,7 @@
       <emu-alg>
         1. If _type_ is *"language"*, then
           1. If _code_ cannot be matched by the <code>unicode_language_id</code> Unicode locale nonterminal, throw a *RangeError* exception.
-          1. If IsStructurallyValidLanguageTag(_code_) is *false*, throw a *RangeError* exception.
+          1. If IsWellFormedLanguageTag(_code_) is *false*, throw a *RangeError* exception.
           1. Return CanonicalizeUnicodeLocaleId(_code_).
         1. If _type_ is *"region"*, then
           1. If _code_ cannot be matched by the <code>unicode_region_subtag</code> Unicode locale nonterminal, throw a *RangeError* exception.

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -30,7 +30,7 @@
         1. Else,
           1. Let _tag_ be ? ToString(_tag_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
-        1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
+        1. If IsWellFormedLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
         1. NOTE: Because <a href="https://unicode.org/reports/tr35/#processing-languageids">LanguageId canonicalization</a> can alter _tag_ in arbitrary ways according to Alias Rules from <a href="https://github.com/unicode-org/cldr/blob/main/common/supplemental/supplementalMetadata.xml"><code>supplementalMetadata.xml</code></a>, it is necessary to perform such canonicalization before applying overrides from _options_.
         1. Set _tag_ to CanonicalizeUnicodeLocaleId(_tag_).
         1. Set _tag_ to ? UpdateLanguageId(_tag_, _options_).

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -31,9 +31,9 @@
 
     <p>All well-formed language tags are appropriate for use with the APIs defined by this specification, but implementations are not required to use Unicode Common Locale Data Repository (<a href="https://cldr.unicode.org">CLDR</a>) data for validating them; the set of locales and thus language tags that an implementation supports with adequate localizations is implementation-defined. <emu-xref href="#sec-constructor-properties-of-the-intl-object">Intl constructors</emu-xref> map requested language tags to locales supported by their respective implementations.</p>
 
-    <emu-clause id="sec-isstructurallyvalidlanguagetag" type="abstract operation">
+    <emu-clause id="sec-iswellformedlanguagetag" oldids="sec-isstructurallyvalidlanguagetag" type="abstract operation">
       <h1>
-        IsStructurallyValidLanguageTag (
+        IsWellFormedLanguageTag (
           _locale_: a String,
         ): a Boolean
       </h1>
@@ -105,7 +105,7 @@
       <h1>DefaultLocale ( ): a Unicode canonicalized locale identifier</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The returned String value represents the well-formed (<emu-xref href="#sec-isstructurallyvalidlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizeunicodelocaleid"></emu-xref>) language tag for the host environment's current locale. It must not contain a Unicode locale extension sequence.</dd>
+        <dd>The returned String value represents the well-formed (<emu-xref href="#sec-iswellformedlanguagetag"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizeunicodelocaleid"></emu-xref>) language tag for the host environment's current locale. It must not contain a Unicode locale extension sequence.</dd>
       </dl>
       <emu-note>
         The returned value is is a potential fingerprinting vector. In browser environments, it should match <a href="https://html.spec.whatwg.org/#language-preferences"><code>navigator.language</code></a> to avoid providing any additional distinguishing information.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -3,9 +3,9 @@
 
   <p><emu-xref href="#service-constructor">Service constructors</emu-xref> use common patterns to negotiate the requests represented by _locales_ and _options_ arguments against the actual capabilities of an implementation. That common behaviour is explained here in terms of internal slots describing the capabilities, abstract operations using these internal slots, and specialized data types defined below.</p>
 
-  <p>An <dfn id="available-locales-list">Available Locales List</dfn> is an arbitrarily-ordered duplicate-free List of language tags, each of which is <emu-xref href="#sec-isstructurallyvalidlanguagetag">well-formed</emu-xref>, <emu-xref href="#sec-canonicalizeunicodelocaleid">canonicalized</emu-xref>, and lacks a Unicode locale extension sequence. It represents all locales for which the implementation provides functionality within a particular context.</p>
+  <p>An <dfn id="available-locales-list">Available Locales List</dfn> is an arbitrarily-ordered duplicate-free List of language tags, each of which is <emu-xref href="#sec-iswellformedlanguagetag">well-formed</emu-xref>, <emu-xref href="#sec-canonicalizeunicodelocaleid">canonicalized</emu-xref>, and lacks a Unicode locale extension sequence. It represents all locales for which the implementation provides functionality within a particular context.</p>
 
-  <p>A <dfn id="language-priority-list">Language Priority List</dfn> is a List of <emu-xref href="#sec-isstructurallyvalidlanguagetag">well-formed</emu-xref> and <emu-xref href="#sec-canonicalizeunicodelocaleid">canonicalized</emu-xref> language tags representing a sequence of locale preferences by descending priority. It corresponds with the term of the same name defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-2.3">RFC 4647 section 2.3</a> but prohibits *"\*"* elements and contains only canonicalized contents.</p>
+  <p>A <dfn id="language-priority-list">Language Priority List</dfn> is a List of <emu-xref href="#sec-iswellformedlanguagetag">well-formed</emu-xref> and <emu-xref href="#sec-canonicalizeunicodelocaleid">canonicalized</emu-xref> language tags representing a sequence of locale preferences by descending priority. It corresponds with the term of the same name defined in <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47</a> at <a href="https://www.rfc-editor.org/rfc/rfc4647.html#section-2.3">RFC 4647 section 2.3</a> but prohibits *"\*"* elements and contains only canonicalized contents.</p>
 
   <p>A <dfn id="resolution-option-descriptor" variants="Resolution Option Descriptors">Resolution Option Descriptor</dfn> is a Record with fields [[Key]] (a string, usually an element of a [[RelevantExtensionKeys]] List) and [[Property]] (a string), and optionally also with either or both of [[Type]] (~boolean~ or ~string~) and [[Values]] (~empty~ or a List of ECMAScript language values). It describes how to read options relevant to locale resolution during object construction.</p>
 
@@ -64,7 +64,7 @@
               1. Let _tag_ be _kValue_.[[Locale]].
             1. Else,
               1. Let _tag_ be ? ToString(_kValue_).
-            1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
+            1. If IsWellFormedLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
             1. Let _canonicalizedTag_ be CanonicalizeUnicodeLocaleId(_tag_).
             1. If _seen_ does not contain _canonicalizedTag_, append _canonicalizedTag_ to _seen_.
           1. Set _k_ to _k_ + 1.
@@ -210,7 +210,7 @@
           1. Let _preExtension_ be the substring of _locale_ from 0 to _privateIndex_.
           1. Let _postExtension_ be the substring of _locale_ from _privateIndex_.
           1. Let _newLocale_ be the string-concatenation of _preExtension_, _extension_, and _postExtension_.
-        1. Assert: IsStructurallyValidLanguageTag(_newLocale_) is *true*.
+        1. Assert: IsWellFormedLanguageTag(_newLocale_) is *true*.
         1. Return CanonicalizeUnicodeLocaleId(_newLocale_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Includes renaming [IsStructurallyValidLanguageTag](https://tc39.es/ecma402/#sec-isstructurallyvalidlanguagetag) and making "well-formed language tag" an explicit auto-linked definition.