### PR TITLE
Normative: Add missing name property for %IntlSegmentsPrototype%[%Symbol.iterator%]

### DIFF
--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -212,6 +212,7 @@
           1. Let _string_ be _segments_.[[SegmentsString]].
           1. Return CreateSegmentIterator(_segmenter_, _string_).
         </emu-alg>
+        <p>The value of the *"name"* property of this function is *"[Symbol.iterator]"*.</p>
       </emu-clause>
     </emu-clause>
 


### PR DESCRIPTION
The function name must be explicitly specified for methods whose property key is a Symbol value.