### PR TITLE
Editorial: Use lists to describe Intl constructors and prototypes

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -3,7 +3,14 @@
 
   <emu-clause id="sec-intl-collator-constructor" oldids="sec-the-intl-collator-constructor">
     <h1>The Intl.Collator Constructor</h1>
-    <p>The Intl.Collator constructor is the <dfn>%Intl.Collator%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+
+    <p>The Intl.Collator constructor:</p>
+    <ul>
+      <li>is <dfn>%Intl.Collator%</dfn>.</li>
+      <li>is the initial value of the *"Collator"* property of the Intl object.</li>
+    </ul>
+
+    <p>Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
 
     <emu-clause id="sec-intl.collator" oldids="sec-initializecollator">
       <h1>Intl.Collator ( [ _locales_ [ , _options_ ] ] )</h1>
@@ -46,7 +53,11 @@
   <emu-clause id="sec-properties-of-the-intl-collator-constructor">
     <h1>Properties of the Intl.Collator Constructor</h1>
 
-    <p>The Intl.Collator constructor has the following properties:</p>
+    <p>The Intl.Collator constructor:</p>
+    <ul>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      <li>has the following properties:</li>
+    </ul>
 
     <emu-clause id="sec-intl.collator.prototype">
       <h1>Intl.Collator.prototype</h1>
@@ -93,7 +104,13 @@
   <emu-clause id="sec-properties-of-the-intl-collator-prototype-object">
     <h1>Properties of the Intl.Collator Prototype Object</h1>
 
-    <p>The Intl.Collator prototype object is itself an ordinary object. <dfn>%Intl.Collator.prototype%</dfn> is not an Intl.Collator instance and does not have an [[InitializedCollator]] internal slot or any of the other internal slots of Intl.Collator instance objects.</p>
+    <p>The <dfn>Intl.Collator prototype object</dfn>:</p>
+    <ul>
+      <li>is <dfn>%Intl.Collator.prototype%</dfn>.</li>
+      <li>is an ordinary object.</li>
+      <li>is not an Intl.Collator instance and does not have an [[InitializedCollator]] internal slot or any of the other internal slots of Intl.Collator instance objects.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    </ul>
 
     <emu-clause id="sec-intl.collator.prototype.constructor">
       <h1>Intl.Collator.prototype.constructor</h1>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -4,7 +4,13 @@
   <emu-clause id="sec-intl-datetimeformat-constructor">
     <h1>The Intl.DateTimeFormat Constructor</h1>
 
-    <p>The Intl.DateTimeFormat constructor is the <dfn>%Intl.DateTimeFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+    <p>The Intl.DateTimeFormat constructor:</p>
+    <ul>
+      <li>is <dfn>%Intl.DateTimeFormat%</dfn>.</li>
+      <li>is the initial value of the *"DateTimeFormat"* property of the Intl object.</li>
+    </ul>
+
+    <p>Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
 
     <emu-clause id="sec-intl.datetimeformat">
       <h1>Intl.DateTimeFormat ( [ _locales_ [ , _options_ ] ] )</h1>
@@ -174,7 +180,11 @@
   <emu-clause id="sec-properties-of-intl-datetimeformat-constructor">
     <h1>Properties of the Intl.DateTimeFormat Constructor</h1>
 
-    <p>The Intl.DateTimeFormat constructor has the following properties:</p>
+    <p>The Intl.DateTimeFormat constructor:</p>
+    <ul>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      <li>has the following properties:</li>
+    </ul>
 
     <emu-clause id="sec-intl.datetimeformat.prototype">
       <h1>Intl.DateTimeFormat.prototype</h1>
@@ -848,7 +858,13 @@
   <emu-clause id="sec-properties-of-intl-datetimeformat-prototype-object">
     <h1>Properties of the Intl.DateTimeFormat Prototype Object</h1>
 
-    <p>The Intl.DateTimeFormat prototype object is itself an ordinary object. <dfn>%Intl.DateTimeFormat.prototype%</dfn> is not an Intl.DateTimeFormat instance and does not have an [[InitializedDateTimeFormat]] internal slot or any of the other internal slots of Intl.DateTimeFormat instance objects.</p>
+    <p>The <dfn>Intl.DateTimeFormat prototype object</dfn>:</p>
+    <ul>
+      <li>is <dfn>%Intl.DateTimeFormat.prototype%</dfn>.</li>
+      <li>is an ordinary object.</li>
+      <li>is not an Intl.DateTimeFormat instance and does not have an [[InitializedDateTimeFormat]] internal slot or any of the other internal slots of Intl.DateTimeFormat instance objects.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    </ul>
 
     <emu-clause id="sec-intl.datetimeformat.prototype.constructor">
       <h1>Intl.DateTimeFormat.prototype.constructor</h1>

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -4,7 +4,13 @@
   <emu-clause id="sec-intl-displaynames-constructor">
     <h1>The Intl.DisplayNames Constructor</h1>
 
-    <p>The DisplayNames constructor is the <dfn>%Intl.DisplayNames%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+    <p>The Intl.DisplayNames constructor:</p>
+    <ul>
+      <li>is <dfn>%Intl.DisplayNames%</dfn>.</li>
+      <li>is the initial value of the *"DisplayNames"* property of the Intl object.</li>
+    </ul>
+
+    <p>Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
 
     <emu-clause id="sec-Intl.DisplayNames">
       <h1>Intl.DisplayNames ( _locales_, _options_ )</h1>
@@ -46,7 +52,11 @@
   <emu-clause id="sec-properties-of-intl-displaynames-constructor">
     <h1>Properties of the Intl.DisplayNames Constructor</h1>
 
-    <p>The Intl.DisplayNames constructor has the following properties:</p>
+    <p>The Intl.DisplayNames constructor:</p>
+    <ul>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      <li>has the following properties:</li>
+    </ul>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype">
       <h1>Intl.DisplayNames.prototype</h1>
@@ -100,7 +110,13 @@
   <emu-clause id="sec-properties-of-intl-displaynames-prototype-object">
     <h1>Properties of the Intl.DisplayNames Prototype Object</h1>
 
-    <p>The Intl.DisplayNames prototype object is itself an ordinary object. <dfn>%Intl.DisplayNames.prototype%</dfn> is not an Intl.DisplayNames instance and does not have an [[InitializedDisplayNames]] internal slot or any of the other internal slots of Intl.DisplayNames instance objects.</p>
+    <p>The <dfn>Intl.DisplayNames prototype object</dfn>:</p>
+    <ul>
+      <li>is <dfn>%Intl.DisplayNames.prototype%</dfn>.</li>
+      <li>is an ordinary object.</li>
+      <li>is not an Intl.DisplayNames instance and does not have an [[InitializedDisplayNames]] internal slot or any of the other internal slots of Intl.DisplayNames instance objects.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    </ul>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype.constructor">
       <h1>Intl.DisplayNames.prototype.constructor</h1>

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -4,7 +4,13 @@
   <emu-clause id="sec-intl-durationformat-constructor">
     <h1>The Intl.DurationFormat Constructor</h1>
 
-    <p>The DurationFormat constructor is the <dfn>%Intl.DurationFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+    <p>The Intl.DurationFormat constructor:</p>
+    <ul>
+      <li>is <dfn>%Intl.DurationFormat%</dfn>.</li>
+      <li>is the initial value of the *"DurationFormat"* property of the Intl object.</li>
+    </ul>
+
+    <p>Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
 
     <emu-clause id="sec-Intl.DurationFormat">
       <h1>Intl.DurationFormat ( [ _locales_ [ , _options_ ] ] )</h1>
@@ -117,7 +123,11 @@
   <emu-clause id="sec-properties-of-intl-durationformat-constructor">
     <h1>Properties of the Intl.DurationFormat Constructor</h1>
 
-    <p>The Intl.DurationFormat constructor has the following properties:</p>
+    <p>The Intl.DurationFormat constructor:</p>
+    <ul>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      <li>has the following properties:</li>
+    </ul>
 
     <emu-clause id="sec-Intl.DurationFormat.prototype">
       <h1>Intl.DurationFormat.prototype</h1>
@@ -169,7 +179,13 @@
   <emu-clause id="sec-properties-of-intl-durationformat-prototype-object">
     <h1>Properties of the Intl.DurationFormat Prototype Object</h1>
 
-    <p>The Intl.DurationFormat prototype object is itself an ordinary object. <dfn>%Intl.DurationFormat.prototype%</dfn> is not an Intl.DurationFormat instance and does not have an [[InitializedDurationFormat]] internal slot or any of the other internal slots of Intl.DurationFormat instance objects.</p>
+    <p>The <dfn>Intl.DurationFormat prototype object</dfn>:</p>
+    <ul>
+      <li>is <dfn>%Intl.DurationFormat.prototype%</dfn>.</li>
+      <li>is an ordinary object.</li>
+      <li>is not an Intl.DurationFormat instance and does not have an [[InitializedDurationFormat]] internal slot or any of the other internal slots of Intl.DurationFormat instance objects.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    </ul>
 
     <emu-clause id="sec-Intl.DurationFormat.prototype.constructor">
       <h1>Intl.DurationFormat.prototype.constructor</h1>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1,12 +1,17 @@
 <emu-clause id="intl-object">
   <h1>The Intl Object</h1>
-  <p>The Intl object is the <dfn>%Intl%</dfn> intrinsic object and the initial value of the *"Intl"* property of the global object. The Intl object is a single ordinary object.</p>
 
-  <p>The value of the [[Prototype]] internal slot of the Intl object is the intrinsic object %Object.prototype%.</p>
-
-  <p>The Intl object is not a function object. It does not have a [[Construct]] internal method; it is not possible to use the Intl object as a constructor with the `new` operator. The Intl object does not have a [[Call]] internal method; it is not possible to invoke the Intl object as a function.</p>
-
-  <p>The Intl object has an internal slot, [[FallbackSymbol]], which is a new %Symbol% in the current realm with the [[Description]] *"IntlLegacyConstructedSymbol"*.</p>
+  <p>The <dfn>Intl object</dfn>:</p>
+  <ul>
+    <li>is <dfn>%Intl%</dfn>.</li>
+    <li>is the initial value of the *"Intl"* property of the global object.</li>
+    <li>is an ordinary object.</li>
+    <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    <li>is not a function object.</li>
+    <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
+    <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
+    <li>has a [[FallbackSymbol]] internal slot, which is a new %Symbol% in the current realm with the [[Description]] *"IntlLegacyConstructedSymbol"*.</li>
+  </ul>
 
   <emu-clause id="sec-value-properties-of-the-intl-object">
     <h1>Value Properties of the Intl Object</h1>

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -4,7 +4,13 @@
   <emu-clause id="sec-intl-listformat-constructor">
     <h1>The Intl.ListFormat Constructor</h1>
 
-    <p>The ListFormat constructor is the <dfn>%Intl.ListFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+    <p>The Intl.ListFormat constructor:</p>
+    <ul>
+      <li>is <dfn>%Intl.ListFormat%</dfn>.</li>
+      <li>is the initial value of the *"ListFormat"* property of the Intl object.</li>
+    </ul>
+
+    <p>Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
 
     <emu-clause id="sec-Intl.ListFormat">
       <h1>Intl.ListFormat ( [ _locales_ [ , _options_ ] ] )</h1>
@@ -33,7 +39,11 @@
   <emu-clause id="sec-properties-of-intl-listformat-constructor">
     <h1>Properties of the Intl.ListFormat Constructor</h1>
 
-    <p>The Intl.ListFormat constructor has the following properties:</p>
+    <p>The Intl.ListFormat constructor:</p>
+    <ul>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      <li>has the following properties:</li>
+    </ul>
 
     <emu-clause id="sec-Intl.ListFormat.prototype">
       <h1>Intl.ListFormat.prototype</h1>
@@ -87,7 +97,13 @@
   <emu-clause id="sec-properties-of-intl-listformat-prototype-object">
     <h1>Properties of the Intl.ListFormat Prototype Object</h1>
 
-    <p>The Intl.ListFormat prototype object is itself an ordinary object. <dfn>%Intl.ListFormat.prototype%</dfn> is not an Intl.ListFormat instance and does not have an [[InitializedListFormat]] internal slot or any of the other internal slots of Intl.ListFormat instance objects.</p>
+    <p>The <dfn>Intl.ListFormat prototype object</dfn>:</p>
+    <ul>
+      <li>is <dfn>%Intl.ListFormat.prototype%</dfn>.</li>
+      <li>is an ordinary object.</li>
+      <li>is not an Intl.ListFormat instance and does not have an [[InitializedListFormat]] internal slot or any of the other internal slots of Intl.ListFormat instance objects.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    </ul>
 
     <emu-clause id="sec-Intl.ListFormat.prototype.constructor">
       <h1>Intl.ListFormat.prototype.constructor</h1>

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -4,7 +4,11 @@
   <emu-clause id="sec-intl-locale-constructor">
     <h1>The Intl.Locale Constructor</h1>
 
-    <p>The Locale constructor is the <dfn>%Intl.Locale%</dfn> intrinsic object and a standard built-in property of the Intl object.</p>
+    <p>The Intl.Locale constructor:</p>
+    <ul>
+      <li>is <dfn>%Intl.Locale%</dfn>.</li>
+      <li>is the initial value of the *"Locale"* property of the Intl object.</li>
+    </ul>
 
     <emu-clause id="sec-Intl.Locale">
       <h1>Intl.Locale ( _tag_ [ , _options_ ] )</h1>
@@ -156,7 +160,11 @@
   <emu-clause id="sec-properties-of-intl-locale-constructor">
     <h1>Properties of the Intl.Locale Constructor</h1>
 
-    <p>The Intl.Locale constructor has the following properties:</p>
+    <p>The Intl.Locale constructor:</p>
+    <ul>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      <li>has the following properties:</li>
+    </ul>
 
     <emu-clause id="sec-Intl.Locale.prototype">
       <h1>Intl.Locale.prototype</h1>
@@ -175,7 +183,13 @@
   <emu-clause id="sec-properties-of-intl-locale-prototype-object">
     <h1>Properties of the Intl.Locale Prototype Object</h1>
 
-    <p>The Intl.Locale prototype object is itself an ordinary object. <dfn>%Intl.Locale.prototype%</dfn> is not an Intl.Locale instance and does not have an [[InitializedLocale]] internal slot or any of the other internal slots of Intl.Locale instance objects.</p>
+    <p>The <dfn>Intl.Locale prototype object</dfn>:</p>
+    <ul>
+      <li>is <dfn>%Intl.Locale.prototype%</dfn>.</li>
+      <li>is an ordinary object.</li>
+      <li>is not an Intl.Locale instance and does not have an [[InitializedLocale]] internal slot or any of the other internal slots of Intl.Locale instance objects.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    </ul>
 
     <emu-clause id="sec-Intl.Locale.prototype.constructor">
       <h1>Intl.Locale.prototype.constructor</h1>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -4,7 +4,13 @@
   <emu-clause id="sec-intl-numberformat-constructor">
     <h1>The Intl.NumberFormat Constructor</h1>
 
-    <p>The NumberFormat constructor is the <dfn>%Intl.NumberFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+    <p>The Intl.NumberFormat constructor:</p>
+    <ul>
+      <li>is <dfn>%Intl.NumberFormat%</dfn>.</li>
+      <li>is the initial value of the *"NumberFormat"* property of the Intl object.</li>
+    </ul>
+
+    <p>Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
 
     <emu-clause id="sec-intl.numberformat" oldids="sec-initializenumberformat">
       <h1>Intl.NumberFormat ( [ _locales_ [ , _options_ ] ] )</h1>
@@ -199,7 +205,11 @@
   <emu-clause id="sec-properties-of-intl-numberformat-constructor">
     <h1>Properties of the Intl.NumberFormat Constructor</h1>
 
-    <p>The Intl.NumberFormat constructor has the following properties:</p>
+    <p>The Intl.NumberFormat constructor:</p>
+    <ul>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      <li>has the following properties:</li>
+    </ul>
 
     <emu-clause id="sec-intl.numberformat.prototype">
       <h1>Intl.NumberFormat.prototype</h1>
@@ -264,7 +274,13 @@
   <emu-clause id="sec-properties-of-intl-numberformat-prototype-object">
     <h1>Properties of the Intl.NumberFormat Prototype Object</h1>
 
-    <p>The Intl.NumberFormat prototype object is itself an ordinary object. <dfn>%Intl.NumberFormat.prototype%</dfn> is not an Intl.NumberFormat instance and does not have an [[InitializedNumberFormat]] internal slot or any of the other internal slots of Intl.NumberFormat instance objects.</p>
+    <p>The <dfn>Intl.NumberFormat prototype object</dfn>:</p>
+    <ul>
+      <li>is <dfn>%Intl.NumberFormat.prototype%</dfn>.</li>
+      <li>is an ordinary object.</li>
+      <li>is not an Intl.NumberFormat instance and does not have an [[InitializedNumberFormat]] internal slot or any of the other internal slots of Intl.NumberFormat instance objects.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    </ul>
 
     <emu-clause id="sec-intl.numberformat.prototype.constructor">
       <h1>Intl.NumberFormat.prototype.constructor</h1>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -4,7 +4,13 @@
   <emu-clause id="sec-intl-pluralrules-constructor">
     <h1>The Intl.PluralRules Constructor</h1>
 
-    <p>The PluralRules constructor is the <dfn>%Intl.PluralRules%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+    <p>The Intl.PluralRules constructor:</p>
+    <ul>
+      <li>is <dfn>%Intl.PluralRules%</dfn>.</li>
+      <li>is the initial value of the *"PluralRules"* property of the Intl object.</li>
+    </ul>
+
+    <p>Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
 
     <emu-clause id="sec-intl.pluralrules" oldids="sec-initializepluralrules">
       <h1>Intl.PluralRules ( [ _locales_ [ , _options_ ] ] )</h1>
@@ -31,7 +37,11 @@
   <emu-clause id="sec-properties-of-intl-pluralrules-constructor">
     <h1>Properties of the Intl.PluralRules Constructor</h1>
 
-    <p>The Intl.PluralRules constructor has the following properties:</p>
+    <p>The Intl.PluralRules constructor:</p>
+    <ul>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      <li>has the following properties:</li>
+    </ul>
 
     <emu-clause id="sec-intl.pluralrules.prototype">
       <h1>Intl.PluralRules.prototype</h1>
@@ -76,7 +86,13 @@
   <emu-clause id="sec-properties-of-intl-pluralrules-prototype-object">
     <h1>Properties of the Intl.PluralRules Prototype Object</h1>
 
-    <p>The Intl.PluralRules prototype object is itself an ordinary object. <dfn>%Intl.PluralRules.prototype%</dfn> is not an Intl.PluralRules instance and does not have an [[InitializedPluralRules]] internal slot or any of the other internal slots of Intl.PluralRules instance objects.</p>
+    <p>The <dfn>Intl.PluralRules prototype object</dfn>:</p>
+    <ul>
+      <li>is <dfn>%Intl.PluralRules.prototype%</dfn>.</li>
+      <li>is an ordinary object.</li>
+      <li>is not an Intl.PluralRules instance and does not have an [[InitializedPluralRules]] internal slot or any of the other internal slots of Intl.PluralRules instance objects.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    </ul>
 
     <emu-clause id="sec-intl.pluralrules.prototype.constructor">
       <h1>Intl.PluralRules.prototype.constructor</h1>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -4,7 +4,13 @@
   <emu-clause id="sec-intl-relativetimeformat-constructor">
     <h1>The Intl.RelativeTimeFormat Constructor</h1>
 
-    <p>The RelativeTimeFormat constructor is the <dfn>%Intl.RelativeTimeFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+    <p>The Intl.RelativeTimeFormat constructor:</p>
+    <ul>
+      <li>is <dfn>%Intl.RelativeTimeFormat%</dfn>.</li>
+      <li>is the initial value of the *"RelativeTimeFormat"* property of the Intl object.</li>
+    </ul>
+
+    <p>Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat" oldids="sec-InitializeRelativeTimeFormat">
       <h1>Intl.RelativeTimeFormat ( [ _locales_ [ , _options_ ] ] )</h1>
@@ -37,7 +43,11 @@
   <emu-clause id="sec-properties-of-intl-relativetimeformat-constructor">
     <h1>Properties of the Intl.RelativeTimeFormat Constructor</h1>
 
-    <p>The Intl.RelativeTimeFormat constructor has the following properties:</p>
+    <p>The Intl.RelativeTimeFormat constructor:</p>
+    <ul>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      <li>has the following properties:</li>
+    </ul>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat.prototype">
       <h1>Intl.RelativeTimeFormat.prototype</h1>
@@ -94,7 +104,13 @@
   <emu-clause id="sec-properties-of-intl-relativetimeformat-prototype-object">
     <h1>Properties of the Intl.RelativeTimeFormat Prototype Object</h1>
 
-    <p>The Intl.RelativeTimeFormat prototype object is itself an ordinary object. <dfn>%Intl.RelativeTimeFormat.prototype%</dfn> is not an Intl.RelativeTimeFormat instance and does not have an [[InitializedRelativeTimeFormat]] internal slot or any of the other internal slots of Intl.RelativeTimeFormat instance objects.</p>
+    <p>The <dfn>Intl.RelativeTimeFormat prototype object</dfn>:</p>
+    <ul>
+      <li>is <dfn>%Intl.RelativeTimeFormat.prototype%</dfn>.</li>
+      <li>is an ordinary object.</li>
+      <li>is not an Intl.RelativeTimeFormat instance and does not have an [[InitializedRelativeTimeFormat]] internal slot or any of the other internal slots of Intl.RelativeTimeFormat instance objects.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    </ul>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat.prototype.constructor">
       <h1>Intl.RelativeTimeFormat.prototype.constructor</h1>

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -4,7 +4,13 @@
   <emu-clause id="sec-intl-segmenter-constructor">
     <h1>The Intl.Segmenter Constructor</h1>
 
-    <p>The Segmenter constructor is the <dfn>%Intl.Segmenter%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+    <p>The Intl.Segmenter constructor:</p>
+    <ul>
+      <li>is <dfn>%Intl.Segmenter%</dfn>.</li>
+      <li>is the initial value of the *"Segmenter"* property of the Intl object.</li>
+    </ul>
+
+    <p>Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
 
     <emu-clause id="sec-intl.segmenter">
       <h1>Intl.Segmenter ( [ _locales_ [ , _options_ ] ] )</h1>
@@ -29,7 +35,11 @@
   <emu-clause id="sec-properties-of-intl-segmenter-constructor">
     <h1>Properties of the Intl.Segmenter Constructor</h1>
 
-    <p>The Intl.Segmenter constructor has the following properties:</p>
+    <p>The Intl.Segmenter constructor:</p>
+    <ul>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+      <li>has the following properties:</li>
+    </ul>
 
     <emu-clause id="sec-intl.segmenter.prototype">
       <h1>Intl.Segmenter.prototype</h1>
@@ -69,7 +79,13 @@
   <emu-clause id="sec-properties-of-intl-segmenter-prototype-object">
     <h1>Properties of the Intl.Segmenter Prototype Object</h1>
 
-    <p>The Intl.Segmenter prototype object is itself an ordinary object. <dfn>%Intl.Segmenter.prototype%</dfn> is not an Intl.Segmenter instance and does not have an [[InitializedSegmenter]] internal slot or any of the other internal slots of Intl.Segmenter instance objects.</p>
+    <p>The <dfn>Intl.Segmenter prototype object</dfn>:</p>
+    <ul>
+      <li>is <dfn>%Intl.Segmenter.prototype%</dfn>.</li>
+      <li>is an ordinary object.</li>
+      <li>is not an Intl.Segmenter instance and does not have an [[InitializedSegmenter]] internal slot or any of the other internal slots of Intl.Segmenter instance objects.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+    </ul>
 
     <emu-clause id="sec-intl.segmenter.prototype.constructor">
       <h1>Intl.Segmenter.prototype.constructor</h1>
@@ -182,6 +198,7 @@
       <ul>
         <li>is the prototype of all Segments objects.</li>
         <li>is an ordinary object.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -258,7 +275,7 @@
       <ul>
         <li>is the prototype of all Segment Iterator objects.</li>
         <li>is an ordinary object.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Iterator.prototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Iterator.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
 


### PR DESCRIPTION
Update descriptions of constructors and prototypes to use `<ul>` elements. This matches the style used in ECMA-262.

The [[Prototype]] is now also always defined, even if it matches the default prototype defined in <https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects>. This is also done to mimic definitions from ECMA-262.