### PR TITLE
Normative: Add [[CompactDisplay]] slot to Intl.PluralRules

### DIFF
--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -19,7 +19,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.PluralRules.prototype%"*, « [[InitializedPluralRules]], [[Locale]], [[Type]], [[Notation]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]] »).
+        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.PluralRules.prototype%"*, « [[InitializedPluralRules]], [[Locale]], [[Type]], [[Notation]], [[CompactDisplay]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]] »).
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.PluralRules%, %Intl.PluralRules%.[[LocaleData]], _locales_, _options_, « ~coerce-options~ »).
         1. Set _options_ to _optionsResolution_.[[Options]].
         1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
@@ -29,6 +29,9 @@
         1. Let _notation_ be ? GetOption(_options_, *"notation"*, ~string~, « *"standard"*, *"scientific"*, *"engineering"*, *"compact"* », *"standard"*).
         1. Set _pluralRules_.[[Notation]] to _notation_.
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, 0, 3, _notation_).
+        1. Let _compactDisplay_ be ? GetOption(_options_, *"compactDisplay"*, ~string~, « *"short"*, *"long"* », *"short"*).
+        1. If _notation_ is *"compact"*, then
+          1. Set _pluralRules_.[[CompactDisplay]] to _compactDisplay_.
         1. Return _pluralRules_.
       </emu-alg>
     </emu-clause>
@@ -150,6 +153,11 @@
             <td></td>
           </tr>
           <tr>
+            <td>[[CompactDisplay]]</td>
+            <td>*"compactDisplay"*</td>
+            <td></td>
+          </tr>
+          <tr>
             <td>[[MinimumIntegerDigits]]</td>
             <td>*"minimumIntegerDigits"*</td>
             <td>~number~</td>
@@ -252,6 +260,7 @@
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used by the plural rules.</li>
       <li>[[Type]] is one of the String values *"cardinal"* or *"ordinal"*, identifying the plural rules used.</li>
       <li>[[Notation]] is one of the String values *"standard"*, *"scientific"*, *"engineering"*, or *"compact"*, identifying the notation used.</li>
+      <li>[[CompactDisplay]] is one of the String values *"short"* or *"long"*, specifying whether to display compact notation affixes in short form ("5K") or long form ("5 thousand") if formatting with the *"compact"* notation, as this can in some cases influence plural form selection. It is only used when [[Notation]] has the value *"compact"*.</li>
       <li>[[MinimumIntegerDigits]] is a non-negative integer indicating the minimum integer digits to be used.</li>
       <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative integers indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
       <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integers indicating the minimum and maximum fraction digits to be used. Either none or both of these properties are present; if they are, they override minimum and maximum integer and fraction digits.</li>
@@ -269,15 +278,13 @@
     <emu-clause id="sec-pluralruleselect" type="implementation-defined abstract operation">
       <h1>
         PluralRuleSelect (
-          _locale_: a language tag,
-          _type_: *"cardinal"* or *"ordinal"*,
-          _notation_: a String,
+          _pluralRules_: an Intl.PluralRules,
           _s_: a decimal String,
         ): *"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, or *"other"*
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The returned String characterizes the plural category of _s_ according to _locale_, _type_, and _notation_.</dd>
+        <dd>The returned String characterizes the plural category of _s_ according to the effective locale and the internal slots of _pluralRules_: [[Type]], one of the String values *"cardinal"* or *"ordinal"*, [[Notation]], specifying the notation used, and [[CompactDisplay]], specifying whether compact notation affixes are to be displayed in short form or long form.</dd>
       </dl>
     </emu-clause>
 
@@ -298,10 +305,7 @@
           1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _s_ }.
         1. Let _res_ be FormatNumericToString(_pluralRules_, ℝ(_n_)).
         1. Let _s_ be _res_.[[FormattedString]].
-        1. Let _locale_ be _pluralRules_.[[Locale]].
-        1. Let _type_ be _pluralRules_.[[Type]].
-        1. Let _notation_ be _pluralRules_.[[Notation]].
-        1. Let _p_ be PluralRuleSelect(_locale_, _type_, _notation_, _s_).
+        1. Let _p_ be PluralRuleSelect(_pluralRules_, _s_).
         1. Return the Record { [[PluralCategory]]: _p_, [[FormattedString]]: _s_ }.
       </emu-alg>
     </emu-clause>
@@ -309,16 +313,14 @@
     <emu-clause id="sec-pluralruleselectrange" type="implementation-defined abstract operation">
       <h1>
         PluralRuleSelectRange (
-          _locale_: a String,
-          _type_: *"cardinal"* or *"ordinal"*,
-          _notation_: a String,
+          _pluralRules_: an Intl.PluralRules,
           _xp_: *"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, or *"other"*,
           _yp_: *"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, or *"other"*,
         ): *"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, or *"other"*
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It performs an implementation-dependent algorithm to map the <emu-xref href="#sec-pluralruleselect">plural category</emu-xref> String values _xp_ and _yp_, respectively characterizing the start and end of a range, to a resolved String value for the plural form of the range as a whole denoted by _type_ and _notation_ for the corresponding _locale_, or the String value *"other"*.</dd>
+        <dd>It performs an implementation-dependent algorithm to map the <emu-xref href="#sec-pluralruleselect">plural category</emu-xref> String values _xp_ and _yp_, respectively characterizing the start and end of a range, to a resolved String value for the plural form of the range as a whole, according to the effective locale and the internal slots of _pluralRules_: [[Type]], one of the String values *"cardinal"* or *"ordinal"*, [[Notation]], specifying the notation used, and [[CompactDisplay]], specifying whether compact notation affixes are displayed in short form or long form. If no such mapping is possible, it returns the String value *"other"*.</dd>
       </dl>
     </emu-clause>
 
@@ -340,10 +342,7 @@
         1. Let _yp_ be ResolvePlural(_pluralRules_, _y_).
         1. If _xp_.[[FormattedString]] is _yp_.[[FormattedString]], then
           1. Return _xp_.[[PluralCategory]].
-        1. Let _locale_ be _pluralRules_.[[Locale]].
-        1. Let _type_ be _pluralRules_.[[Type]].
-        1. Let _notation_ be _pluralRules_.[[Notation]].
-        1. Return PluralRuleSelectRange(_locale_, _type_, _notation_, _xp_.[[PluralCategory]], _yp_.[[PluralCategory]]).
+        1. Return PluralRuleSelectRange(_pluralRules_, _xp_.[[PluralCategory]], _yp_.[[PluralCategory]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This PR allows implementations to take into account potential differences between the short compact form ("5K") and long form ("5 thousand") when determining the correct plural form to use.