### PR TITLE
Normative: Increase limits on Intl MV and explicitly limit significant digits

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1659,11 +1659,13 @@
         1. If _literal_ is a List of errors, return ~not-a-number~.
         1. Let _intlMV_ be the StringIntlMV of _literal_.
         1. If _intlMV_ is a mathematical value, then
-          1. Let _rounded_ be RoundMVResult(abs(_intlMV_)).
-          1. If _rounded_ is *+∞*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-infinity~.
-          1. If _rounded_ is *+∞*<sub>𝔽</sub>, return ~positive-infinity~.
-          1. If _rounded_ is *+0*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-zero~.
-          1. If _rounded_ is *+0*<sub>𝔽</sub>, return 0.
+          1. Let _e_ be the integer such that 10<sup>_e_</sup> ≤ abs(_intlMV_) &lt; 10<sup>_e_ + 1</sup>.
+          1. If _e_ ≥ 10000, then
+            1. If _intlMV_ &lt; 0, return ~negative-infinity~.
+            1. Else, return ~positive-infinity~.
+          1. If _e_ &lt; -10000, then
+            1. If _intlMV_ &lt; 0, return ~negative-zero~.
+            1. Else, return 0.
         1. Return _intlMV_.
       </emu-alg>
     </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -1666,6 +1666,11 @@
           1. If _e_ &lt; -10000, then
             1. If _intlMV_ &lt; 0, return ~negative-zero~.
             1. Else, return 0.
+          1. Let _q_ be the largest integer such that _intlMV_ × 10<sup>-_q_</sup> is an integer.
+          1. If _q_ &lt; -10000, then
+            1. Let _truncated_ be the largest mathematical value such that _truncated_ × 10<sup>10000</sup> is an integer and _truncated_ &lt; abs(_intlMV_).
+            1. If _intlMV_ &lt; 0, return -_truncated_.
+            1. Else, return _truncated_.
         1. Return _intlMV_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
See #1017

The intent of this PR is the following. In this table, `99~9` stands in for 9999 digit 9s, and `999~9` stands in for 10000 digit 9s.

| Input String MV | Resolved MV | Comments |
|---|---|---|
| 1e9999 | 1e9999 |
| 99~9e9999 | 99~9e9999 |
| 99\~9.999\~9e9999 | 99~9e9999 | Largest in-bounds value |
| 1e10000 | ∞ | Smallest out-of-bounds value |
| 1e-10000 | 1e-10000 | Smallest in-bounds value |
| 9e-10001 | 0 |
| 0.999~9 | 0.999~9 |
| 0.999~98 | 0.999~9 | Truncate such that the least significant digit is at 1e-10000 |
|1.9e-10000 | 1e-10000 | ^ |
| 1.234e-9998 | 1.23e-9998 | ^ |
