### PR TITLE
Typo fix: Intl.NumberFormat's SetNumberFormatDigitOptions AO

### DIFF
--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -111,7 +111,7 @@
         1. Set _intlObj_.[[RoundingMode]] to _roundingMode_.
         1. Set _intlObj_.[[TrailingZeroDisplay]] to _trailingZeroDisplay_.
         1. If _mnsd_ is *undefined* and _mxsd_ is *undefined*, let _hasSd_ be *false*. Otherwise, let _hasSd_ be *true*.
-        1. If _mnfd_ is *undefined* and _mxsd_ is *undefined*, let _hasFd_ be *false*. Otherwise, let _hasFd_ be *true*.
+        1. If _mnfd_ is *undefined* and _mxfd_ is *undefined*, let _hasFd_ be *false*. Otherwise, let _hasFd_ be *true*.
         1. Let _needSd_ be *true*.
         1. Let _needFd_ be *true*.
         1. If _roundingPriority_ is *"auto"*, then


### PR DESCRIPTION
As the result of a typo in #796 (cf. 053a606ce2d1355be419891796fce31d7571acf9), _mxsd_ was checked rather than _mxfd_ when determining value of _hasFd_. This fixes that.

fix #1023 

