### PR TITLE
Normative: Make `Intl.PluralRules` `ResolvePlural` and associated AOs take Intl mathematical values rather than Numbers

### DIFF
--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -211,7 +211,7 @@
       <emu-alg>
         1. Let _pr_ be the *this* value.
         1. Perform ? RequireInternalSlot(_pr_, [[InitializedPluralRules]]).
-        1. Let _n_ be ? ToNumber(_value_).
+        1. Let _n_ be ? ToIntlMathematicalValue(_value_).
         1. Return ResolvePlural(_pr_, _n_).[[PluralCategory]].
       </emu-alg>
     </emu-clause>
@@ -225,8 +225,8 @@
         1. Let _pr_ be the *this* value.
         1. Perform ? RequireInternalSlot(_pr_, [[InitializedPluralRules]]).
         1. If _start_ is *undefined* or _end_ is *undefined*, throw a *TypeError* exception.
-        1. Let _x_ be ? ToNumber(_start_).
-        1. Let _y_ be ? ToNumber(_end_).
+        1. Let _x_ be ? ToIntlMathematicalValue(_start_).
+        1. Let _y_ be ? ToIntlMathematicalValue(_end_).
         1. Return ? ResolvePluralRange(_pr_, _x_, _y_).
       </emu-alg>
     </emu-clause>
@@ -285,7 +285,7 @@
       <h1>
         ResolvePlural (
           _pluralRules_: an Intl.PluralRules,
-          _n_: a Number,
+          _n_: an Intl mathematical value,
         ): a Record with fields [[PluralCategory]] (*"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, or *"other"*) and [[FormattedString]] (a String)
       </h1>
       <dl class="header">
@@ -293,10 +293,16 @@
         <dd>The returned Record contains two string-valued fields describing _n_ according to the effective locale and the options of _pluralRules_: [[PluralCategory]] characterizing its <emu-xref href="#sec-pluralruleselect">plural category</emu-xref>, and [[FormattedString]] containing its formatted representation.</dd>
       </dl>
       <emu-alg>
-        1. If _n_ is not a finite Number, then
-          1. Let _s_ be ! ToString(_n_).
+        1. If _n_ is ~not-a-number~, then
+          1. Let _s_ be an ILD String value indicating the *NaN* value.
           1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _s_ }.
-        1. Let _res_ be FormatNumericToString(_pluralRules_, ℝ(_n_)).
+        1. If _n_ is ~positive-infinity~, then
+          1. Let _s_ be an ILD String value indicating positive infinity.
+          1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _s_ }.
+        1. If _n_ is ~negative-infinity~, then
+          1. Let _s_ be an ILD String value indicating negative infinity.
+          1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _s_ }.
+        1. Let _res_ be FormatNumericToString(_pluralRules_, _n_).
         1. Let _s_ be _res_.[[FormattedString]].
         1. Let _locale_ be _pluralRules_.[[Locale]].
         1. Let _type_ be _pluralRules_.[[Type]].
@@ -326,8 +332,8 @@
       <h1>
         ResolvePluralRange (
           _pluralRules_: an Intl.PluralRules,
-          _x_: a Number,
-          _y_: a Number,
+          _x_: an Intl mathematical value,
+          _y_: an Intl mathematical value,
         ): either a normal completion containing either *"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, or *"other"*, or a throw completion
       </h1>
       <dl class="header">
@@ -335,7 +341,7 @@
         <dd>The returned String value represents the plural form of the range starting from _x_ and ending at _y_ according to the effective locale and the options of _pluralRules_.</dd>
       </dl>
       <emu-alg>
-        1. If _x_ is *NaN* or _y_ is *NaN*, throw a *RangeError* exception.
+        1. If _x_ is ~not-a-number~ or _y_ is ~not-a-number~, throw a *RangeError* exception.
         1. Let _xp_ be ResolvePlural(_pluralRules_, _x_).
         1. Let _yp_ be ResolvePlural(_pluralRules_, _y_).
         1. If _xp_.[[FormattedString]] is _yp_.[[FormattedString]], then


### PR DESCRIPTION
 Normative: Updates the following `Intl.PluralRules` AOs to take Intl mathematical values rather than Numbers:

* `ResolvePlural`
* `ResolvePluralRange`

This allows `Intl.PluralRules.select` and `Intl.PluralRules.selectRange` to take BigInts as arguments.

fix https://github.com/tc39/ecma402/issues/910