### PR TITLE
Normative: In PluralRules, set compactDisplay only if notation is "compact"

### DIFF
--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -29,7 +29,8 @@
         1. Let _notation_ be ? GetOption(_options_, *"notation"*, ~string~, « *"standard"*, *"scientific"*, *"engineering"*, *"compact"* », *"standard"*).
         1. Set _pluralRules_.[[Notation]] to _notation_.
         1. Let _compactDisplay_ be ? GetOption(_options_, *"compactDisplay"*, ~string~, « *"short"*, *"long"* », *"short"*).
-        1. Set _pluralRules_.[[CompactDisplay]] to _compactDisplay_.
+        1. If _notation_ is *"compact"*, then
+          1. Set _pluralRules_.[[CompactDisplay]] to _compactDisplay_.
         1. Perform ? SetNumberFormatDigitOptions(_pluralRules_, _options_, 0, 3, _notation_).
         1. Return _pluralRules_.
       </emu-alg>


### PR DESCRIPTION
Address https://github.com/tc39/ecma402/issues/1031 

NumberFormat does this for a while but the recently added compactDisply for PluralRule is not

This fix is necessary because
1. compatDisplay does not make sense if notation is not compact
2. costly to implement resolvedOptions() w/o in v8 since currently v8 depends on icu's skeleton to get the compactDisplay and there are no defined value for the case while notation is not compact

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
