### PR TITLE
Editorial: Check for undefined [[FirstDayOfWeek]] field

### DIFF
--- a/spec/locale.html
+++ b/spec/locale.html
@@ -864,9 +864,10 @@
         1. Let _locale_ be _loc_.[[Locale]].
         1. Let _r_ be a Record whose fields are defined by <emu-xref href="#table-locale-weekinfo-record"></emu-xref>, with values based on _locale_.
         1. Let _fws_ be _loc_.[[FirstDayOfWeek]].
-        1. Let _fw_ be WeekdayUValueToNumber(_fws_).
-        1. If _fw_ is not *undefined*, then
-          1. Set _r_.[[FirstDay]] to _fw_.
+        1. If _fws_ is not *undefined*, then
+          1. Let _fw_ be WeekdayUValueToNumber(_fws_).
+          1. If _fw_ is not *undefined*, then
+            1. Set _r_.[[FirstDay]] to _fw_.
         1. Return _r_.
       </emu-alg>
 


### PR DESCRIPTION
`[[FirstDayOfWeek]]` can be `undefined`, but `WeekdayUValueToNumber` expects String values. Perform the check for `undefined` in `WeekInfoOfLocale` to match other operations which allow Unicode extension overrides (`CalendarsOfLocale`, `CollationsOfLocale`, `HourCyclesOfLocale`, and `NumberingSystemsOfLocale`.)

