### PR TITLE
Editorial: Update GetOption to throw a TypeError when a required option is missing

### DIFF
--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -25,7 +25,7 @@
         1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"narrow"*, *"short"*, *"long"* », *"long"*).
         1. Set _displayNames_.[[Style]] to _style_.
-        1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, « *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* », *undefined*).
+        1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, « *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* », ~required~).
         1. If _type_ is *undefined*, throw a *TypeError* exception.
         1. Set _displayNames_.[[Type]] to _type_.
         1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, « *"code"*, *"none"* », *"code"*).

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -26,7 +26,6 @@
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"narrow"*, *"short"*, *"long"* », *"long"*).
         1. Set _displayNames_.[[Style]] to _style_.
         1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, « *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* », ~required~).
-        1. If _type_ is *undefined*, throw a *TypeError* exception.
         1. Set _displayNames_.[[Type]] to _type_.
         1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, « *"code"*, *"none"* », *"code"*).
         1. Set _displayNames_.[[Fallback]] to _fallback_.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -383,7 +383,7 @@
       <emu-alg>
         1. Let _value_ be ? Get(_options_, _property_).
         1. If _value_ is *undefined*, then
-          1. If _default_ is ~required~, throw a *RangeError* exception.
+          1. If _default_ is ~required~, throw a *TypeError* exception.
           1. Return _default_.
         1. If _type_ is ~boolean~, then
           1. Set _value_ to ToBoolean(_value_).


### PR DESCRIPTION
TypeError rather than RangeError is in better alignment with other parts of the spec where a required parameter or option is missing:
* [ECMA-262 GroupBy](https://tc39.es/ecma262/#sec-groupby)
* [ECMA-262 Object static functions](https://tc39.es/ecma262/#sec-properties-of-the-object-constructor)
* [ECMA-262 RegExp.escape](https://tc39.es/ecma262/#sec-regexp.escape)
* [ECMA-262 Array.prototype.every](https://tc39.es/ecma262/#sec-array.prototype.every) et al.
  * Also {Map,Set}.prototype.{forEach,getOrInsertComputed}
* [ECMA-262 Uint8Array static methods](https://tc39.es/ecma262/#sec-additional-properties-of-the-uint8array-constructor)
* ECMA-262 Set.prototype.{difference,intersection,union,...}
* ECMA-262 [WeakMap methods](https://tc39.es/ecma262/#sec-properties-of-the-weakmap-prototype-object) and [WeakSet methods](https://tc39.es/ecma262/#sec-properties-of-the-weakset-prototype-object)
* [ECMA-262 Promise](https://tc39.es/ecma262/#sec-promise-constructor)
* [ECMA-262 Reflect functions](https://tc39.es/ecma262/#sec-reflect-object)
* [Intl.DateTimeFormat.prototype.{formatRange,formatRangeToParts}](https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formatRange)
  * Also [Intl.NumberFormat.prototype.{formatRange,formatRangeToParts}](https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formatrange) and [Intl.PluralRules.prototype.selectRange](https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.selectrange)
* [Intl.DisplayNames](https://tc39.es/ecma402/#sec-Intl.DisplayNames)
* [Intl.DurationFormat.prototype.{format,formatToParts}](https://tc39.es/ecma402/#sec-Intl.DurationFormat.prototype.format)
* [Intl.Locale](https://tc39.es/ecma402/#sec-Intl.Locale)
* [SetNumberFormatUnitOptions](https://tc39.es/ecma402/#sec-setnumberformatunitoptions) as exercised by e.g. `new Intl.NumberFormat("en", { style: "currency" })` and `new Intl.NumberFormat("en", { style: "unit" })`

Fortunately, this change is editorial because no current site calls GetOption with _default_ \~required\~, although I expect proposals like [Amount](https://github.com/tc39/proposal-amount) to do so.