### PR TITLE
Normative: Don't fall back to default locale in Locale.p.getCollations()

### DIFF
--- a/spec/locale.html
+++ b/spec/locale.html
@@ -662,10 +662,9 @@
       <emu-alg>
         1. If _loc_.[[Collation]] is not *undefined*, then
           1. Return CreateArrayFromList(« _loc_.[[Collation]] »).
-        1. Let _language_ be GetLocaleLanguage(_loc_.[[Locale]]).
-        1. If _language_ is not *"und"*, then
-          1. Let _match_ be LookupMatchingLocaleByPrefix(%Intl.Collator%.[[AvailableLocales]], « _loc_.[[Locale]] »).
-          1. If _match_ is not *undefined*, let _foundLocale_ be _match_.[[locale]]; else let _foundLocale_ be DefaultLocale().
+        1. Let _match_ be LookupMatchingLocaleByPrefix(%Intl.Collator%.[[AvailableLocales]], « _loc_.[[Locale]] »).
+        1. If _match_ is not *undefined*, then
+          1. Let _foundLocale_ be _match_.[[locale]].
           1. Let _foundLocaleData_ be %Intl.Collator%.[[SortLocaleData]].[[&lt;_foundLocale_&gt;]].
           1. Let _list_ be a copy of _foundLocaleData_.[[co]].
           1. Assert: _list_[0] is *null*.


### PR DESCRIPTION
This is Anba's proposed change from the issue. It would change the handling of locales with undefined languages such as `und-u-co-emoji` and also remove the fallback to the default locale (so `LANG=` environment variables would have no effect.)

Closes: #1053
