### PR TITLE
Normative: Allow Locale.p.getNumberingSystems to return >1 item

### DIFF
--- a/spec/locale.html
+++ b/spec/locale.html
@@ -720,7 +720,7 @@
           1. Let _foundLocale_ be _match_.[[locale]].
           1. Let _foundLocaleData_ be %Intl.NumberFormat%.[[LocaleData]].[[&lt;_foundLocale_&gt;]].
           1. Let _numberingSystems_ be _foundLocaleData_.[[nu]].
-          1. Let _list_ be « _numberingSystems_[0] ».
+          1. Let _list_ be a copy of _numberingSystems_, sorted in descending preference of those in common use for formatting numeric values in _foundLocale_.
         1. Else,
           1. Let _list_ be « *"latn"* ».
         1. Return CreateArrayFromList(_list_).

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -713,7 +713,7 @@
           1. Let _foundLocale_ be _r_.[[locale]].
           1. Let _foundLocaleData_ be %Intl.NumberFormat%.[[LocaleData]].[[&lt;_foundLocale_&gt;]].
           1. Let _numberingSystems_ be _foundLocaleData_.[[nu]].
-          1. Let _list_ be « _numberingSystems_[0] ».
+          1. Let _list_ be a copy of _numberingSystems_, sorted in descending preference of those in common use for formatting numeric values in _foundLocale_.
         1. Else,
           1. Let _list_ be « *"latn"* ».
         1. Return CreateArrayFromList(_list_).

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -719,8 +719,13 @@
         1. If _match_ is not *undefined*, then
           1. Let _foundLocale_ be _match_.[[locale]].
           1. Let _foundLocaleData_ be %Intl.NumberFormat%.[[LocaleData]].[[&lt;_foundLocale_&gt;]].
-          1. Let _numberingSystems_ be _foundLocaleData_.[[nu]].
-          1. Let _list_ be a copy of _numberingSystems_, sorted in descending preference of those in common use for formatting numeric values in _foundLocale_.
+          1. Let _supportedNumberingSystems_ be _foundLocaleData_.[[nu]].
+          1. Let _numberingSystemsInUse_ be a List of unique numbering system identifiers in common use for formatting numeric values in locale _foundLocale_, sorted by descending preference of use in _foundLocale_.
+          1. Let _list_ be a new empty List.
+          1. For each element _identifier_ of _numberingSystemsInUse_, do
+            1. If _supportedNumberingSystems_ contains _identifier_, then
+              1. Append _identifier_ to _list_.
+          1. Assert: _list_[0] is _supportedNumberingSystems_[0].
         1. Else,
           1. Let _list_ be « *"latn"* ».
         1. Return CreateArrayFromList(_list_).

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -725,7 +725,7 @@
           1. For each element _identifier_ of _numberingSystemsInUse_, do
             1. If _supportedNumberingSystems_ contains _identifier_, then
               1. Append _identifier_ to _list_.
-          1. Assert: _list_[0] is _supportedNumberingSystems_[0].
+          1. Assert: _list_ is not empty and _list_[0] is _supportedNumberingSystems_[0].
         1. Else,
           1. Let _list_ be « *"latn"* ».
         1. Return CreateArrayFromList(_list_).


### PR DESCRIPTION
This seems to be a regression from https://github.com/tc39/proposal-intl-locale-info/pull/92 that went unnoticed, accidentally removing the ability to return more than one numbering system from Intl.Locale.prototype.getNumberingSystems.

The sorting criterion added here matches the one that was removed in that change.

Closes: #1071

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
