### PR TITLE
Editorial: Sync alias names with recent 262 changes

### DIFF
--- a/spec/collator.html
+++ b/spec/collator.html
@@ -30,13 +30,13 @@
         1. Else,
           1. Let _localeData_ be %Intl.Collator%.[[SearchLocaleData]].
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.Collator%, _localeData_, CreateArrayFromList(_requestedLocales_), _options_).
-        1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
-        1. Set _collator_.[[Locale]] to _r_.[[Locale]].
-        1. If _r_.[[co]] is *null*, let _collation_ be *"default"*. Otherwise, let _collation_ be _r_.[[co]].
+        1. Let _resolvedLocale_ be _optionsResolution_.[[ResolvedLocale]].
+        1. Set _collator_.[[Locale]] to _resolvedLocale_.[[Locale]].
+        1. If _resolvedLocale_.[[co]] is *null*, let _collation_ be *"default"*. Otherwise, let _collation_ be _resolvedLocale_.[[co]].
         1. Set _collator_.[[Collation]] to _collation_.
-        1. Set _collator_.[[Numeric]] to SameValue(_r_.[[kn]], *"true"*).
-        1. Set _collator_.[[CaseFirst]] to _r_.[[kf]].
-        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
+        1. Set _collator_.[[Numeric]] to SameValue(_resolvedLocale_.[[kn]], *"true"*).
+        1. Set _collator_.[[CaseFirst]] to _resolvedLocale_.[[kf]].
+        1. Let _resolvedLocaleData_ be _resolvedLocale_.[[LocaleData]].
         1. If _usage_ is *"sort"*, let _defaultSensitivity_ be *"variant"*. Otherwise, let _defaultSensitivity_ be _resolvedLocaleData_.[[sensitivity]].
         1. Set _collator_.[[Sensitivity]] to ? GetOption(_options_, *"sensitivity"*, ~string~, « *"base"*, *"accent"*, *"case"*, *"variant"* », _defaultSensitivity_).
         1. Let _defaultIgnorePunctuation_ be _resolvedLocaleData_.[[ignorePunctuation]].
@@ -128,14 +128,14 @@
         1. Perform ? RequireInternalSlot(_collator_, [[InitializedCollator]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. For each row of <emu-xref href="#table-collator-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _collator_'s internal slot whose name is the Internal Slot value of the current row.
+          1. Let _propertyKey_ be the Property value of the current row.
+          1. Let _value_ be the value of _collator_'s internal slot whose name is the Internal Slot value of the current row.
           1. If the current row has an Extension Key value, then
             1. Let _extensionKey_ be the Extension Key value of the current row.
             1. If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain _extensionKey_, then
-              1. Set _v_ to *undefined*.
-          1. If _v_ is not *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+              1. Set _value_ to *undefined*.
+          1. If _value_ is not *undefined*, then
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _propertyKey_, _value_).
         1. Return _options_.
       </emu-alg>
 
@@ -198,9 +198,9 @@
         1. Let _collator_ be the *this* value.
         1. Perform ? RequireInternalSlot(_collator_, [[InitializedCollator]]).
         1. If _collator_.[[BoundCompare]] is *undefined*, then
-          1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-collator-compare-functions"></emu-xref>.
-          1. Set _F_.[[Collator]] to _collator_.
-          1. Set _collator_.[[BoundCompare]] to _F_.
+          1. Let _func_ be a new built-in function object as defined in <emu-xref href="#sec-collator-compare-functions"></emu-xref>.
+          1. Set _func_.[[Collator]] to _collator_.
+          1. Set _collator_.[[BoundCompare]] to _func_.
         1. Return _collator_.[[BoundCompare]].
       </emu-alg>
 
@@ -212,16 +212,16 @@
         <h1>Collator Compare Functions</h1>
 
         <p>A Collator compare function is an anonymous built-in function that has a [[Collator]] internal slot.</p>
-        <p>When a Collator compare function _F_ is called with arguments _x_ and _y_, the following steps are taken:</p>
+        <p>When a Collator compare function _func_ is called with arguments _x_ and _y_, the following steps are taken:</p>
 
         <emu-alg>
-          1. Let _collator_ be _F_.[[Collator]].
+          1. Let _collator_ be _func_.[[Collator]].
           1. Assert: _collator_ is an Object and _collator_ has an [[InitializedCollator]] internal slot.
           1. If _x_ is not provided, let _x_ be *undefined*.
           1. If _y_ is not provided, let _y_ be *undefined*.
-          1. Let _X_ be ? ToString(_x_).
-          1. Let _Y_ be ? ToString(_y_).
-          1. Return CompareStrings(_collator_, _X_, _Y_).
+          1. Let _xString_ be ? ToString(_x_).
+          1. Let _yString_ be ? ToString(_y_).
+          1. Return CompareStrings(_collator_, _xString_, _yString_).
         </emu-alg>
 
         <p>The *"length"* property of a Collator compare function is *2*<sub>𝔽</sub>.</p>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -1419,10 +1419,7 @@
             1. Append the Record { [[Type]]: _partType_, [[Value]]: _formattedValue_ } to _result_.
           1. Else if _partType_ is *"ampm"*, then
             1. Let _value_ be _localTime_.[[Hour]].
-            1. If _value_ is greater than 11, then
-              1. Let _formattedValue_ be an ILD String value representing *"post meridiem"*.
-            1. Else,
-              1. Let _formattedValue_ be an ILD String value representing *"ante meridiem"*.
+            1. If _value_ > 11, let _formattedValue_ be an ILD String value representing *"post meridiem"*; else let _formattedValue_ be an ILD String value representing *"ante meridiem"*.
             1. Append the Record { [[Type]]: *"dayPeriod"*, [[Value]]: _formattedValue_ } to _result_.
           1. Else if _partType_ is *"relatedYear"*, then
             1. Let _value_ be _localTime_.[[RelatedYear]].
@@ -1433,7 +1430,7 @@
             1. Let _formattedValue_ be an ILD String value representing _value_.
             1. Append the Record { [[Type]]: *"yearName"*, [[Value]]: _formattedValue_ } to _result_.
           1. Else,
-            1. Let _unknown_ be an implementation-, locale-, and numbering system-dependent String based on _epochNanoseconds_ and _partType_.
+            1. Let _unknown_ be an ILND String based on _epochNanoseconds_ and _partType_.
             1. Append the Record { [[Type]]: *"unknown"*, [[Value]]: _unknown_ } to _result_.
         1. Return _result_.
       </emu-alg>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -68,19 +68,19 @@
           1. If _hour12_ is not *undefined*, set _options_.[[hc]] to *null*.
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.DateTimeFormat%, %Intl.DateTimeFormat%.[[LocaleData]], _locales_, _options_, « ~coerce-options~ », _modifyResolutionOptions_).
         1. Set _options_ to _optionsResolution_.[[Options]].
-        1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
-        1. Set _dateTimeFormat_.[[Locale]] to _r_.[[Locale]].
-        1. Let _resolvedCalendar_ be _r_.[[ca]].
+        1. Let _resolvedLocale_ be _optionsResolution_.[[ResolvedLocale]].
+        1. Set _dateTimeFormat_.[[Locale]] to _resolvedLocale_.[[Locale]].
+        1. Let _resolvedCalendar_ be _resolvedLocale_.[[ca]].
         1. Set _dateTimeFormat_.[[Calendar]] to _resolvedCalendar_.
-        1. Set _dateTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
+        1. Set _dateTimeFormat_.[[NumberingSystem]] to _resolvedLocale_.[[nu]].
+        1. Let _resolvedLocaleData_ be _resolvedLocale_.[[LocaleData]].
         1. If _hour12_ is *true*, then
           1. Let _hc_ be _resolvedLocaleData_.[[hourCycle12]].
         1. Else if _hour12_ is *false*, then
           1. Let _hc_ be _resolvedLocaleData_.[[hourCycle24]].
         1. Else,
           1. Assert: _hour12_ is *undefined*.
-          1. Let _hc_ be _r_.[[hc]].
+          1. Let _hc_ be _resolvedLocale_.[[hc]].
           1. If _hc_ is *null*, set _hc_ to _resolvedLocaleData_.[[hourCycle]].
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is *undefined*, then
@@ -104,13 +104,13 @@
         1. Set _formatOptions_.[[hourCycle]] to _hc_.
         1. Let _hasExplicitFormatComponents_ be *false*.
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
-          1. Let _prop_ be the name given in the Property column of the current row.
-          1. If _prop_ is *"fractionalSecondDigits"*, then
+          1. Let _property_ be the name given in the Property column of the current row.
+          1. If _property_ is *"fractionalSecondDigits"*, then
             1. Let _value_ be ? GetNumberOption(_options_, *"fractionalSecondDigits"*, 1, 3, *undefined*).
           1. Else,
             1. Let _values_ be a List whose elements are the strings given in the Values column of the current row.
-            1. Let _value_ be ? GetOption(_options_, _prop_, ~string~, _values_, *undefined*).
-          1. Set _formatOptions_.[[&lt;_prop_>]] to _value_.
+            1. Let _value_ be ? GetOption(_options_, _property_, ~string~, _values_, *undefined*).
+          1. Set _formatOptions_.[[&lt;_property_>]] to _value_.
           1. If _value_ is not *undefined*, then
             1. Set _hasExplicitFormatComponents_ to *true*.
         1. Let _formatMatcher_ be ? GetOption(_options_, *"formatMatcher"*, ~string~, « *"basic"*, *"best fit"* », *"best fit"*).
@@ -130,19 +130,19 @@
         1. Else,
           1. Let _needDefaults_ be *true*.
           1. If _required_ is ~date~ or ~any~, then
-            1. For each property name _prop_ of « *"weekday"*, *"year"*, *"month"*, *"day"* », do
-              1. Let _value_ be _formatOptions_.[[&lt;_prop_>]].
+            1. For each property name _property_ of « *"weekday"*, *"year"*, *"month"*, *"day"* », do
+              1. Let _value_ be _formatOptions_.[[&lt;_property_>]].
               1. If _value_ is not *undefined*, set _needDefaults_ to *false*.
           1. If _required_ is ~time~ or ~any~, then
-            1. For each property name _prop_ of « *"dayPeriod"*, *"hour"*, *"minute"*, *"second"*, *"fractionalSecondDigits"* », do
-              1. Let _value_ be _formatOptions_.[[&lt;_prop_>]].
+            1. For each property name _property_ of « *"dayPeriod"*, *"hour"*, *"minute"*, *"second"*, *"fractionalSecondDigits"* », do
+              1. Let _value_ be _formatOptions_.[[&lt;_property_>]].
               1. If _value_ is not *undefined*, set _needDefaults_ to *false*.
           1. If _needDefaults_ is *true* and _defaults_ is either ~date~ or ~all~, then
-            1. For each property name _prop_ of « *"year"*, *"month"*, *"day"* », do
-              1. Set _formatOptions_.[[&lt;_prop_>]] to *"numeric"*.
+            1. For each property name _property_ of « *"year"*, *"month"*, *"day"* », do
+              1. Set _formatOptions_.[[&lt;_property_>]] to *"numeric"*.
           1. If _needDefaults_ is *true* and _defaults_ is either ~time~ or ~all~, then
-            1. For each property name _prop_ of « *"hour"*, *"minute"*, *"second"* », do
-              1. Set _formatOptions_.[[&lt;_prop_>]] to *"numeric"*.
+            1. For each property name _property_ of « *"hour"*, *"minute"*, *"second"* », do
+              1. Set _formatOptions_.[[&lt;_property_>]] to *"numeric"*.
           1. Let _formats_ be _resolvedLocaleData_.[[formats]].[[&lt;_resolvedCalendar_>]].
           1. If _formatMatcher_ is *"basic"*, then
             1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
@@ -884,24 +884,24 @@
         1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. For each row of <emu-xref href="#table-datetimeformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
+          1. Let _property_ be the Property value of the current row.
           1. If there is an Internal Slot value in the current row, then
-            1. Let _v_ be the value of _dtf_'s internal slot whose name is the Internal Slot value of the current row.
+            1. Let _value_ be the value of _dtf_'s internal slot whose name is the Internal Slot value of the current row.
           1. Else,
             1. Let _format_ be _dtf_.[[DateTimeFormat]].
-            1. If _format_ has a field [[&lt;_p_>]] and _dtf_.[[DateStyle]] is *undefined* and _dtf_.[[TimeStyle]] is *undefined*, then
-              1. Let _v_ be _format_.[[&lt;_p_>]].
+            1. If _format_ has a field [[&lt;_property_>]] and _dtf_.[[DateStyle]] is *undefined* and _dtf_.[[TimeStyle]] is *undefined*, then
+              1. Let _value_ be _format_.[[&lt;_property_>]].
             1. Else,
-              1. Let _v_ be *undefined*.
-          1. If _v_ is not *undefined*, then
+              1. Let _value_ be *undefined*.
+          1. If _value_ is not *undefined*, then
             1. If there is a Conversion value in the current row, then
               1. Let _conversion_ be the Conversion value of the current row.
               1. If _conversion_ is ~hour12~, then
-                1. If _v_ is *"h11"* or *"h12"*, set _v_ to *true*. Otherwise, set _v_ to *false*.
+                1. If _value_ is *"h11"* or *"h12"*, set _value_ to *true*. Otherwise, set _value_ to *false*.
               1. Else,
                 1. Assert: _conversion_ is ~number~.
-                1. Set _v_ to 𝔽(_v_).
-            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+                1. Set _value_ to 𝔽(_value_).
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _property_, _value_).
         1. Return _options_.
       </emu-alg>
 
@@ -1035,9 +1035,9 @@
           1. Set _dtf_ to ? UnwrapDateTimeFormat(_dtf_).
         1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
         1. If _dtf_.[[BoundFormat]] is *undefined*, then
-          1. Let _F_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-format-functions"></emu-xref>).
-          1. Set _F_.[[DateTimeFormat]] to _dtf_.
-          1. Set _dtf_.[[BoundFormat]] to _F_.
+          1. Let _func_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-format-functions"></emu-xref>).
+          1. Set _func_.[[DateTimeFormat]] to _dtf_.
+          1. Set _dtf_.[[BoundFormat]] to _func_.
         1. Return _dtf_.[[BoundFormat]].
       </emu-alg>
 
@@ -1323,10 +1323,10 @@
       <h1>DateTime Format Functions</h1>
 
       <p>A DateTime format function is an anonymous built-in function that has a [[DateTimeFormat]] internal slot.</p>
-      <p>When a DateTime format function _F_ is called with optional argument _date_, the following steps are taken:</p>
+      <p>When a DateTime format function _func_ is called with optional argument _date_, the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _dtf_ be _F_.[[DateTimeFormat]].
+        1. Let _dtf_ be _func_.[[DateTimeFormat]].
         1. Assert: _dtf_ is an Object and _dtf_ has an [[InitializedDateTimeFormat]] internal slot.
         1. If _date_ is not provided or is *undefined*, then
           1. Let _x_ be ! Call(%Date.now%, *undefined*).
@@ -1369,71 +1369,71 @@
           1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"numberingSystem"*, _dateTimeFormat_.[[NumberingSystem]]).
           1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
           1. Let _nf3_ be ! Construct(%Intl.NumberFormat%, « _locale_, _nf3Options_ »).
-        1. Let _tm_ be ToLocalTime(_epochNanoseconds_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
+        1. Let _localTime_ be ToLocalTime(_epochNanoseconds_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. Let _result_ be a new empty List.
         1. For each Record { [[Type]], [[Value]] } _patternPart_ of _patternParts_, do
-          1. Let _p_ be _patternPart_.[[Type]].
-          1. If _p_ is *"literal"*, then
+          1. Let _partType_ be _patternPart_.[[Type]].
+          1. If _partType_ is *"literal"*, then
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
-          1. Else if _p_ is *"fractionalSecondDigits"*, then
+          1. Else if _partType_ is *"fractionalSecondDigits"*, then
             1. Assert: _format_ has a field [[fractionalSecondDigits]].
-            1. Let _v_ be _tm_.[[Millisecond]].
-            1. Set _v_ to floor(_v_ × 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
-            1. Let _fv_ be FormatNumeric(_nf3_, _v_).
-            1. Append the Record { [[Type]]: *"fractionalSecond"*, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is *"dayPeriod"*, then
+            1. Let _value_ be _localTime_.[[Millisecond]].
+            1. Set _value_ to floor(_value_ × 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
+            1. Let _formattedValue_ be FormatNumeric(_nf3_, _value_).
+            1. Append the Record { [[Type]]: *"fractionalSecond"*, [[Value]]: _formattedValue_ } to _result_.
+          1. Else if _partType_ is *"dayPeriod"*, then
             1. Assert: _format_ has a field [[dayPeriod]].
-            1. Let _f_ be _format_.[[dayPeriod]].
-            1. Let _fv_ be a String value representing the day period of _tm_ in the form given by _f_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
-            1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is *"timeZoneName"*, then
+            1. Let _fieldFormat_ be _format_.[[dayPeriod]].
+            1. Let _formattedValue_ be a String value representing the day period of _localTime_ in the form given by _fieldFormat_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
+            1. Append the Record { [[Type]]: _partType_, [[Value]]: _formattedValue_ } to _result_.
+          1. Else if _partType_ is *"timeZoneName"*, then
             1. Assert: _format_ has a field [[timeZoneName]].
-            1. Let _f_ be _format_.[[timeZoneName]].
-            1. Let _v_ be _dateTimeFormat_.[[TimeZone]].
-            1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_. The String value may also depend on the value of the [[InDST]] field of _tm_ if _f_ is *"short"*, *"long"*, *"shortOffset"*, or *"longOffset"*. If the implementation does not have such a localized representation of _f_, then use the String value of _v_ itself.
-            1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ matches a Property column of the row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, then
-            1. Assert: _format_ has a field [[&lt;_p_>]].
-            1. Let _f_ be _format_.[[&lt;_p_>]].
-            1. Let _v_ be the value of _tm_'s field whose name is the Internal Slot column of the matching row.
-            1. If _p_ is *"year"* and _v_ ≤ 0, set _v_ to 1 - _v_.
-            1. If _p_ is *"month"*, set _v_ to _v_ + 1.
-            1. If _p_ is *"hour"* and _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
-              1. Set _v_ to _v_ modulo 12.
-              1. If _v_ is 0 and _dateTimeFormat_.[[HourCycle]] is *"h12"*, set _v_ to 12.
-            1. If _p_ is *"hour"* and _dateTimeFormat_.[[HourCycle]] is *"h24"*, then
-              1. If _v_ is 0, set _v_ to 24.
-            1. If _f_ is *"numeric"*, then
-              1. Let _fv_ be FormatNumeric(_nf_, _v_).
-            1. Else if _f_ is *"2-digit"*, then
-              1. Let _fv_ be FormatNumeric(_nf2_, _v_).
-              1. Let _codePoints_ be StringToCodePoints(_fv_).
+            1. Let _fieldFormat_ be _format_.[[timeZoneName]].
+            1. Let _value_ be _dateTimeFormat_.[[TimeZone]].
+            1. Let _formattedValue_ be a String value representing _value_ in the form given by _fieldFormat_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_. The String value may also depend on the value of the [[InDST]] field of _localTime_ if _fieldFormat_ is *"short"*, *"long"*, *"shortOffset"*, or *"longOffset"*. If the implementation does not have such a localized representation of _fieldFormat_, then use the String value of _value_ itself.
+            1. Append the Record { [[Type]]: _partType_, [[Value]]: _formattedValue_ } to _result_.
+          1. Else if _partType_ matches a Property column of the row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, then
+            1. Assert: _format_ has a field [[&lt;_partType_>]].
+            1. Let _fieldFormat_ be _format_.[[&lt;_partType_>]].
+            1. Let _value_ be the value of _localTime_'s field whose name is the Internal Slot column of the matching row.
+            1. If _partType_ is *"year"* and _value_ ≤ 0, set _value_ to 1 - _value_.
+            1. If _partType_ is *"month"*, set _value_ to _value_ + 1.
+            1. If _partType_ is *"hour"* and _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
+              1. Set _value_ to _value_ modulo 12.
+              1. If _value_ is 0 and _dateTimeFormat_.[[HourCycle]] is *"h12"*, set _value_ to 12.
+            1. If _partType_ is *"hour"* and _dateTimeFormat_.[[HourCycle]] is *"h24"*, then
+              1. If _value_ is 0, set _value_ to 24.
+            1. If _fieldFormat_ is *"numeric"*, then
+              1. Let _formattedValue_ be FormatNumeric(_nf_, _value_).
+            1. Else if _fieldFormat_ is *"2-digit"*, then
+              1. Let _formattedValue_ be FormatNumeric(_nf2_, _value_).
+              1. Let _codePoints_ be StringToCodePoints(_formattedValue_).
               1. Let _count_ be the number of elements in _codePoints_.
               1. If _count_ > 2, then
                 1. Let _tens_ be _codePoints_[_count_ - 2].
                 1. Let _ones_ be _codePoints_[_count_ - 1].
-                1. Set _fv_ to CodePointsToString(« _tens_, _ones_ »).
-            1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then
-              1. Let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether _format_.[[day]] is present. If the implementation does not have a localized representation of _f_, then use the String value of _v_ itself.
-            1. Append the Record { [[Type]]: _p_, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is *"ampm"*, then
-            1. Let _v_ be _tm_.[[Hour]].
-            1. If _v_ is greater than 11, then
-              1. Let _fv_ be an ILD String value representing *"post meridiem"*.
+                1. Set _formattedValue_ to CodePointsToString(« _tens_, _ones_ »).
+            1. Else if _fieldFormat_ is *"narrow"*, *"short"*, or *"long"*, then
+              1. Let _formattedValue_ be a String value representing _value_ in the form given by _fieldFormat_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _partType_ is *"month"*, then the String value may also depend on whether _format_.[[day]] is present. If the implementation does not have a localized representation of _fieldFormat_, then use the String value of _value_ itself.
+            1. Append the Record { [[Type]]: _partType_, [[Value]]: _formattedValue_ } to _result_.
+          1. Else if _partType_ is *"ampm"*, then
+            1. Let _value_ be _localTime_.[[Hour]].
+            1. If _value_ is greater than 11, then
+              1. Let _formattedValue_ be an ILD String value representing *"post meridiem"*.
             1. Else,
-              1. Let _fv_ be an ILD String value representing *"ante meridiem"*.
-            1. Append the Record { [[Type]]: *"dayPeriod"*, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is *"relatedYear"*, then
-            1. Let _v_ be _tm_.[[RelatedYear]].
-            1. Let _fv_ be FormatNumeric(_nf_, _v_).
-            1. Append the Record { [[Type]]: *"relatedYear"*, [[Value]]: _fv_ } to _result_.
-          1. Else if _p_ is *"yearName"*, then
-            1. Let _v_ be _tm_.[[YearName]].
-            1. Let _fv_ be an ILD String value representing _v_.
-            1. Append the Record { [[Type]]: *"yearName"*, [[Value]]: _fv_ } to _result_.
+              1. Let _formattedValue_ be an ILD String value representing *"ante meridiem"*.
+            1. Append the Record { [[Type]]: *"dayPeriod"*, [[Value]]: _formattedValue_ } to _result_.
+          1. Else if _partType_ is *"relatedYear"*, then
+            1. Let _value_ be _localTime_.[[RelatedYear]].
+            1. Let _formattedValue_ be FormatNumeric(_nf_, _value_).
+            1. Append the Record { [[Type]]: *"relatedYear"*, [[Value]]: _formattedValue_ } to _result_.
+          1. Else if _partType_ is *"yearName"*, then
+            1. Let _value_ be _localTime_.[[YearName]].
+            1. Let _formattedValue_ be an ILD String value representing _value_.
+            1. Append the Record { [[Type]]: *"yearName"*, [[Value]]: _formattedValue_ } to _result_.
           1. Else,
-            1. Let _unknown_ be an implementation-, locale-, and numbering system-dependent String based on _epochNanoseconds_ and _p_.
+            1. Let _unknown_ be an implementation-, locale-, and numbering system-dependent String based on _epochNanoseconds_ and _partType_.
             1. Append the Record { [[Type]]: *"unknown"*, [[Value]]: _unknown_ } to _result_.
         1. Return _result_.
       </emu-alg>
@@ -1500,10 +1500,10 @@
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each Record { [[Type]], [[Value]] } _part_ of _parts_, do
-          1. Let _O_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _O_).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>
@@ -1528,8 +1528,8 @@
         1. If _y_ is *NaN*, throw a *RangeError* exception.
         1. Let _xEpochNanoseconds_ be ℤ(ℝ(_x_) × 10<sup>6</sup>).
         1. Let _yEpochNanoseconds_ be ℤ(ℝ(_y_) × 10<sup>6</sup>).
-        1. Let _tm1_ be ToLocalTime(_xEpochNanoseconds_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
-        1. Let _tm2_ be ToLocalTime(_yEpochNanoseconds_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
+        1. Let _localTime1_ be ToLocalTime(_xEpochNanoseconds_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
+        1. Let _localTime2_ be ToLocalTime(_yEpochNanoseconds_, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
         1. Let _format_ be _dateTimeFormat_.[[DateTimeFormat]].
         1. If _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then
           1. Let _pattern_ be _format_.[[pattern12]].
@@ -1549,29 +1549,29 @@
           1. If _fieldName_ is not equal to [[Default]] and _relevantFieldsEqual_ is *true* and _checkMoreFields_ is *true*, then
             1. Set _selectedRangePattern_ to _rangePattern_.
             1. If _fieldName_ is [[AmPm]], then
-              1. If _tm1_.[[Hour]] is less than 12, let _v1_ be *"am"*; else let _v1_ be *"pm"*.
-              1. If _tm2_.[[Hour]] is less than 12, let _v2_ be *"am"*; else let _v2_ be *"pm"*.
+              1. If _localTime1_.[[Hour]] is less than 12, let _v1_ be *"am"*; else let _v1_ be *"pm"*.
+              1. If _localTime2_.[[Hour]] is less than 12, let _v2_ be *"am"*; else let _v2_ be *"pm"*.
             1. Else if _fieldName_ is [[DayPeriod]], then
-              1. Let _v1_ be a String value representing the day period of _tm1_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
-              1. Let _v2_ be a String value representing the day period of _tm2_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
+              1. Let _v1_ be a String value representing the day period of _localTime1_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
+              1. Let _v2_ be a String value representing the day period of _localTime2_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
             1. Else if _fieldName_ is [[FractionalSecondDigits]], then
               1. If _format_ has a [[fractionalSecondDigits]] field, then
                 1. Let _fractionalSecondDigits_ be _format_.[[fractionalSecondDigits]].
               1. Else,
                 1. Let _fractionalSecondDigits_ be 3.
               1. Let _exp_ be _fractionalSecondDigits_ - 3.
-              1. Let _v1_ be floor(_tm1_.[[Millisecond]] × 10<sup>_exp_</sup>).
-              1. Let _v2_ be floor(_tm2_.[[Millisecond]] × 10<sup>_exp_</sup>).
+              1. Let _v1_ be floor(_localTime1_.[[Millisecond]] × 10<sup>_exp_</sup>).
+              1. Let _v2_ be floor(_localTime2_.[[Millisecond]] × 10<sup>_exp_</sup>).
             1. Else,
-              1. Let _v1_ be _tm1_'s field whose name is _fieldName_.
-              1. Let _v2_ be _tm2_'s field whose name is _fieldName_.
+              1. Let _v1_ be _localTime1_'s field whose name is _fieldName_.
+              1. Let _v2_ be _localTime2_'s field whose name is _fieldName_.
             1. If _v1_ is not equal to _v2_, then
               1. Set _relevantFieldsEqual_ to *false*.
         1. If _relevantFieldsEqual_ is *true*, then
           1. Let _collapsedResult_ be a new empty List.
           1. Let _resultParts_ be FormatDateTimePattern(_dateTimeFormat_, _format_, _pattern_, _xEpochNanoseconds_).
-          1. For each Record { [[Type]], [[Value]] } _r_ of _resultParts_, do
-            1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: *"shared"* } to _collapsedResult_.
+          1. For each Record { [[Type]], [[Value]] } _part_ of _resultParts_, do
+            1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Source]]: *"shared"* } to _collapsedResult_.
           1. Return _collapsedResult_.
         1. Let _rangeResult_ be a new empty List.
         1. If _selectedRangePattern_ is *undefined*, then
@@ -1584,8 +1584,8 @@
           1. Else,
             1. Let _z_ be _yEpochNanoseconds_.
           1. Let _resultParts_ be FormatDateTimePattern(_dateTimeFormat_, _selectedRangePattern_, _pattern_, _z_).
-          1. For each Record { [[Type]], [[Value]] } _r_ of _resultParts_, do
-            1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: _source_ } to _rangeResult_.
+          1. For each Record { [[Type]], [[Value]] } _part_ of _resultParts_, do
+            1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Source]]: _source_ } to _rangeResult_.
         1. Return _rangeResult_.
       </emu-alg>
     </emu-clause>
@@ -1624,11 +1624,11 @@
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each Record { [[Type]], [[Value]], [[Source]] } _part_ of _parts_, do
-          1. Let _O_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"source"*, _part_.[[Source]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _O_).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"source"*, _part_.[[Source]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -104,13 +104,13 @@
         1. Set _formatOptions_.[[hourCycle]] to _hc_.
         1. Let _hasExplicitFormatComponents_ be *false*.
         1. For each row of <emu-xref href="#table-datetimeformat-components"></emu-xref>, except the header row, in table order, do
-          1. Let _property_ be the name given in the Property column of the current row.
-          1. If _property_ is *"fractionalSecondDigits"*, then
+          1. Let _propertyKey_ be the name given in the Property column of the current row.
+          1. If _propertyKey_ is *"fractionalSecondDigits"*, then
             1. Let _value_ be ? GetNumberOption(_options_, *"fractionalSecondDigits"*, 1, 3, *undefined*).
           1. Else,
             1. Let _values_ be a List whose elements are the strings given in the Values column of the current row.
-            1. Let _value_ be ? GetOption(_options_, _property_, ~string~, _values_, *undefined*).
-          1. Set _formatOptions_.[[&lt;_property_>]] to _value_.
+            1. Let _value_ be ? GetOption(_options_, _propertyKey_, ~string~, _values_, *undefined*).
+          1. Set _formatOptions_.[[&lt;_propertyKey_>]] to _value_.
           1. If _value_ is not *undefined*, then
             1. Set _hasExplicitFormatComponents_ to *true*.
         1. Let _formatMatcher_ be ? GetOption(_options_, *"formatMatcher"*, ~string~, « *"basic"*, *"best fit"* », *"best fit"*).
@@ -130,19 +130,19 @@
         1. Else,
           1. Let _needDefaults_ be *true*.
           1. If _required_ is ~date~ or ~any~, then
-            1. For each property name _property_ of « *"weekday"*, *"year"*, *"month"*, *"day"* », do
-              1. Let _value_ be _formatOptions_.[[&lt;_property_>]].
+            1. For each property name _propertyKey_ of « *"weekday"*, *"year"*, *"month"*, *"day"* », do
+              1. Let _value_ be _formatOptions_.[[&lt;_propertyKey_>]].
               1. If _value_ is not *undefined*, set _needDefaults_ to *false*.
           1. If _required_ is ~time~ or ~any~, then
-            1. For each property name _property_ of « *"dayPeriod"*, *"hour"*, *"minute"*, *"second"*, *"fractionalSecondDigits"* », do
-              1. Let _value_ be _formatOptions_.[[&lt;_property_>]].
+            1. For each property name _propertyKey_ of « *"dayPeriod"*, *"hour"*, *"minute"*, *"second"*, *"fractionalSecondDigits"* », do
+              1. Let _value_ be _formatOptions_.[[&lt;_propertyKey_>]].
               1. If _value_ is not *undefined*, set _needDefaults_ to *false*.
           1. If _needDefaults_ is *true* and _defaults_ is either ~date~ or ~all~, then
-            1. For each property name _property_ of « *"year"*, *"month"*, *"day"* », do
-              1. Set _formatOptions_.[[&lt;_property_>]] to *"numeric"*.
+            1. For each property name _propertyKey_ of « *"year"*, *"month"*, *"day"* », do
+              1. Set _formatOptions_.[[&lt;_propertyKey_>]] to *"numeric"*.
           1. If _needDefaults_ is *true* and _defaults_ is either ~time~ or ~all~, then
-            1. For each property name _property_ of « *"hour"*, *"minute"*, *"second"* », do
-              1. Set _formatOptions_.[[&lt;_property_>]] to *"numeric"*.
+            1. For each property name _propertyKey_ of « *"hour"*, *"minute"*, *"second"* », do
+              1. Set _formatOptions_.[[&lt;_propertyKey_>]] to *"numeric"*.
           1. Let _formats_ be _resolvedLocaleData_.[[formats]].[[&lt;_resolvedCalendar_>]].
           1. If _formatMatcher_ is *"basic"*, then
             1. Let _bestFormat_ be BasicFormatMatcher(_formatOptions_, _formats_).
@@ -884,13 +884,13 @@
         1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. For each row of <emu-xref href="#table-datetimeformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _property_ be the Property value of the current row.
+          1. Let _propertyKey_ be the Property value of the current row.
           1. If there is an Internal Slot value in the current row, then
             1. Let _value_ be the value of _dtf_'s internal slot whose name is the Internal Slot value of the current row.
           1. Else,
             1. Let _format_ be _dtf_.[[DateTimeFormat]].
-            1. If _format_ has a field [[&lt;_property_>]] and _dtf_.[[DateStyle]] is *undefined* and _dtf_.[[TimeStyle]] is *undefined*, then
-              1. Let _value_ be _format_.[[&lt;_property_>]].
+            1. If _format_ has a field [[&lt;_propertyKey_>]] and _dtf_.[[DateStyle]] is *undefined* and _dtf_.[[TimeStyle]] is *undefined*, then
+              1. Let _value_ be _format_.[[&lt;_propertyKey_>]].
             1. Else,
               1. Let _value_ be *undefined*.
           1. If _value_ is not *undefined*, then
@@ -901,7 +901,7 @@
               1. Else,
                 1. Assert: _conversion_ is ~number~.
                 1. Set _value_ to 𝔽(_value_).
-            1. Perform ! CreateDataPropertyOrThrow(_options_, _property_, _value_).
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _propertyKey_, _value_).
         1. Return _options_.
       </emu-alg>
 
@@ -1500,10 +1500,10 @@
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each Record { [[Type]], [[Value]] } _part_ of _parts_, do
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
+          1. Let _partObj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"value"*, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _partObj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>
@@ -1624,11 +1624,11 @@
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each Record { [[Type]], [[Value]], [[Source]] } _part_ of _parts_, do
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"source"*, _part_.[[Source]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
+          1. Let _partObj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"value"*, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"source"*, _part_.[[Source]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _partObj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -22,7 +22,7 @@
         1. Let _displayNames_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.DisplayNames.prototype%"*, « [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], [[LanguageDisplay]], [[Fields]] »).
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.DisplayNames%, %Intl.DisplayNames%.[[LocaleData]], _locales_, _options_, « ~require-options~ »).
         1. Set _options_ to _optionsResolution_.[[Options]].
-        1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
+        1. Let _resolvedLocale_ be _optionsResolution_.[[ResolvedLocale]].
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"narrow"*, *"short"*, *"long"* », *"long"*).
         1. Set _displayNames_.[[Style]] to _style_.
         1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, « *"language"*, *"region"*, *"script"*, *"currency"*, *"calendar"*, *"dateTimeField"* », *undefined*).
@@ -30,8 +30,8 @@
         1. Set _displayNames_.[[Type]] to _type_.
         1. Let _fallback_ be ? GetOption(_options_, *"fallback"*, ~string~, « *"code"*, *"none"* », *"code"*).
         1. Set _displayNames_.[[Fallback]] to _fallback_.
-        1. Set _displayNames_.[[Locale]] to _r_.[[Locale]].
-        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
+        1. Set _displayNames_.[[Locale]] to _resolvedLocale_.[[Locale]].
+        1. Let _resolvedLocaleData_ be _resolvedLocale_.[[LocaleData]].
         1. Let _types_ be _resolvedLocaleData_.[[types]].
         1. Assert: _types_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. Let _languageDisplay_ be ? GetOption(_options_, *"languageDisplay"*, ~string~, « *"dialect"*, *"standard"* », *"dialect"*).
@@ -134,10 +134,10 @@
         1. Perform ? RequireInternalSlot(_displayNames_, [[InitializedDisplayNames]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. For each row of <emu-xref href="#table-displaynames-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _displayNames_'s internal slot whose name is the Internal Slot value of the current row.
-          1. If _v_ is not *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+          1. Let _propertyKey_ be the Property value of the current row.
+          1. Let _value_ be the value of _displayNames_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If _value_ is not *undefined*, then
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _propertyKey_, _value_).
         1. Return _options_.
       </emu-alg>
 

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -22,13 +22,13 @@
         1. Let _durationFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.DurationFormatPrototype%"*, « [[InitializedDurationFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[YearsOptions]], [[MonthsOptions]], [[WeeksOptions]], [[DaysOptions]], [[HoursOptions]], [[MinutesOptions]], [[SecondsOptions]], [[MillisecondsOptions]], [[MicrosecondsOptions]], [[NanosecondsOptions]], [[HourMinuteSeparator]], [[MinuteSecondSeparator]], [[FractionalDigits]] »).
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.DurationFormat%, %Intl.DurationFormat%.[[LocaleData]], _locales_, _options_).
         1. Set _options_ to _optionsResolution_.[[Options]].
-        1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
-        1. Set _durationFormat_.[[Locale]] to _r_.[[Locale]].
-        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
+        1. Let _resolvedLocale_ be _optionsResolution_.[[ResolvedLocale]].
+        1. Set _durationFormat_.[[Locale]] to _resolvedLocale_.[[Locale]].
+        1. Let _resolvedLocaleData_ be _resolvedLocale_.[[LocaleData]].
         1. Let _digitalFormat_ be _resolvedLocaleData_.[[DigitalFormat]].
         1. Set _durationFormat_.[[HourMinuteSeparator]] to _digitalFormat_.[[HourMinuteSeparator]].
         1. Set _durationFormat_.[[MinuteSecondSeparator]] to _digitalFormat_.[[MinuteSecondSeparator]].
-        1. Set _durationFormat_.[[NumberingSystem]] to _r_.[[nu]].
+        1. Set _durationFormat_.[[NumberingSystem]] to _resolvedLocale_.[[nu]].
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"long"*, *"short"*, *"narrow"*, *"digital"* », *"short"*).
         1. Set _durationFormat_.[[Style]] to _style_.
         1. Let _prevStyle_ be the empty String.
@@ -203,23 +203,23 @@
         1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. For each row of <emu-xref href="#table-durationformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _df_'s internal slot whose name is the Internal Slot value of the current row.
-          1. If _v_ is not *undefined*, then
+          1. Let _propertyKey_ be the Property value of the current row.
+          1. Let _value_ be the value of _df_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If _value_ is not *undefined*, then
             1. If there is a Conversion value in the current row, let _conversion_ be that value; else let _conversion_ be ~empty~.
             1. If _conversion_ is ~number~, then
-              1. Set _v_ to 𝔽(_v_).
+              1. Set _value_ to 𝔽(_value_).
             1. Else if _conversion_ is not ~empty~, then
-              1. Assert: _conversion_ is ~style+display~ and _v_ is a Duration Unit Options Record.
-              1. NOTE: _v_.[[Style]] will be represented with a property named _p_ (a plural Temporal unit), then _v_.[[Display]] will be represented with a property whose name suffixes _p_ with *"Display"*.
-              1. Let _style_ be _v_.[[Style]].
+              1. Assert: _conversion_ is ~style+display~ and _value_ is a Duration Unit Options Record.
+              1. NOTE: _value_.[[Style]] will be represented with a property named _propertyKey_ (a plural Temporal unit), then _value_.[[Display]] will be represented with a property whose name suffixes _propertyKey_ with *"Display"*.
+              1. Let _style_ be _value_.[[Style]].
               1. If _style_ is *"fractional"*, then
-                1. Assert: IsFractionalSecondUnitName(_p_) is *true*.
+                1. Assert: IsFractionalSecondUnitName(_propertyKey_) is *true*.
                 1. Set _style_ to *"numeric"*.
-              1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _style_).
-              1. Set _p_ to the string-concatenation of _p_ and *"Display"*.
-              1. Set _v_ to _v_.[[Display]].
-            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+              1. Perform ! CreateDataPropertyOrThrow(_options_, _propertyKey_, _style_).
+              1. Set _propertyKey_ to the string-concatenation of _propertyKey_ and *"Display"*.
+              1. Set _value_ to _value_.[[Display]].
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _propertyKey_, _value_).
         1. Return _options_.
       </emu-alg>
 
@@ -462,15 +462,15 @@
     <emu-clause id="sec-tointegerifintegral" oldids="sec-tointegerwithoutrounding" type="abstract operation">
       <h1>
         ToIntegerIfIntegral (
-          _argument_: an ECMAScript language value,
+          _arg_: an ECMAScript language value,
         ): either a normal completion containing an integer, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to an integer representing its Number value, or throws a *RangeError* when that value is not <emu-xref href="#integral-number">integral</emu-xref>.</dd>
+        <dd>It converts _arg_ to an integer representing its Number value, or throws a *RangeError* when that value is not <emu-xref href="#integral-number">integral</emu-xref>.</dd>
       </dl>
       <emu-alg>
-        1. Let _number_ be ? ToNumber(_argument_).
+        1. Let _number_ be ? ToNumber(_arg_).
         1. If _number_ is not an integral Number, throw a *RangeError* exception.
         1. Return ℝ(_number_).
       </emu-alg>
@@ -727,15 +727,15 @@
         1. Let _result_ be a new empty List.
         1. Let _hoursStyle_ be _durationFormat_.[[HoursOptions]].[[Style]].
         1. Assert: _hoursStyle_ is *"numeric"* or _hoursStyle_ is *"2-digit"*.
-        1. Let _nfOpts_ be OrdinaryObjectCreate(*null*).
+        1. Let _nfOptions_ be OrdinaryObjectCreate(*null*).
         1. Let _numberingSystem_ be _durationFormat_.[[NumberingSystem]].
-        1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"numberingSystem"*, _numberingSystem_).
+        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"numberingSystem"*, _numberingSystem_).
         1. If _hoursStyle_ is *"2-digit"*, then
-          1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"minimumIntegerDigits"*, *2*<sub>𝔽</sub>).
+          1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"minimumIntegerDigits"*, *2*<sub>𝔽</sub>).
         1. If _signDisplayed_ is *false*, then
-          1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"signDisplay"*, *"never"*).
-        1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"useGrouping"*, *false*).
-        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOpts_ »).
+          1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"signDisplay"*, *"never"*).
+        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"useGrouping"*, *false*).
+        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOptions_ »).
         1. Let _hoursParts_ be PartitionNumberPattern(_nf_, _hoursValue_).
         1. For each Record { [[Type]], [[Value]] } _part_ of _hoursParts_, do
           1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: *"hour"* } to _result_.
@@ -764,15 +764,15 @@
           1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _separator_, [[Unit]]: ~empty~ } to _result_.
         1. Let _minutesStyle_ be _durationFormat_.[[MinutesOptions]].[[Style]].
         1. Assert: _minutesStyle_ is *"numeric"* or _minutesStyle_ is *"2-digit"*.
-        1. Let _nfOpts_ be OrdinaryObjectCreate(*null*).
+        1. Let _nfOptions_ be OrdinaryObjectCreate(*null*).
         1. Let _numberingSystem_ be _durationFormat_.[[NumberingSystem]].
-        1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"numberingSystem"*, _numberingSystem_).
+        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"numberingSystem"*, _numberingSystem_).
         1. If _minutesStyle_ is *"2-digit"*, then
-          1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"minimumIntegerDigits"*, *2*<sub>𝔽</sub>).
+          1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"minimumIntegerDigits"*, *2*<sub>𝔽</sub>).
         1. If _signDisplayed_ is *false*, then
-          1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"signDisplay"*, *"never"*).
-        1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"useGrouping"*, *false*).
-        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOpts_ »).
+          1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"signDisplay"*, *"never"*).
+        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"useGrouping"*, *false*).
+        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOptions_ »).
         1. Let _minutesParts_ be PartitionNumberPattern(_nf_, _minutesValue_).
         1. For each Record { [[Type]], [[Value]] } _part_ of _minutesParts_, do
           1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: *"minute"* } to _result_.
@@ -801,23 +801,23 @@
           1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _separator_, [[Unit]]: ~empty~ } to _result_.
         1. Let _secondsStyle_ be _durationFormat_.[[SecondsOptions]].[[Style]].
         1. Assert: _secondsStyle_ is *"numeric"* or _secondsStyle_ is *"2-digit"*.
-        1. Let _nfOpts_ be OrdinaryObjectCreate(*null*).
+        1. Let _nfOptions_ be OrdinaryObjectCreate(*null*).
         1. Let _numberingSystem_ be _durationFormat_.[[NumberingSystem]].
-        1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"numberingSystem"*, _numberingSystem_).
+        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"numberingSystem"*, _numberingSystem_).
         1. If _secondsStyle_ is *"2-digit"*, then
-          1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"minimumIntegerDigits"*, *2*<sub>𝔽</sub>).
+          1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"minimumIntegerDigits"*, *2*<sub>𝔽</sub>).
         1. If _signDisplayed_ is *false*, then
-          1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"signDisplay"*, *"never"*).
-        1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"useGrouping"*, *false*).
+          1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"signDisplay"*, *"never"*).
+        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"useGrouping"*, *false*).
         1. Let _fractionDigits_ be _durationFormat_.[[FractionalDigits]].
         1. If _fractionDigits_ is *undefined*, then
-          1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"maximumFractionDigits"*, *9*<sub>𝔽</sub>).
-          1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"minimumFractionDigits"*, *+0*<sub>𝔽</sub>).
+          1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"maximumFractionDigits"*, *9*<sub>𝔽</sub>).
+          1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"minimumFractionDigits"*, *+0*<sub>𝔽</sub>).
         1. Else,
-          1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"maximumFractionDigits"*, _fractionDigits_).
-          1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"minimumFractionDigits"*, _fractionDigits_).
-        1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"roundingMode"*, *"trunc"*).
-        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOpts_ »).
+          1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"maximumFractionDigits"*, _fractionDigits_).
+          1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"minimumFractionDigits"*, _fractionDigits_).
+        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"roundingMode"*, *"trunc"*).
+        1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOptions_ »).
         1. Let _secondsParts_ be PartitionNumberPattern(_nf_, _secondsValue_).
         1. For each Record { [[Type]], [[Value]] } _part_ of _secondsParts_, do
           1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: *"second"* } to _result_.
@@ -911,13 +911,13 @@
         <dd>It creates a List corresponding to the parts within the Lists in _partitionedPartsList_ according to the effective locale and the formatting options of _durationFormat_.</dd>
       </dl>
       <emu-alg>
-        1. Let _lfOpts_ be OrdinaryObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_lfOpts_, *"type"*, *"unit"*).
+        1. Let _lfOptions_ be OrdinaryObjectCreate(*null*).
+        1. Perform ! CreateDataPropertyOrThrow(_lfOptions_, *"type"*, *"unit"*).
         1. Let _listStyle_ be _durationFormat_.[[Style]].
         1. If _listStyle_ is *"digital"*, then
           1. Set _listStyle_ to *"short"*.
-        1. Perform ! CreateDataPropertyOrThrow(_lfOpts_, *"style"*, _listStyle_).
-        1. Let _lf_ be ! Construct(%Intl.ListFormat%, « _durationFormat_.[[Locale]], _lfOpts_ »).
+        1. Perform ! CreateDataPropertyOrThrow(_lfOptions_, *"style"*, _listStyle_).
+        1. Let _lf_ be ! Construct(%Intl.ListFormat%, « _durationFormat_.[[Locale]], _lfOptions_ »).
         1. Let _strings_ be a new empty List.
         1. For each element _parts_ of _partitionedPartsList_, do
           1. Let _string_ be the empty String.
@@ -970,29 +970,29 @@
             1. If _numericPartsList_ is not empty, append _numericPartsList_ to _result_.
             1. Set _numericUnitFound_ to *true*.
           1. Else,
-            1. Let _nfOpts_ be OrdinaryObjectCreate(*null*).
+            1. Let _nfOptions_ be OrdinaryObjectCreate(*null*).
             1. If NextUnitFractional(_durationFormat_, _unit_) is *true*, then
               1. Set _value_ to _value_ + ComputeFractionalDigits(_durationFormat_, _duration_).
               1. Let _fractionDigits_ be _durationFormat_.[[FractionalDigits]].
               1. If _fractionDigits_ is *undefined*, then
-                1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"maximumFractionDigits"*, *9*<sub>𝔽</sub>).
-                1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"minimumFractionDigits"*, *+0*<sub>𝔽</sub>).
+                1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"maximumFractionDigits"*, *9*<sub>𝔽</sub>).
+                1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"minimumFractionDigits"*, *+0*<sub>𝔽</sub>).
               1. Else,
-                1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"maximumFractionDigits"*, _fractionDigits_).
-                1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"minimumFractionDigits"*, _fractionDigits_).
-              1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"roundingMode"*, *"trunc"*).
+                1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"maximumFractionDigits"*, _fractionDigits_).
+                1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"minimumFractionDigits"*, _fractionDigits_).
+              1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"roundingMode"*, *"trunc"*).
               1. Set _numericUnitFound_ to *true*.
             1. If _display_ is *"always"* or _value_ is not 0, then
-              1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"numberingSystem"*, _durationFormat_.[[NumberingSystem]]).
+              1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"numberingSystem"*, _durationFormat_.[[NumberingSystem]]).
               1. If _signDisplayed_ is *true*, then
                 1. Set _signDisplayed_ to *false*.
                 1. If _value_ is 0 and DurationSign(_duration_) is -1, set _value_ to ~negative-zero~.
               1. Else,
-                1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"signDisplay"*, *"never"*).
-              1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"style"*, *"unit"*).
-              1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"unit"*, _numberFormatUnit_).
-              1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"unitDisplay"*, _style_).
-              1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOpts_ »).
+                1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"signDisplay"*, *"never"*).
+              1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"style"*, *"unit"*).
+              1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"unit"*, _numberFormatUnit_).
+              1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"unitDisplay"*, _style_).
+              1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOptions_ »).
               1. Let _parts_ be PartitionNumberPattern(_nf_, _value_).
               1. Let _list_ be a new empty List.
               1. For each Record { [[Type]], [[Value]] } _part_ of _parts_, do

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -89,8 +89,8 @@
       <p>When the `getCanonicalLocales` method is called with argument _locales_, the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _ll_ be ? CanonicalizeLocaleList(_locales_).
-        1. Return CreateArrayFromList(_ll_).
+        1. Let _localeList_ be ? CanonicalizeLocaleList(_locales_).
+        1. Return CreateArrayFromList(_localeList_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -22,13 +22,13 @@
         1. Let _listFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.ListFormat.prototype%"*, « [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[Templates]] »).
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.ListFormat%, %Intl.ListFormat%.[[LocaleData]], _locales_, _options_).
         1. Set _options_ to _optionsResolution_.[[Options]].
-        1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
-        1. Set _listFormat_.[[Locale]] to _r_.[[Locale]].
+        1. Let _resolvedLocale_ be _optionsResolution_.[[ResolvedLocale]].
+        1. Set _listFormat_.[[Locale]] to _resolvedLocale_.[[Locale]].
         1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, « *"conjunction"*, *"disjunction"*, *"unit"* », *"conjunction"*).
         1. Set _listFormat_.[[Type]] to _type_.
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"long"*, *"short"*, *"narrow"* », *"long"*).
         1. Set _listFormat_.[[Style]] to _style_.
-        1. Let _resolvedLocaleData_ be _r_.[[LocaleData]].
+        1. Let _resolvedLocaleData_ be _resolvedLocale_.[[LocaleData]].
         1. Let _dataLocaleTypes_ be _resolvedLocaleData_.[[&lt;_type_>]].
         1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[&lt;_style_>]].
         1. Return _listFormat_.
@@ -121,10 +121,10 @@
         1. Perform ? RequireInternalSlot(_lf_, [[InitializedListFormat]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. For each row of <emu-xref href="#table-listformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _lf_'s internal slot whose name is the Internal Slot value of the current row.
-          1. Assert: _v_ is not *undefined*.
-          1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+          1. Let _propertyKey_ be the Property value of the current row.
+          1. Let _value_ be the value of _lf_'s internal slot whose name is the Internal Slot value of the current row.
+          1. Assert: _value_ is not *undefined*.
+          1. Perform ! CreateDataPropertyOrThrow(_options_, _propertyKey_, _value_).
         1. Return _options_.
       </emu-alg>
 
@@ -244,17 +244,17 @@ Output (List of parts Records):
         1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. Let _result_ be a new empty List.
         1. For each Record { [[Type]], [[Value]] } _patternPart_ of _patternParts_, do
-          1. Let _part_ be _patternPart_.[[Type]].
-          1. If _part_ is *"literal"*, then
+          1. Let _partType_ be _patternPart_.[[Type]].
+          1. If _partType_ is *"literal"*, then
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
           1. Else,
-            1. Assert: _placeables_ has a field [[&lt;_part_>]].
-            1. Let _subst_ be _placeables_.[[&lt;_part_>]].
-            1. If _subst_ is a List, then
-              1. For each element _s_ of _subst_, do
-                1. Append _s_ to _result_.
+            1. Assert: _placeables_ has a field [[&lt;_partType_>]].
+            1. Let _substitution_ be _placeables_.[[&lt;_partType_>]].
+            1. If _substitution_ is a List, then
+              1. For each element _part_ of _substitution_, do
+                1. Append _part_ to _result_.
             1. Else,
-              1. Append _subst_ to _result_.
+              1. Append _substitution_ to _result_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -336,10 +336,10 @@ Output (List of parts Records):
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each Record { [[Type]], [[Value]] } _part_ of _parts_, do
-          1. Let _O_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _O_).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -18,11 +18,11 @@
       <p>When the `localeCompare` method is called with argument _that_ and optional arguments _locales_, and _options_, the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _O_ be ? RequireObjectCoercible(*this* value).
-        1. Let _S_ be ? ToString(_O_).
+        1. Let _thisValue_ be ? RequireObjectCoercible(*this* value).
+        1. Let _string_ be ? ToString(_thisValue_).
         1. Let _thatValue_ be ? ToString(_that_).
         1. Let _collator_ be ? Construct(%Intl.Collator%, « _locales_, _options_ »).
-        1. Return CompareStrings(_collator_, _S_, _thatValue_).
+        1. Return CompareStrings(_collator_, _string_, _thatValue_).
       </emu-alg>
 
       <p>The *"length"* property of this function is *1*<sub>𝔽</sub>.</p>
@@ -44,9 +44,9 @@
       <p>This function interprets a String value as a sequence of code points, as described in ECMA-262, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. The following steps are taken:</p>
 
       <emu-alg>
-        1. Let _O_ be ? RequireObjectCoercible(*this* value).
-        1. Let _S_ be ? ToString(_O_).
-        1. Return ? TransformCase(_S_, _locales_, ~lower~).
+        1. Let _thisValue_ be ? RequireObjectCoercible(*this* value).
+        1. Let _string_ be ? ToString(_thisValue_).
+        1. Return ? TransformCase(_string_, _locales_, ~lower~).
       </emu-alg>
 
       <emu-note>
@@ -56,14 +56,14 @@
       <emu-clause id="sec-transform-case" type="abstract operation">
         <h1>
           TransformCase (
-            _S_: a String,
+            _string_: a String,
             _locales_: an ECMAScript language value,
             _targetCase_: ~lower~ or ~upper~,
           )
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It interprets _S_ as a sequence of UTF-16 encoded code points, as described in ECMA-262, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and returns the result of ILD transformation into _targetCase_ as a new String value.</dd>
+          <dd>It interprets _string_ as a sequence of UTF-16 encoded code points, as described in ECMA-262, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and returns the result of ILD transformation into _targetCase_ as a new String value.</dd>
         </dl>
         <emu-alg>
           1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
@@ -74,7 +74,7 @@
           1. Let _availableLocales_ be an Available Locales List which includes the language tags for which the Unicode Character Database contains language-sensitive case mappings. If the implementation supports additional locale-sensitive case mappings, _availableLocales_ should also include their corresponding language tags.
           1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, « _requestedLocale_ »).
           1. If _match_ is not *undefined*, let _locale_ be _match_.[[locale]]; else let _locale_ be *"und"*.
-          1. Let _codePoints_ be StringToCodePoints(_S_).
+          1. Let _codePoints_ be StringToCodePoints(_string_).
           1. If _targetCase_ is ~lower~, then
             1. Let _newCodePoints_ be a List whose elements are the result of a lowercase transformation of _codePoints_ according to an implementation-derived algorithm using _locale_ or the Unicode Default Case Conversion algorithm.
           1. Else,
@@ -99,9 +99,9 @@
       <p>This function interprets a String value as a sequence of code points, as described in ECMA-262, <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. The following steps are taken:</p>
 
       <emu-alg>
-        1. Let _O_ be ? RequireObjectCoercible(*this* value).
-        1. Let _S_ be ? ToString(_O_).
-        1. Return ? TransformCase(_S_, _locales_, ~upper~).
+        1. Let _thisValue_ be ? RequireObjectCoercible(*this* value).
+        1. Let _string_ be ? ToString(_thisValue_).
+        1. Return ? TransformCase(_string_, _locales_, ~upper~).
       </emu-alg>
 
       <emu-note>
@@ -163,9 +163,9 @@
       <p>When the `toLocaleString` method is called with optional arguments _locales_ and _options_, the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _dateObject_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
-        1. Let _x_ be _dateObject_.[[DateValue]].
+        1. Let _dateObj_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
+        1. Let _x_ be _dateObj_.[[DateValue]].
         1. If _x_ is *NaN*, return *"Invalid Date"*.
         1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~any~, ~all~).
         1. Return ! FormatDateTime(_dateFormat_, _x_).
@@ -180,9 +180,9 @@
       <p>When the `toLocaleDateString` method is called with optional arguments _locales_ and _options_, the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _dateObject_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
-        1. Let _x_ be _dateObject_.[[DateValue]].
+        1. Let _dateObj_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
+        1. Let _x_ be _dateObj_.[[DateValue]].
         1. If _x_ is *NaN*, return *"Invalid Date"*.
         1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~date~, ~date~).
         1. Return ! FormatDateTime(_dateFormat_, _x_).
@@ -197,9 +197,9 @@
       <p>When the `toLocaleTimeString` method is called with optional arguments _locales_ and _options_, the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _dateObject_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
-        1. Let _x_ be _dateObject_.[[DateValue]].
+        1. Let _dateObj_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
+        1. Let _x_ be _dateObj_.[[DateValue]].
         1. If _x_ is *NaN*, return *"Invalid Date"*.
         1. Let _timeFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~time~, ~time~).
         1. Return ! FormatDateTime(_timeFormat_, _x_).
@@ -221,17 +221,17 @@
         1. Let _array_ be ? ToObject(*this* value).
         1. Let _len_ be ? LengthOfArrayLike(_array_).
         1. Let _separator_ be the implementation-defined list-separator String value appropriate for the host environment's current locale (such as *", "*).
-        1. Let _R_ be the empty String.
+        1. Let _result_ be the empty String.
         1. Let _k_ be 0.
         1. Repeat, while _k_ &lt; _len_,
           1. If _k_ > 0, then
-            1. Set _R_ to the string-concatenation of _R_ and _separator_.
-          1. Let _nextElement_ be ? Get(_array_, ! ToString(𝔽(_k_))).
-          1. If _nextElement_ is not *undefined* or *null*, then
-            1. Let _S_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*, « _locales_, _options_ »)).
-            1. Set _R_ to the string-concatenation of _R_ and _S_.
+            1. Set _result_ to the string-concatenation of _result_ and _separator_.
+          1. Let _element_ be ? Get(_array_, ! ToString(𝔽(_k_))).
+          1. If _element_ is not *undefined* or *null*, then
+            1. Let _elementString_ be ? ToString(? Invoke(_element_, *"toLocaleString"*, « _locales_, _options_ »)).
+            1. Set _result_ to the string-concatenation of _result_ and _elementString_.
           1. Set _k_ to _k_ + 1.
-        1. Return _R_.
+        1. Return _result_.
       </emu-alg>
 
       <emu-note>

--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -227,7 +227,7 @@
           1. If _k_ > 0, then
             1. Set _result_ to the string-concatenation of _result_ and _separator_.
           1. Let _element_ be ? Get(_array_, ! ToString(𝔽(_k_))).
-          1. If _element_ is not *undefined* or *null*, then
+          1. If _element_ is neither *undefined* nor *null*, then
             1. Let _elementString_ be ? ToString(? Invoke(_element_, *"toLocaleString"*, « _locales_, _options_ »)).
             1. Set _result_ to the string-concatenation of _result_ and _elementString_.
           1. Set _k_ to _k_ + 1.

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -59,20 +59,20 @@
         1. If _numberingSystem_ is not *undefined*, then
           1. If _numberingSystem_ cannot be matched by the <code>type</code> Unicode locale nonterminal, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numberingSystem_.
-        1. Let _r_ be MakeLocaleRecord(_tag_, _opt_, _localeExtensionKeys_).
-        1. Set _locale_.[[Locale]] to _r_.[[locale]].
-        1. Set _locale_.[[Calendar]] to _r_.[[ca]].
-        1. Set _locale_.[[Collation]] to _r_.[[co]].
-        1. Set _locale_.[[FirstDayOfWeek]] to _r_.[[fw]].
-        1. Set _locale_.[[HourCycle]] to _r_.[[hc]].
+        1. Let _localeRecord_ be MakeLocaleRecord(_tag_, _opt_, _localeExtensionKeys_).
+        1. Set _locale_.[[Locale]] to _localeRecord_.[[locale]].
+        1. Set _locale_.[[Calendar]] to _localeRecord_.[[ca]].
+        1. Set _locale_.[[Collation]] to _localeRecord_.[[co]].
+        1. Set _locale_.[[FirstDayOfWeek]] to _localeRecord_.[[fw]].
+        1. Set _locale_.[[HourCycle]] to _localeRecord_.[[hc]].
         1. If _localeExtensionKeys_ contains *"kf"*, then
-          1. Set _locale_.[[CaseFirst]] to _r_.[[kf]].
+          1. Set _locale_.[[CaseFirst]] to _localeRecord_.[[kf]].
         1. If _localeExtensionKeys_ contains *"kn"*, then
-          1. If SameValue(_r_.[[kn]], *"true"*) is *true* or _r_.[[kn]] is the empty String, then
+          1. If SameValue(_localeRecord_.[[kn]], *"true"*) is *true* or _localeRecord_.[[kn]] is the empty String, then
             1. Set _locale_.[[Numeric]] to *true*.
           1. Else,
             1. Set _locale_.[[Numeric]] to *false*.
-        1. Set _locale_.[[NumberingSystem]] to _r_.[[nu]].
+        1. Set _locale_.[[NumberingSystem]] to _localeRecord_.[[nu]].
         1. Return _locale_.
       </emu-alg>
     </emu-clause>
@@ -418,9 +418,9 @@
         1. Let _loc_ be the *this* value.
         1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
         1. Let _info_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _wi_ be WeekInfoOfLocale(_loc_).
-        1. Perform ! CreateDataPropertyOrThrow(_info_, *"firstDay"*, _wi_.[[FirstDay]]).
-        1. Perform ! CreateDataPropertyOrThrow(_info_, *"weekend"*, CreateArrayFromList(_wi_.[[Weekend]])).
+        1. Let _weekInfo_ be WeekInfoOfLocale(_loc_).
+        1. Perform ! CreateDataPropertyOrThrow(_info_, *"firstDay"*, _weekInfo_.[[FirstDay]]).
+        1. Perform ! CreateDataPropertyOrThrow(_info_, *"weekend"*, CreateArrayFromList(_weekInfo_.[[Weekend]])).
         1. Return _info_.
       </emu-alg>
     </emu-clause>
@@ -655,9 +655,9 @@
           1. Return CreateArrayFromList(« _loc_.[[Collation]] »).
         1. Let _language_ be GetLocaleLanguage(_loc_.[[Locale]]).
         1. If _language_ is not *"und"*, then
-          1. Let _r_ be LookupMatchingLocaleByPrefix(%Intl.Collator%.[[AvailableLocales]], « _loc_.[[Locale]] »).
-          1. If _r_ is not *undefined*, then
-            1. Let _foundLocale_ be _r_.[[locale]].
+          1. Let _match_ be LookupMatchingLocaleByPrefix(%Intl.Collator%.[[AvailableLocales]], « _loc_.[[Locale]] »).
+          1. If _match_ is not *undefined*, then
+            1. Let _foundLocale_ be _match_.[[locale]].
           1. Else,
             1. Let _foundLocale_ be DefaultLocale().
           1. Let _foundLocaleData_ be %Intl.Collator%.[[SortLocaleData]].[[&lt;_foundLocale_&gt;]].
@@ -708,9 +708,9 @@
       <emu-alg>
         1. If _loc_.[[NumberingSystem]] is not *undefined*, then
           1. Return CreateArrayFromList(« _loc_.[[NumberingSystem]] »).
-        1. Let _r_ be LookupMatchingLocaleByPrefix(%Intl.NumberFormat%.[[AvailableLocales]], « _loc_.[[Locale]] »).
-        1. If _r_ is not *undefined*, then
-          1. Let _foundLocale_ be _r_.[[locale]].
+        1. Let _match_ be LookupMatchingLocaleByPrefix(%Intl.NumberFormat%.[[AvailableLocales]], « _loc_.[[Locale]] »).
+        1. If _match_ is not *undefined*, then
+          1. Let _foundLocale_ be _match_.[[locale]].
           1. Let _foundLocaleData_ be %Intl.NumberFormat%.[[LocaleData]].[[&lt;_foundLocale_&gt;]].
           1. Let _numberingSystems_ be _foundLocaleData_.[[nu]].
           1. Let _list_ be « _numberingSystems_[0] ».
@@ -777,9 +777,9 @@
       </dl>
       <emu-alg>
         1. For each row of <emu-xref href="#table-locale-weekday-string-value"></emu-xref>, except the header row, in table order, do
-          1. Let _w_ be the Weekday value of the current row.
-          1. Let _s_ be the String value of the current row.
-          1. If _fw_ is equal to _w_, return _s_.
+          1. Let _weekday_ be the Weekday value of the current row.
+          1. Let _string_ be the String value of the current row.
+          1. If _fw_ is equal to _weekday_, return _string_.
         1. Return _fw_.
       </emu-alg>
 
@@ -849,9 +849,9 @@
       </dl>
       <emu-alg>
         1. For each row of <emu-xref href="#table-locale-weekday-string-value"></emu-xref>, except the header row, in table order, do
-          1. Let _s_ be the String value of the current row.
-          1. Let _v_ be the Value value of the current row.
-          1. If _fw_ is equal to _s_, return _v_.
+          1. Let _string_ be the String value of the current row.
+          1. Let _value_ be the Value value of the current row.
+          1. If _fw_ is equal to _string_, return _value_.
         1. Return *undefined*.
       </emu-alg>
     </emu-clause>
@@ -868,13 +868,13 @@
       </dl>
       <emu-alg>
         1. Let _locale_ be _loc_.[[Locale]].
-        1. Let _r_ be a Record whose fields are defined by <emu-xref href="#table-locale-weekinfo-record"></emu-xref>, with values based on _locale_.
-        1. Let _fws_ be _loc_.[[FirstDayOfWeek]].
-        1. If _fws_ is not *undefined*, then
-          1. Let _fw_ be WeekdayUValueToNumber(_fws_).
-          1. If _fw_ is not *undefined*, then
-            1. Set _r_.[[FirstDay]] to _fw_.
-        1. Return _r_.
+        1. Let _weekInfo_ be a Record whose fields are defined by <emu-xref href="#table-locale-weekinfo-record"></emu-xref>, with values based on _locale_.
+        1. Let _firstDayString_ be _loc_.[[FirstDayOfWeek]].
+        1. If _firstDayString_ is not *undefined*, then
+          1. Let _firstDay_ be WeekdayUValueToNumber(_firstDayString_).
+          1. If _firstDay_ is not *undefined*, then
+            1. Set _weekInfo_.[[FirstDay]] to _firstDay_.
+        1. Return _weekInfo_.
       </emu-alg>
 
       <emu-note>

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -68,7 +68,7 @@
         1. If _localeExtensionKeys_ contains *"kf"*, then
           1. Set _locale_.[[CaseFirst]] to _localeRecord_.[[kf]].
         1. If _localeExtensionKeys_ contains *"kn"*, then
-          1. If SameValue(_localeRecord_.[[kn]], *"true"*) is *true* or _localeRecord_.[[kn]] is the empty String, then
+          1. If _localeRecord_.[[kn]] is either *"true"* or the empty String, then
             1. Set _locale_.[[Numeric]] to *true*.
           1. Else,
             1. Set _locale_.[[Numeric]] to *false*.
@@ -656,10 +656,7 @@
         1. Let _language_ be GetLocaleLanguage(_loc_.[[Locale]]).
         1. If _language_ is not *"und"*, then
           1. Let _match_ be LookupMatchingLocaleByPrefix(%Intl.Collator%.[[AvailableLocales]], « _loc_.[[Locale]] »).
-          1. If _match_ is not *undefined*, then
-            1. Let _foundLocale_ be _match_.[[locale]].
-          1. Else,
-            1. Let _foundLocale_ be DefaultLocale().
+          1. If _match_ is not *undefined*, let _foundLocale_ be _match_.[[locale]]; else let _foundLocale_ be DefaultLocale().
           1. Let _foundLocaleData_ be %Intl.Collator%.[[SortLocaleData]].[[&lt;_foundLocale_&gt;]].
           1. Let _list_ be a copy of _foundLocaleData_.[[co]].
           1. Assert: _list_[0] is *null*.
@@ -872,8 +869,7 @@
         1. Let _firstDayString_ be _loc_.[[FirstDayOfWeek]].
         1. If _firstDayString_ is not *undefined*, then
           1. Let _firstDay_ be WeekdayUValueToNumber(_firstDayString_).
-          1. If _firstDay_ is not *undefined*, then
-            1. Set _weekInfo_.[[FirstDay]] to _firstDay_.
+          1. If _firstDay_ is not *undefined*, set _weekInfo_.[[FirstDay]] to _firstDay_.
         1. Return _weekInfo_.
       </emu-alg>
 

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -10,8 +10,8 @@
     <emu-note>
       For example, *"ß"* (U+00DF) must not match or be mapped to *"SS"* (U+0053, U+0053). *"ı"* (U+0131) must not match or be mapped to *"I"* (U+0049).
     </emu-note>
-    <p>The <dfn>ASCII-uppercase</dfn> of a String value _S_ is the String value derived from _S_ by replacing each occurrence of an ASCII lowercase letter code unit (0x0061 through 0x007A, inclusive) with the corresponding ASCII uppercase letter code unit (0x0041 through 0x005A, inclusive) while preserving all other code units.</p>
-    <p>The <dfn>ASCII-lowercase</dfn> of a String value _S_ is the String value derived from _S_ by replacing each occurrence of an ASCII uppercase letter code unit (0x0041 through 0x005A, inclusive) with the corresponding ASCII lowercase letter code unit (0x0061 through 0x007A, inclusive) while preserving all other code units.</p>
+    <p>The <dfn>ASCII-uppercase</dfn> of a String value _string_ is the String value derived from _string_ by replacing each occurrence of an ASCII lowercase letter code unit (0x0061 through 0x007A, inclusive) with the corresponding ASCII uppercase letter code unit (0x0041 through 0x005A, inclusive) while preserving all other code units.</p>
+    <p>The <dfn>ASCII-lowercase</dfn> of a String value _string_ is the String value derived from _string_ by replacing each occurrence of an ASCII uppercase letter code unit (0x0041 through 0x005A, inclusive) with the corresponding ASCII lowercase letter code unit (0x0061 through 0x007A, inclusive) while preserving all other code units.</p>
     <p>A String value _A_ is an <dfn>ASCII-case-insensitive match</dfn> for String value _B_ if the ASCII-uppercase of _A_ is exactly the same sequence of code units as the ASCII-uppercase of _B_. A sequence of Unicode code points _A_ is an ASCII-case-insensitive match for _B_ if _B_ is an ASCII-case-insensitive match for CodePointsToString(_A_).</p>
   </emu-clause>
 
@@ -269,7 +269,7 @@
             1. Set _primary_ to _renamedIdentifier_.
           1. Let _record_ be the Time Zone Identifier Record { [[Identifier]]: _identifier_, [[PrimaryIdentifier]]: _primary_ }.
           1. Append _record_ to _result_.
-        1. Assert: _result_ contains a Time Zone Identifier Record _r_ such that _r_.[[Identifier]] is *"UTC"* and _r_.[[PrimaryIdentifier]] is *"UTC"*.
+        1. Assert: _result_ contains a Time Zone Identifier Record _record_ such that _record_.[[Identifier]] is *"UTC"* and _record_.[[PrimaryIdentifier]] is *"UTC"*.
         1. Return _result_.
       </emu-alg>
 
@@ -344,31 +344,31 @@
     <emu-clause id="sec-string-split-to-list" type="abstract operation">
       <h1>
         StringSplitToList (
-          _S_: a String,
+          _string_: a String,
           _separator_: a String,
         ): a List of Strings
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          The returned List contains all disjoint substrings of _S_ that do not contain _separator_ but are immediately preceded and/or immediately followed by an occurrence of _separator_.
-          Each such <emu-not-ref>substring</emu-not-ref> will be the empty String between adjacent occurrences of _separator_, before a _separator_ at the very start of _S_, or after a _separator_ at the very end of _S_, but otherwise will not be empty.
+          The returned List contains all disjoint substrings of _string_ that do not contain _separator_ but are immediately preceded and/or immediately followed by an occurrence of _separator_.
+          Each such <emu-not-ref>substring</emu-not-ref> will be the empty String between adjacent occurrences of _separator_, before a _separator_ at the very start of _string_, or after a _separator_ at the very end of _string_, but otherwise will not be empty.
         </dd>
       </dl>
       <emu-alg>
-        1. Assert: _S_ is not the empty String.
+        1. Assert: _string_ is not the empty String.
         1. Assert: _separator_ is not the empty String.
         1. Let _separatorLength_ be the length of _separator_.
         1. Let _substrings_ be a new empty List.
         1. Let _i_ be 0.
-        1. Let _j_ be StringIndexOf(_S_, _separator_, 0).
+        1. Let _j_ be StringIndexOf(_string_, _separator_, 0).
         1. Repeat, while _j_ is not ~not-found~,
-          1. Let _T_ be the substring of _S_ from _i_ to _j_.
-          1. Append _T_ to _substrings_.
+          1. Let _substring_ be the substring of _string_ from _i_ to _j_.
+          1. Append _substring_ to _substrings_.
           1. Set _i_ to _j_ + _separatorLength_.
-          1. Set _j_ to StringIndexOf(_S_, _separator_, _i_).
-        1. Let _T_ be the substring of _S_ from _i_.
-        1. Append _T_ to _substrings_.
+          1. Set _j_ to StringIndexOf(_string_, _separator_, _i_).
+        1. Let _substring_ be the substring of _string_ from _i_.
+        1. Append _substring_ to _substrings_.
         1. Return _substrings_.
       </emu-alg>
     </emu-clause>

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -269,7 +269,7 @@
             1. Set _primary_ to _renamedIdentifier_.
           1. Let _record_ be the Time Zone Identifier Record { [[Identifier]]: _identifier_, [[PrimaryIdentifier]]: _primary_ }.
           1. Append _record_ to _result_.
-        1. Assert: _result_ contains a Time Zone Identifier Record _record_ such that _record_.[[Identifier]] is *"UTC"* and _record_.[[PrimaryIdentifier]] is *"UTC"*.
+        1. Assert: _result_ contains a Time Zone Identifier Record _utcRecord_ such that _utcRecord_.[[Identifier]] is *"UTC"* and _utcRecord_.[[PrimaryIdentifier]] is *"UTC"*.
         1. Return _result_.
       </emu-alg>
 

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -49,21 +49,21 @@
           1. Return a new empty List.
         1. Let _seen_ be a new empty List.
         1. If _locales_ is a String or _locales_ is an Object and _locales_ has an [[InitializedLocale]] internal slot, then
-          1. Let _obj_ be CreateArrayFromList(« _locales_ »).
+          1. Let _localesObj_ be CreateArrayFromList(« _locales_ »).
         1. Else,
-          1. Let _obj_ be ? ToObject(_locales_).
-        1. Let _len_ be ? LengthOfArrayLike(_obj_).
+          1. Let _localesObj_ be ? ToObject(_locales_).
+        1. Let _len_ be ? LengthOfArrayLike(_localesObj_).
         1. Let _k_ be 0.
         1. Repeat, while _k_ &lt; _len_,
           1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
-          1. Let _kPresent_ be ? HasProperty(_obj_, _propertyKey_).
-          1. If _kPresent_ is *true*, then
-            1. Let _kValue_ be ? Get(_obj_, _propertyKey_).
-            1. If _kValue_ is not a String and _kValue_ is not an Object, throw a *TypeError* exception.
-            1. If _kValue_ is an Object and _kValue_ has an [[InitializedLocale]] internal slot, then
-              1. Let _tag_ be _kValue_.[[Locale]].
+          1. Let _exists_ be ? HasProperty(_localesObj_, _propertyKey_).
+          1. If _exists_ is *true*, then
+            1. Let _element_ be ? Get(_localesObj_, _propertyKey_).
+            1. If _element_ is neither a String nor an Object, throw a *TypeError* exception.
+            1. If _element_ is an Object and _element_ has an [[InitializedLocale]] internal slot, then
+              1. Let _tag_ be _element_.[[Locale]].
             1. Else,
-              1. Let _tag_ be ? ToString(_kValue_).
+              1. Let _tag_ be ? ToString(_element_).
             1. If IsWellFormedLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
             1. Let _canonicalizedTag_ be CanonicalizeUnicodeLocaleId(_tag_).
             1. If _seen_ does not contain _canonicalizedTag_, append _canonicalizedTag_ to _seen_.
@@ -76,7 +76,7 @@
       </emu-note>
 
       <emu-note>
-        Requiring _kValue_ to be a String or Object means that the Number value *NaN* will not be interpreted as the language tag *"nan"*, which stands for Min Nan Chinese.
+        Requiring _element_ to be a String or Object means that the Number value *NaN* will not be interpreted as the language tag *"nan"*, which stands for Min Nan Chinese.
       </emu-note>
     </emu-clause>
 

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -49,16 +49,16 @@
           1. Return a new empty List.
         1. Let _seen_ be a new empty List.
         1. If _locales_ is a String or _locales_ is an Object and _locales_ has an [[InitializedLocale]] internal slot, then
-          1. Let _O_ be CreateArrayFromList(« _locales_ »).
+          1. Let _obj_ be CreateArrayFromList(« _locales_ »).
         1. Else,
-          1. Let _O_ be ? ToObject(_locales_).
-        1. Let _len_ be ? LengthOfArrayLike(_O_).
+          1. Let _obj_ be ? ToObject(_locales_).
+        1. Let _len_ be ? LengthOfArrayLike(_obj_).
         1. Let _k_ be 0.
         1. Repeat, while _k_ &lt; _len_,
-          1. Let _Pk_ be ! ToString(𝔽(_k_)).
-          1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
+          1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
+          1. Let _kPresent_ be ? HasProperty(_obj_, _propertyKey_).
           1. If _kPresent_ is *true*, then
-            1. Let _kValue_ be ? Get(_O_, _Pk_).
+            1. Let _kValue_ be ? Get(_obj_, _propertyKey_).
             1. If _kValue_ is not a String and _kValue_ is not an Object, throw a *TypeError* exception.
             1. If _kValue_ is an Object and _kValue_ has an [[InitializedLocale]] internal slot, then
               1. Let _tag_ be _kValue_.[[Locale]].
@@ -232,17 +232,17 @@
       <emu-alg>
         1. Let _matcher_ be _options_.[[localeMatcher]].
         1. If _matcher_ is *"lookup"*, then
-          1. Let _r_ be LookupMatchingLocaleByPrefix(_availableLocales_, _requestedLocales_).
+          1. Let _match_ be LookupMatchingLocaleByPrefix(_availableLocales_, _requestedLocales_).
         1. Else,
-          1. Let _r_ be LookupMatchingLocaleByBestFit(_availableLocales_, _requestedLocales_).
-        1. If _r_ is *undefined*, set _r_ to the Record { [[locale]]: DefaultLocale(), [[extension]]: ~empty~ }.
-        1. Let _foundLocale_ be _r_.[[locale]].
+          1. Let _match_ be LookupMatchingLocaleByBestFit(_availableLocales_, _requestedLocales_).
+        1. If _match_ is *undefined*, set _match_ to the Record { [[locale]]: DefaultLocale(), [[extension]]: ~empty~ }.
+        1. Let _foundLocale_ be _match_.[[locale]].
         1. Let _foundLocaleData_ be _localeData_.[[&lt;_foundLocale_>]].
         1. Assert: _foundLocaleData_ is a Record.
         1. Let _result_ be a new Record.
         1. Set _result_.[[LocaleData]] to _foundLocaleData_.
-        1. If _r_.[[extension]] is not ~empty~, then
-          1. Let _components_ be UnicodeExtensionComponents(_r_.[[extension]]).
+        1. If _match_.[[extension]] is not ~empty~, then
+          1. Let _components_ be UnicodeExtensionComponents(_match_.[[extension]]).
           1. Let _keywords_ be _components_.[[Keywords]].
         1. Else,
           1. Let _keywords_ be a new empty List.
@@ -287,7 +287,7 @@
     <emu-clause id="sec-resolveoptions" type="abstract operation">
       <h1>
         ResolveOptions (
-          _constructor_: a service constructor,
+          _ctor_: a service constructor,
           _localeData_: a Record,
           _locales_: an ECMAScript language value,
           _options_: an ECMAScript language value,
@@ -297,7 +297,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It reads the inputs for _constructor_ and resolves them into a locale.</dd>
+        <dd>It reads the inputs for _ctor_ and resolves them into a locale.</dd>
       </dl>
       <emu-alg>
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
@@ -305,7 +305,7 @@
         1. If _specialBehaviours_ is present and contains ~coerce-options~, set _options_ to ? CoerceOptionsToObject(_options_). Otherwise, set _options_ to ? GetOptionsObject(_options_).
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Let _opt_ be the Record { [[localeMatcher]]: _matcher_ }.
-        1. For each Resolution Option Descriptor _desc_ of _constructor_.[[ResolutionOptionDescriptors]], do
+        1. For each Resolution Option Descriptor _desc_ of _ctor_.[[ResolutionOptionDescriptors]], do
           1. If _desc_ has a [[Type]] field, let _type_ be _desc_.[[Type]]. Otherwise, let _type_ be ~string~.
           1. If _desc_ has a [[Values]] field, let _values_ be _desc_.[[Values]]. Otherwise, let _values_ be ~empty~.
           1. Let _value_ be ? GetOption(_options_, _desc_.[[Property]], _type_, _values_, *undefined*).
@@ -315,7 +315,7 @@
           1. Let _key_ be _desc_.[[Key]].
           1. Set _opt_.[[&lt;_key_>]] to _value_.
         1. If _modifyResolutionOptions_ is present, perform ! _modifyResolutionOptions_(_opt_).
-        1. Let _resolution_ be ResolveLocale(_constructor_.[[AvailableLocales]], _requestedLocales_, _opt_, _constructor_.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _resolution_ be ResolveLocale(_ctor_.[[AvailableLocales]], _requestedLocales_, _opt_, _ctor_.[[RelevantExtensionKeys]], _localeData_).
         1. Return the Record { [[Options]]: _options_, [[ResolvedLocale]]: _resolution_, [[ResolutionOptions]]: _opt_ }.
       </emu-alg>
     </emu-clause>
@@ -370,7 +370,7 @@
       <h1>
         GetOption (
           _options_: an Object,
-          _property_: a property key,
+          _propertyKey_: a property key,
           _type_: ~boolean~ or ~string~,
           _values_: ~empty~ or a List of ECMAScript language values,
           _default_: ~required~ or an ECMAScript language value,
@@ -381,7 +381,7 @@
         <dd>It extracts the value of the specified property of _options_, converts it to the required _type_, checks whether it is allowed by _values_ if _values_ is not ~empty~, and substitutes _default_ if the value is *undefined*.</dd>
       </dl>
       <emu-alg>
-        1. Let _value_ be ? Get(_options_, _property_).
+        1. Let _value_ be ? Get(_options_, _propertyKey_).
         1. If _value_ is *undefined*, then
           1. If _default_ is ~required~, throw a *RangeError* exception.
           1. Return _default_.
@@ -399,17 +399,17 @@
       <h1>
         GetBooleanOrStringNumberFormatOption (
           _options_: an Object,
-          _property_: a property key,
+          _propertyKey_: a property key,
           _stringValues_: a List of Strings,
           _fallback_: an ECMAScript language value,
         ): either a normal completion containing either a Boolean, String, or _fallback_, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It extracts the value of the property named _property_ from the provided _options_ object. It returns _fallback_ if that value is *undefined*, *true* if that value is *true*, *false* if that value coerces to *false*, and otherwise coerces it to a String and returns the result if it is allowed by _stringValues_.</dd>
+        <dd>It extracts the value of the property named _propertyKey_ from the provided _options_ object. It returns _fallback_ if that value is *undefined*, *true* if that value is *true*, *false* if that value coerces to *false*, and otherwise coerces it to a String and returns the result if it is allowed by _stringValues_.</dd>
       </dl>
       <emu-alg>
-        1. Let _value_ be ? Get(_options_, _property_).
+        1. Let _value_ be ? Get(_options_, _propertyKey_).
         1. If _value_ is *undefined*, return _fallback_.
         1. If _value_ is *true*, return *true*.
         1. If ToBoolean(_value_) is *false*, return *false*.
@@ -444,7 +444,7 @@
       <h1>
         GetNumberOption (
           _options_: an Object,
-          _property_: a String,
+          _propertyKey_: a String,
           _minimum_: an integer,
           _maximum_: an integer,
           _fallback_: an integer or *undefined*,
@@ -452,10 +452,10 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It extracts the value of the property named _property_ from the provided _options_ object, converts it to an integer, checks whether it is in the allowed range, and fills in a _fallback_ value if necessary.</dd>
+        <dd>It extracts the value of the property named _propertyKey_ from the provided _options_ object, converts it to an integer, checks whether it is in the allowed range, and fills in a _fallback_ value if necessary.</dd>
       </dl>
       <emu-alg>
-        1. Let _value_ be ? Get(_options_, _property_).
+        1. Let _value_ be ? Get(_options_, _propertyKey_).
         1. Return ? DefaultNumberOption(_value_, _minimum_, _maximum_, _fallback_).
       </emu-alg>
     </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -723,9 +723,9 @@
           1. Let _i_ be StringIndexOf(_string_, *"."*, 0).
           1. If _i_ is not ~not-found~, set _string_ to the substring of _string_ from 0 to _i_.
         1. Let _int_ be _result_.[[IntegerDigitsCount]].
-        1. Let _minInt_ be _intlObj_.[[MinimumIntegerDigits]].
-        1. If _int_ &lt; _minInt_, then
-          1. Let _forwardZeros_ be the String consisting of _minInt_ - _int_ occurrences of the code unit 0x0030 (DIGIT ZERO).
+        1. Let _minIntDigits_ be _intlObj_.[[MinimumIntegerDigits]].
+        1. If _int_ &lt; _minIntDigits_, then
+          1. Let _forwardZeros_ be the String consisting of _minIntDigits_ - _int_ occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Set _string_ to the string-concatenation of _forwardZeros_ and _string_.
         1. If _sign_ is ~negative~, then
           1. If _x_ is 0, set _x_ to ~negative-zero~. Otherwise, set _x_ to -_x_.
@@ -793,8 +793,7 @@
             1. Append the Record { [[Type]]: *"unit"*, [[Value]]: _unitString_ } to _result_.
           1. Else if _partType_ is *"currencyCode"* and _numberFormat_.[[Style]] is *"currency"*, then
             1. Let _currency_ be _numberFormat_.[[Currency]].
-            1. Let _currencyString_ be _currency_.
-            1. Append the Record { [[Type]]: *"currency"*, [[Value]]: _currencyString_ } to _result_.
+            1. Append the Record { [[Type]]: *"currency"*, [[Value]]: _currency_ } to _result_.
           1. Else if _partType_ is *"currencyPrefix"* and _numberFormat_.[[Style]] is *"currency"*, then
             1. Let _currency_ be _numberFormat_.[[Currency]].
             1. Let _currencyDisplay_ be _numberFormat_.[[CurrencyDisplay]].
@@ -861,26 +860,26 @@
                 1. Use an implementation dependent algorithm to map _formattedString_ to the appropriate representation of _formattedString_ in the given numbering system.
               1. Let _decimalSepIndex_ be StringIndexOf(_formattedString_, *"."*, 0).
               1. If _decimalSepIndex_ is not ~not-found~ and _decimalSepIndex_ > 0, then
-                1. Let _int_ be the substring of _formattedString_ from 0 to _decimalSepIndex_.
-                1. Let _fraction_ be the substring of _formattedString_ from _decimalSepIndex_ + 1.
+                1. Let _intDigits_ be the substring of _formattedString_ from 0 to _decimalSepIndex_.
+                1. Let _fractionDigits_ be the substring of _formattedString_ from _decimalSepIndex_ + 1.
               1. Else,
-                1. Let _int_ be _formattedString_.
-                1. Let _fraction_ be *undefined*.
+                1. Let _intDigits_ be _formattedString_.
+                1. Let _fractionDigits_ be *undefined*.
               1. If the _numberFormat_.[[UseGrouping]] is *false*, then
-                1. Append the Record { [[Type]]: *"integer"*, [[Value]]: _int_ } to _result_.
+                1. Append the Record { [[Type]]: *"integer"*, [[Value]]: _intDigits_ } to _result_.
               1. Else,
                 1. Let _groupSepSymbol_ be the ILND String representing the grouping separator.
-                1. Let _groups_ be a List whose elements are, in left to right order, the substrings defined by ILND set of locations within the _int_, which may depend on the value of _numberFormat_.[[UseGrouping]].
+                1. Let _groups_ be a List whose elements are, in left to right order, the substrings defined by ILND set of locations within _intDigits_, which may depend on the value of _numberFormat_.[[UseGrouping]].
                 1. Assert: The number of elements in _groups_ List is greater than 0.
                 1. Repeat, while _groups_ List is not empty,
                   1. Remove the first element from _groups_ and let _intGroup_ be the value of that element.
                   1. Append the Record { [[Type]]: *"integer"*, [[Value]]: _intGroup_ } to _result_.
                   1. If _groups_ List is not empty, then
                     1. Append the Record { [[Type]]: *"group"*, [[Value]]: _groupSepSymbol_ } to _result_.
-              1. If _fraction_ is not *undefined*, then
+              1. If _fractionDigits_ is not *undefined*, then
                 1. Let _decimalSepSymbol_ be the ILND String representing the decimal separator.
                 1. Append the Record { [[Type]]: *"decimal"*, [[Value]]: _decimalSepSymbol_ } to _result_.
-                1. Append the Record { [[Type]]: *"fraction"*, [[Value]]: _fraction_ } to _result_.
+                1. Append the Record { [[Type]]: *"fraction"*, [[Value]]: _fractionDigits_ } to _result_.
             1. Else if _partType_ is *"compactSymbol"*, then
               1. Let _compactSymbol_ be an ILD string representing _exponent_ in short form, which may depend on _x_ in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a *"{compactSymbol}"* placeholder.
               1. Append the Record { [[Type]]: *"compact"*, [[Value]]: _compactSymbol_ } to _result_.
@@ -1268,10 +1267,10 @@
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each Record { [[Type]], [[Value]] } _part_ of _parts_, do
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
+          1. Let _partObj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"value"*, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _partObj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>
@@ -1918,11 +1917,11 @@
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each element _part_ of _parts_, do
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"source"*, _part_.[[Source]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
+          1. Let _partObj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"value"*, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"source"*, _part_.[[Source]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _partObj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -22,10 +22,10 @@
         1. Let _numberFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.NumberFormat.prototype%"*, « [[InitializedNumberFormat]], [[Locale]], [[LocaleData]], [[NumberingSystem]], [[Style]], [[Unit]], [[UnitDisplay]], [[Currency]], [[CurrencyDisplay]], [[CurrencySign]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[Notation]], [[CompactDisplay]], [[UseGrouping]], [[SignDisplay]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]], [[BoundFormat]] »).
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.NumberFormat%, %Intl.NumberFormat%.[[LocaleData]], _locales_, _options_, « ~coerce-options~ »).
         1. Set _options_ to _optionsResolution_.[[Options]].
-        1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
-        1. Set _numberFormat_.[[Locale]] to _r_.[[Locale]].
-        1. Set _numberFormat_.[[LocaleData]] to _r_.[[LocaleData]].
-        1. Set _numberFormat_.[[NumberingSystem]] to _r_.[[nu]].
+        1. Let _resolvedLocale_ be _optionsResolution_.[[ResolvedLocale]].
+        1. Set _numberFormat_.[[Locale]] to _resolvedLocale_.[[Locale]].
+        1. Set _numberFormat_.[[LocaleData]] to _resolvedLocale_.[[LocaleData]].
+        1. Set _numberFormat_.[[NumberingSystem]] to _resolvedLocale_.[[nu]].
         1. Perform ? SetNumberFormatUnitOptions(_numberFormat_, _options_).
         1. Let _style_ be _numberFormat_.[[Style]].
         1. Let _notation_ be ? GetOption(_options_, *"notation"*, ~string~, « *"standard"*, *"scientific"*, *"engineering"*, *"compact"* », *"standard"*).
@@ -300,13 +300,13 @@
         1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. For each row of <emu-xref href="#table-numberformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _nf_'s internal slot whose name is the Internal Slot value of the current row.
-          1. If _v_ is not *undefined*, then
+          1. Let _propertyKey_ be the Property value of the current row.
+          1. Let _value_ be the value of _nf_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If _value_ is not *undefined*, then
             1. If there is a Conversion value in the current row, then
               1. Assert: The Conversion value of the current row is ~number~.
-              1. Set _v_ to 𝔽(_v_).
-            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+              1. Set _value_ to 𝔽(_value_).
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _propertyKey_, _value_).
         1. Return _options_.
       </emu-alg>
 
@@ -440,9 +440,9 @@
           1. Set _nf_ to ? UnwrapNumberFormat(_nf_).
         1. Perform ? RequireInternalSlot(_nf_, [[InitializedNumberFormat]]).
         1. If _nf_.[[BoundFormat]] is *undefined*, then
-          1. Let _F_ be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions"></emu-xref>).
-          1. Set _F_.[[NumberFormat]] to _nf_.
-          1. Set _nf_.[[BoundFormat]] to _F_.
+          1. Let _func_ be a new built-in function object as defined in Number Format Functions (<emu-xref href="#sec-number-format-functions"></emu-xref>).
+          1. Set _func_.[[NumberFormat]] to _nf_.
+          1. Set _nf_.[[BoundFormat]] to _func_.
         1. Return _nf_.[[BoundFormat]].
       </emu-alg>
 
@@ -668,10 +668,10 @@
       <h1>Number Format Functions</h1>
 
       <p>A Number format function is an anonymous built-in function that has a [[NumberFormat]] internal slot.</p>
-      <p>When a Number format function _F_ is called with optional argument _value_, the following steps are taken:</p>
+      <p>When a Number format function _func_ is called with optional argument _value_, the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _nf_ be _F_.[[NumberFormat]].
+        1. Let _nf_ be _func_.[[NumberFormat]].
         1. Assert: _nf_ is an Object and _nf_ has an [[InitializedNumberFormat]] internal slot.
         1. If _value_ is not provided, let _value_ be *undefined*.
         1. Let _x_ be ? ToIntlMathematicalValue(_value_).
@@ -684,16 +684,16 @@
     <emu-clause id="sec-formatnumerictostring" oldids="sec-formatnumberstring" type="abstract operation">
       <h1>
         FormatNumericToString (
-          _intlObject_: an Object,
+          _intlObj_: an Object,
           _x_: a mathematical value or ~negative-zero~,
         ): a Record with fields [[RoundedNumber]] (a mathematical value or ~negative-zero~) and [[FormattedString]] (a String)
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It rounds _x_ to an Intl mathematical value according to the internal slots of _intlObject_. The [[RoundedNumber]] field contains the rounded result value and the [[FormattedString]] field contains a String value representation of that result formatted according to the internal slots of _intlObject_.</dd>
+        <dd>It rounds _x_ to an Intl mathematical value according to the internal slots of _intlObj_. The [[RoundedNumber]] field contains the rounded result value and the [[FormattedString]] field contains a String value representation of that result formatted according to the internal slots of _intlObj_.</dd>
       </dl>
       <emu-alg>
-        1. Assert: _intlObject_ has [[RoundingMode]], [[RoundingType]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[RoundingIncrement]], and [[TrailingZeroDisplay]] internal slots.
+        1. Assert: _intlObj_ has [[RoundingMode]], [[RoundingType]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[RoundingIncrement]], and [[TrailingZeroDisplay]] internal slots.
         1. If _x_ is ~negative-zero~, then
           1. Let _sign_ be ~negative~.
           1. Set _x_ to 0.
@@ -702,30 +702,30 @@
           1. If _x_ &lt; 0, let _sign_ be ~negative~; else let _sign_ be ~positive~.
           1. If _sign_ is ~negative~, then
             1. Set _x_ to -_x_.
-        1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_intlObject_.[[RoundingMode]], _sign_).
-        1. If _intlObject_.[[RoundingType]] is ~significant-digits~, then
-          1. Let _result_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
-        1. Else if _intlObject_.[[RoundingType]] is ~fraction-digits~, then
-          1. Let _result_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
+        1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_intlObj_.[[RoundingMode]], _sign_).
+        1. If _intlObj_.[[RoundingType]] is ~significant-digits~, then
+          1. Let _result_ be ToRawPrecision(_x_, _intlObj_.[[MinimumSignificantDigits]], _intlObj_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
+        1. Else if _intlObj_.[[RoundingType]] is ~fraction-digits~, then
+          1. Let _result_ be ToRawFixed(_x_, _intlObj_.[[MinimumFractionDigits]], _intlObj_.[[MaximumFractionDigits]], _intlObj_.[[RoundingIncrement]], _unsignedRoundingMode_).
         1. Else,
-          1. Let _sResult_ be ToRawPrecision(_x_, _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
-          1. Let _fResult_ be ToRawFixed(_x_, _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
-          1. If _fResult_.[[RoundingMagnitude]] &lt; _sResult_.[[RoundingMagnitude]], let _fixedIsMorePrecise_ be *true*; else let _fixedIsMorePrecise_ be *false*.
-          1. If _intlObject_.[[RoundingType]] is ~more-precision~ and _fixedIsMorePrecise_ is *true*, then
-            1. Let _result_ be _fResult_.
-          1. Else if _intlObject_.[[RoundingType]] is ~less-precision~ and _fixedIsMorePrecise_ is *false*, then
-            1. Let _result_ be _fResult_.
+          1. Let _significantResult_ be ToRawPrecision(_x_, _intlObj_.[[MinimumSignificantDigits]], _intlObj_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
+          1. Let _fractionResult_ be ToRawFixed(_x_, _intlObj_.[[MinimumFractionDigits]], _intlObj_.[[MaximumFractionDigits]], _intlObj_.[[RoundingIncrement]], _unsignedRoundingMode_).
+          1. If _fractionResult_.[[RoundingMagnitude]] &lt; _significantResult_.[[RoundingMagnitude]], let _fixedIsMorePrecise_ be *true*; else let _fixedIsMorePrecise_ be *false*.
+          1. If _intlObj_.[[RoundingType]] is ~more-precision~ and _fixedIsMorePrecise_ is *true*, then
+            1. Let _result_ be _fractionResult_.
+          1. Else if _intlObj_.[[RoundingType]] is ~less-precision~ and _fixedIsMorePrecise_ is *false*, then
+            1. Let _result_ be _fractionResult_.
           1. Else,
-            1. Let _result_ be _sResult_.
+            1. Let _result_ be _significantResult_.
         1. Set _x_ to _result_.[[RoundedNumber]].
         1. Let _string_ be _result_.[[FormattedString]].
-        1. If _intlObject_.[[TrailingZeroDisplay]] is *"stripIfInteger"* and <emu-eqn>_x_ modulo 1 = 0</emu-eqn>, then
+        1. If _intlObj_.[[TrailingZeroDisplay]] is *"stripIfInteger"* and <emu-eqn>_x_ modulo 1 = 0</emu-eqn>, then
           1. Let _i_ be StringIndexOf(_string_, *"."*, 0).
           1. If _i_ is not ~not-found~, set _string_ to the substring of _string_ from 0 to _i_.
         1. Let _int_ be _result_.[[IntegerDigitsCount]].
-        1. Let _minInteger_ be _intlObject_.[[MinimumIntegerDigits]].
-        1. If _int_ &lt; _minInteger_, then
-          1. Let _forwardZeros_ be the String consisting of _minInteger_ - _int_ occurrences of the code unit 0x0030 (DIGIT ZERO).
+        1. Let _minInt_ be _intlObj_.[[MinimumIntegerDigits]].
+        1. If _int_ &lt; _minInt_, then
+          1. Let _forwardZeros_ be the String consisting of _minInt_ - _int_ occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Set _string_ to the string-concatenation of _forwardZeros_ and _string_.
         1. If _sign_ is ~negative~, then
           1. If _x_ is 0, set _x_ to ~negative-zero~. Otherwise, set _x_ to -_x_.
@@ -748,11 +748,11 @@
       <emu-alg>
         1. Let _exponent_ be 0.
         1. If _x_ is ~not-a-number~, then
-          1. Let _n_ be an ILD String value indicating the *NaN* value.
+          1. Let _formattedString_ be an ILD String value indicating the *NaN* value.
         1. Else if _x_ is ~positive-infinity~, then
-          1. Let _n_ be an ILD String value indicating positive infinity.
+          1. Let _formattedString_ be an ILD String value indicating positive infinity.
         1. Else if _x_ is ~negative-infinity~, then
-          1. Let _n_ be an ILD String value indicating negative infinity.
+          1. Let _formattedString_ be an ILD String value indicating negative infinity.
         1. Else,
           1. If _x_ is not ~negative-zero~, then
             1. Assert: _x_ is a mathematical value.
@@ -760,53 +760,53 @@
             1. Set _exponent_ to ComputeExponent(_numberFormat_, _x_).
             1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.
           1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_).
-          1. Let _n_ be _formatNumberResult_.[[FormattedString]].
+          1. Let _formattedString_ be _formatNumberResult_.[[FormattedString]].
           1. Set _x_ to _formatNumberResult_.[[RoundedNumber]].
         1. Let _pattern_ be GetNumberFormatPattern(_numberFormat_, _x_).
         1. Let _result_ be a new empty List.
         1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. For each Record { [[Type]], [[Value]] } _patternPart_ of _patternParts_, do
-          1. Let _p_ be _patternPart_.[[Type]].
-          1. If _p_ is *"literal"*, then
+          1. Let _partType_ be _patternPart_.[[Type]].
+          1. If _partType_ is *"literal"*, then
             1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
-          1. Else if _p_ is *"number"*, then
-            1. Let _notationSubParts_ be PartitionNotationSubPattern(_numberFormat_, _x_, _n_, _exponent_).
+          1. Else if _partType_ is *"number"*, then
+            1. Let _notationSubParts_ be PartitionNotationSubPattern(_numberFormat_, _x_, _formattedString_, _exponent_).
             1. Set _result_ to the list-concatenation of _result_ and _notationSubParts_.
-          1. Else if _p_ is *"plusSign"*, then
+          1. Else if _partType_ is *"plusSign"*, then
             1. Let _plusSignSymbol_ be the ILND String representing the plus sign.
             1. Append the Record { [[Type]]: *"plusSign"*, [[Value]]: _plusSignSymbol_ } to _result_.
-          1. Else if _p_ is *"minusSign"*, then
+          1. Else if _partType_ is *"minusSign"*, then
             1. Let _minusSignSymbol_ be the ILND String representing the minus sign.
             1. Append the Record { [[Type]]: *"minusSign"*, [[Value]]: _minusSignSymbol_ } to _result_.
-          1. Else if _p_ is *"percentSign"* and _numberFormat_.[[Style]] is *"percent"*, then
+          1. Else if _partType_ is *"percentSign"* and _numberFormat_.[[Style]] is *"percent"*, then
             1. Let _percentSignSymbol_ be the ILND String representing the percent sign.
             1. Append the Record { [[Type]]: *"percentSign"*, [[Value]]: _percentSignSymbol_ } to _result_.
-          1. Else if _p_ is *"unitPrefix"* and _numberFormat_.[[Style]] is *"unit"*, then
+          1. Else if _partType_ is *"unitPrefix"* and _numberFormat_.[[Style]] is *"unit"*, then
             1. Let _unit_ be _numberFormat_.[[Unit]].
             1. Let _unitDisplay_ be _numberFormat_.[[UnitDisplay]].
-            1. Let _mu_ be an ILD String value representing _unit_ before _x_ in _unitDisplay_ form, which may depend on _x_ in languages having different plural forms.
-            1. Append the Record { [[Type]]: *"unit"*, [[Value]]: _mu_ } to _result_.
-          1. Else if _p_ is *"unitSuffix"* and _numberFormat_.[[Style]] is *"unit"*, then
+            1. Let _unitString_ be an ILD String value representing _unit_ before _x_ in _unitDisplay_ form, which may depend on _x_ in languages having different plural forms.
+            1. Append the Record { [[Type]]: *"unit"*, [[Value]]: _unitString_ } to _result_.
+          1. Else if _partType_ is *"unitSuffix"* and _numberFormat_.[[Style]] is *"unit"*, then
             1. Let _unit_ be _numberFormat_.[[Unit]].
             1. Let _unitDisplay_ be _numberFormat_.[[UnitDisplay]].
-            1. Let _mu_ be an ILD String value representing _unit_ after _x_ in _unitDisplay_ form, which may depend on _x_ in languages having different plural forms.
-            1. Append the Record { [[Type]]: *"unit"*, [[Value]]: _mu_ } to _result_.
-          1. Else if _p_ is *"currencyCode"* and _numberFormat_.[[Style]] is *"currency"*, then
+            1. Let _unitString_ be an ILD String value representing _unit_ after _x_ in _unitDisplay_ form, which may depend on _x_ in languages having different plural forms.
+            1. Append the Record { [[Type]]: *"unit"*, [[Value]]: _unitString_ } to _result_.
+          1. Else if _partType_ is *"currencyCode"* and _numberFormat_.[[Style]] is *"currency"*, then
             1. Let _currency_ be _numberFormat_.[[Currency]].
-            1. Let _cd_ be _currency_.
-            1. Append the Record { [[Type]]: *"currency"*, [[Value]]: _cd_ } to _result_.
-          1. Else if _p_ is *"currencyPrefix"* and _numberFormat_.[[Style]] is *"currency"*, then
-            1. Let _currency_ be _numberFormat_.[[Currency]].
-            1. Let _currencyDisplay_ be _numberFormat_.[[CurrencyDisplay]].
-            1. Let _cd_ be an ILD String value representing _currency_ before _x_ in _currencyDisplay_ form, which may depend on _x_ in languages having different plural forms.
-            1. Append the Record { [[Type]]: *"currency"*, [[Value]]: _cd_ } to _result_.
-          1. Else if _p_ is *"currencySuffix"* and _numberFormat_.[[Style]] is *"currency"*, then
+            1. Let _currencyString_ be _currency_.
+            1. Append the Record { [[Type]]: *"currency"*, [[Value]]: _currencyString_ } to _result_.
+          1. Else if _partType_ is *"currencyPrefix"* and _numberFormat_.[[Style]] is *"currency"*, then
             1. Let _currency_ be _numberFormat_.[[Currency]].
             1. Let _currencyDisplay_ be _numberFormat_.[[CurrencyDisplay]].
-            1. Let _cd_ be an ILD String value representing _currency_ after _x_ in _currencyDisplay_ form, which may depend on _x_ in languages having different plural forms. If the implementation does not have such a representation of _currency_, use _currency_ itself.
-            1. Append the Record { [[Type]]: *"currency"*, [[Value]]: _cd_ } to _result_.
+            1. Let _currencyString_ be an ILD String value representing _currency_ before _x_ in _currencyDisplay_ form, which may depend on _x_ in languages having different plural forms.
+            1. Append the Record { [[Type]]: *"currency"*, [[Value]]: _currencyString_ } to _result_.
+          1. Else if _partType_ is *"currencySuffix"* and _numberFormat_.[[Style]] is *"currency"*, then
+            1. Let _currency_ be _numberFormat_.[[Currency]].
+            1. Let _currencyDisplay_ be _numberFormat_.[[CurrencyDisplay]].
+            1. Let _currencyString_ be an ILD String value representing _currency_ after _x_ in _currencyDisplay_ form, which may depend on _x_ in languages having different plural forms. If the implementation does not have such a representation of _currency_, use _currency_ itself.
+            1. Append the Record { [[Type]]: *"currency"*, [[Value]]: _currencyString_ } to _result_.
           1. Else,
-            1. Let _unknown_ be an ILND String based on _x_ and _p_.
+            1. Let _unknown_ be an ILND String based on _x_ and _partType_.
             1. Append the Record { [[Type]]: *"unknown"*, [[Value]]: _unknown_ } to _result_.
         1. Return _result_.
       </emu-alg>
@@ -817,80 +817,80 @@
         PartitionNotationSubPattern (
           _numberFormat_: an Intl.NumberFormat,
           _x_: an Intl mathematical value,
-          _n_: a String,
+          _formattedString_: a String,
           _exponent_: an integer,
         ): a List of Records with fields [[Type]] (a String) and [[Value]] (a String)
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          _x_ is an Intl mathematical value after rounding is applied and _n_ is an intermediate formatted string.
+          _x_ is an Intl mathematical value after rounding is applied and _formattedString_ is an intermediate formatted string.
           It creates the corresponding parts for the number and notation according to the effective locale and the formatting options of _numberFormat_.
         </dd>
       </dl>
       <emu-alg>
         1. Let _result_ be a new empty List.
         1. If _x_ is ~not-a-number~, then
-          1. Append the Record { [[Type]]: *"nan"*, [[Value]]: _n_ } to _result_.
+          1. Append the Record { [[Type]]: *"nan"*, [[Value]]: _formattedString_ } to _result_.
         1. Else if _x_ is ~positive-infinity~ or ~negative-infinity~, then
-          1. Append the Record { [[Type]]: *"infinity"*, [[Value]]: _n_ } to _result_.
+          1. Append the Record { [[Type]]: *"infinity"*, [[Value]]: _formattedString_ } to _result_.
         1. Else,
           1. Let _notationSubPattern_ be GetNotationSubPattern(_numberFormat_, _exponent_).
           1. Let _patternParts_ be PartitionPattern(_notationSubPattern_).
           1. For each Record { [[Type]], [[Value]] } _patternPart_ of _patternParts_, do
-            1. Let _p_ be _patternPart_.[[Type]].
-            1. If _p_ is *"literal"*, then
+            1. Let _partType_ be _patternPart_.[[Type]].
+            1. If _partType_ is *"literal"*, then
               1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } to _result_.
-            1. Else if _p_ is *"number"*, then
+            1. Else if _partType_ is *"number"*, then
               1. If the _numberFormat_.[[NumberingSystem]] matches one of the values in the Numbering System column of <emu-xref href="#table-numbering-system-digits"></emu-xref> below, then
                 1. Let _digits_ be a List whose elements are the code points specified in the Digits column of the matching row in <emu-xref href="#table-numbering-system-digits"></emu-xref>.
                 1. Assert: The length of _digits_ is 10.
                 1. Let _transliterated_ be the empty String.
-                1. Let _len_ be the length of _n_.
+                1. Let _len_ be the length of _formattedString_.
                 1. Let _position_ be 0.
                 1. Repeat, while _position_ &lt; _len_,
-                  1. Let _c_ be the code unit at index _position_ within _n_.
+                  1. Let _c_ be the code unit at index _position_ within _formattedString_.
                   1. If 0x0030 ≤ _c_ ≤ 0x0039, then
                     1. NOTE: _c_ is an ASCII digit.
                     1. Let _i_ be _c_ - 0x0030.
                     1. Set _c_ to CodePointsToString(« _digits_[_i_] »).
                   1. Set _transliterated_ to the string-concatenation of _transliterated_ and _c_.
                   1. Set _position_ to _position_ + 1.
-                1. Set _n_ to _transliterated_.
+                1. Set _formattedString_ to _transliterated_.
               1. Else,
-                1. Use an implementation dependent algorithm to map _n_ to the appropriate representation of _n_ in the given numbering system.
-              1. Let _decimalSepIndex_ be StringIndexOf(_n_, *"."*, 0).
+                1. Use an implementation dependent algorithm to map _formattedString_ to the appropriate representation of _formattedString_ in the given numbering system.
+              1. Let _decimalSepIndex_ be StringIndexOf(_formattedString_, *"."*, 0).
               1. If _decimalSepIndex_ is not ~not-found~ and _decimalSepIndex_ > 0, then
-                1. Let _integer_ be the substring of _n_ from 0 to _decimalSepIndex_.
-                1. Let _fraction_ be the substring of _n_ from _decimalSepIndex_ + 1.
+                1. Let _int_ be the substring of _formattedString_ from 0 to _decimalSepIndex_.
+                1. Let _fraction_ be the substring of _formattedString_ from _decimalSepIndex_ + 1.
               1. Else,
-                1. Let _integer_ be _n_.
+                1. Let _int_ be _formattedString_.
                 1. Let _fraction_ be *undefined*.
               1. If the _numberFormat_.[[UseGrouping]] is *false*, then
-                1. Append the Record { [[Type]]: *"integer"*, [[Value]]: _integer_ } to _result_.
+                1. Append the Record { [[Type]]: *"integer"*, [[Value]]: _int_ } to _result_.
               1. Else,
                 1. Let _groupSepSymbol_ be the ILND String representing the grouping separator.
-                1. Let _groups_ be a List whose elements are, in left to right order, the substrings defined by ILND set of locations within the _integer_, which may depend on the value of _numberFormat_.[[UseGrouping]].
+                1. Let _groups_ be a List whose elements are, in left to right order, the substrings defined by ILND set of locations within the _int_, which may depend on the value of _numberFormat_.[[UseGrouping]].
                 1. Assert: The number of elements in _groups_ List is greater than 0.
                 1. Repeat, while _groups_ List is not empty,
-                  1. Remove the first element from _groups_ and let _integerGroup_ be the value of that element.
-                  1. Append the Record { [[Type]]: *"integer"*, [[Value]]: _integerGroup_ } to _result_.
+                  1. Remove the first element from _groups_ and let _intGroup_ be the value of that element.
+                  1. Append the Record { [[Type]]: *"integer"*, [[Value]]: _intGroup_ } to _result_.
                   1. If _groups_ List is not empty, then
                     1. Append the Record { [[Type]]: *"group"*, [[Value]]: _groupSepSymbol_ } to _result_.
               1. If _fraction_ is not *undefined*, then
                 1. Let _decimalSepSymbol_ be the ILND String representing the decimal separator.
                 1. Append the Record { [[Type]]: *"decimal"*, [[Value]]: _decimalSepSymbol_ } to _result_.
                 1. Append the Record { [[Type]]: *"fraction"*, [[Value]]: _fraction_ } to _result_.
-            1. Else if _p_ is *"compactSymbol"*, then
+            1. Else if _partType_ is *"compactSymbol"*, then
               1. Let _compactSymbol_ be an ILD string representing _exponent_ in short form, which may depend on _x_ in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a *"{compactSymbol}"* placeholder.
               1. Append the Record { [[Type]]: *"compact"*, [[Value]]: _compactSymbol_ } to _result_.
-            1. Else if _p_ is *"compactName"*, then
+            1. Else if _partType_ is *"compactName"*, then
               1. Let _compactName_ be an ILD string representing _exponent_ in long form, which may depend on _x_ in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a *"{compactName}"* placeholder.
               1. Append the Record { [[Type]]: *"compact"*, [[Value]]: _compactName_ } to _result_.
-            1. Else if _p_ is *"scientificSeparator"*, then
+            1. Else if _partType_ is *"scientificSeparator"*, then
               1. Let _scientificSeparator_ be the ILND String representing the exponent separator.
               1. Append the Record { [[Type]]: *"exponentSeparator"*, [[Value]]: _scientificSeparator_ } to _result_.
-            1. Else if _p_ is *"scientificExponent"*, then
+            1. Else if _partType_ is *"scientificExponent"*, then
               1. If _exponent_ &lt; 0, then
                 1. Let _minusSignSymbol_ be the ILND String representing the minus sign.
                 1. Append the Record { [[Type]]: *"exponentMinusSign"*, [[Value]]: _minusSignSymbol_ } to _result_.
@@ -898,7 +898,7 @@
               1. Let _exponentResult_ be ToRawFixed(_exponent_, 0, 0, 1, *undefined*).
               1. Append the Record { [[Type]]: *"exponentInteger"*, [[Value]]: _exponentResult_.[[FormattedString]] } to _result_.
             1. Else,
-              1. Let _unknown_ be an ILND String based on _x_ and _p_.
+              1. Let _unknown_ be an ILND String based on _x_ and _partType_.
               1. Append the Record { [[Type]]: *"unknown"*, [[Value]]: _unknown_ } to _result_.
         1. Return _result_.
       </emu-alg>
@@ -1268,10 +1268,10 @@
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each Record { [[Type]], [[Value]] } _part_ of _parts_, do
-          1. Let _O_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _O_).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>
@@ -1831,17 +1831,17 @@
         1. Let _xResult_ be PartitionNumberPattern(_numberFormat_, _x_).
         1. Let _yResult_ be PartitionNumberPattern(_numberFormat_, _y_).
         1. If FormatNumeric(_numberFormat_, _x_) is FormatNumeric(_numberFormat_, _y_), then
-          1. Let _appxResult_ be FormatApproximately(_numberFormat_, _xResult_).
-          1. For each element _r_ of _appxResult_, do
-            1. Set _r_.[[Source]] to *"shared"*.
-          1. Return _appxResult_.
+          1. Let _approximateResult_ be FormatApproximately(_numberFormat_, _xResult_).
+          1. For each element _part_ of _approximateResult_, do
+            1. Set _part_.[[Source]] to *"shared"*.
+          1. Return _approximateResult_.
         1. Let _result_ be a new empty List.
-        1. For each element _r_ of _xResult_, do
-          1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: *"startRange"* } to _result_.
+        1. For each element _part_ of _xResult_, do
+          1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Source]]: *"startRange"* } to _result_.
         1. Let _rangeSeparator_ be an ILND String value used to separate two numbers.
         1. Append the Record { [[Type]]: *"literal"*, [[Value]]: _rangeSeparator_, [[Source]]: *"shared"* } to _result_.
-        1. For each element _r_ of _yResult_, do
-          1. Append the Record { [[Type]]: _r_.[[Type]], [[Value]]: _r_.[[Value]], [[Source]]: *"endRange"* } to _result_.
+        1. For each element _part_ of _yResult_, do
+          1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Source]]: *"endRange"* } to _result_.
         1. Return CollapseNumberRange(_numberFormat_, _result_).
       </emu-alg>
     </emu-clause>
@@ -1918,11 +1918,11 @@
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each element _part_ of _parts_, do
-          1. Let _O_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"source"*, _part_.[[Source]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _O_).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"source"*, _part_.[[Source]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>

--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -22,10 +22,10 @@
         1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.PluralRules.prototype%"*, « [[InitializedPluralRules]], [[Locale]], [[Type]], [[Notation]], [[CompactDisplay]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[RoundingType]], [[RoundingIncrement]], [[RoundingMode]], [[ComputedRoundingPriority]], [[TrailingZeroDisplay]] »).
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.PluralRules%, %Intl.PluralRules%.[[LocaleData]], _locales_, _options_, « ~coerce-options~ »).
         1. Set _options_ to _optionsResolution_.[[Options]].
-        1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
-        1. Set _pluralRules_.[[Locale]] to _r_.[[Locale]].
-        1. Let _t_ be ? GetOption(_options_, *"type"*, ~string~, « *"cardinal"*, *"ordinal"* », *"cardinal"*).
-        1. Set _pluralRules_.[[Type]] to _t_.
+        1. Let _resolvedLocale_ be _optionsResolution_.[[ResolvedLocale]].
+        1. Set _pluralRules_.[[Locale]] to _resolvedLocale_.[[Locale]].
+        1. Let _type_ be ? GetOption(_options_, *"type"*, ~string~, « *"cardinal"*, *"ordinal"* », *"cardinal"*).
+        1. Set _pluralRules_.[[Type]] to _type_.
         1. Let _notation_ be ? GetOption(_options_, *"notation"*, ~string~, « *"standard"*, *"scientific"*, *"engineering"*, *"compact"* », *"standard"*).
         1. Set _pluralRules_.[[Notation]] to _notation_.
         1. Let _compactDisplay_ be ? GetOption(_options_, *"compactDisplay"*, ~string~, « *"short"*, *"long"* », *"short"*).
@@ -114,16 +114,16 @@
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _pluralCategories_ be a List of Strings containing all possible results of <emu-xref href="#sec-pluralruleselect">PluralRuleSelect</emu-xref> for the selected locale _pr_.[[Locale]], sorted according to the following order: *"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, *"other"*.
         1. For each row of <emu-xref href="#table-pluralrules-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
-          1. If _p_ is *"pluralCategories"*, then
-            1. Let _v_ be CreateArrayFromList(_pluralCategories_).
+          1. Let _propertyKey_ be the Property value of the current row.
+          1. If _propertyKey_ is *"pluralCategories"*, then
+            1. Let _value_ be CreateArrayFromList(_pluralCategories_).
           1. Else,
-            1. Let _v_ be the value of _pr_'s internal slot whose name is the Internal Slot value of the current row.
-          1. If _v_ is not *undefined*, then
+            1. Let _value_ be the value of _pr_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If _value_ is not *undefined*, then
             1. If there is a Conversion value in the current row, then
               1. Assert: The Conversion value of the current row is ~number~.
-              1. Set _v_ to 𝔽(_v_).
-            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+              1. Set _value_ to 𝔽(_value_).
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _propertyKey_, _value_).
         1. Return _options_.
       </emu-alg>
 
@@ -282,12 +282,12 @@
           _type_: *"cardinal"* or *"ordinal"*,
           _notation_: a String,
           _compactDisplay_: *"short"* or *"long"*,
-          _s_: a decimal String,
+          _decimalString_: a decimal String,
         ): *"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, or *"other"*
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The returned String characterizes the plural category of _s_ according to _type_, _notation_, and _compactDisplay_ for the corresponding _locale_.</dd>
+        <dd>The returned String characterizes the plural category of _decimalString_ according to _type_, _notation_, and _compactDisplay_ for the corresponding _locale_.</dd>
       </dl>
     </emu-clause>
 
@@ -304,22 +304,22 @@
       </dl>
       <emu-alg>
         1. If _n_ is ~not-a-number~, then
-          1. Let _s_ be an ILD String value indicating the *NaN* value.
-          1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _s_ }.
+          1. Let _formattedString_ be an ILD String value indicating the *NaN* value.
+          1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _formattedString_ }.
         1. If _n_ is ~positive-infinity~, then
-          1. Let _s_ be an ILD String value indicating positive infinity.
-          1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _s_ }.
+          1. Let _formattedString_ be an ILD String value indicating positive infinity.
+          1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _formattedString_ }.
         1. If _n_ is ~negative-infinity~, then
-          1. Let _s_ be an ILD String value indicating negative infinity.
-          1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _s_ }.
+          1. Let _formattedString_ be an ILD String value indicating negative infinity.
+          1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _formattedString_ }.
         1. Let _res_ be FormatNumericToString(_pluralRules_, _n_).
-        1. Let _s_ be _res_.[[FormattedString]].
+        1. Let _formattedString_ be _res_.[[FormattedString]].
         1. Let _locale_ be _pluralRules_.[[Locale]].
         1. Let _type_ be _pluralRules_.[[Type]].
         1. Let _notation_ be _pluralRules_.[[Notation]].
         1. Let _compactDisplay_ be _pluralRules_.[[CompactDisplay]].
-        1. Let _p_ be PluralRuleSelect(_locale_, _type_, _notation_, _compactDisplay_, _s_).
-        1. Return the Record { [[PluralCategory]]: _p_, [[FormattedString]]: _s_ }.
+        1. Let _pluralCategory_ be PluralRuleSelect(_locale_, _type_, _notation_, _compactDisplay_, _formattedString_).
+        1. Return the Record { [[PluralCategory]]: _pluralCategory_, [[FormattedString]]: _formattedString_ }.
       </emu-alg>
     </emu-clause>
 
@@ -354,15 +354,15 @@
       </dl>
       <emu-alg>
         1. If _x_ is ~not-a-number~ or _y_ is ~not-a-number~, throw a *RangeError* exception.
-        1. Let _xp_ be ResolvePlural(_pluralRules_, _x_).
-        1. Let _yp_ be ResolvePlural(_pluralRules_, _y_).
-        1. If _xp_.[[FormattedString]] is _yp_.[[FormattedString]], then
-          1. Return _xp_.[[PluralCategory]].
+        1. Let _xResult_ be ResolvePlural(_pluralRules_, _x_).
+        1. Let _yResult_ be ResolvePlural(_pluralRules_, _y_).
+        1. If _xResult_.[[FormattedString]] is _yResult_.[[FormattedString]], then
+          1. Return _xResult_.[[PluralCategory]].
         1. Let _locale_ be _pluralRules_.[[Locale]].
         1. Let _type_ be _pluralRules_.[[Type]].
         1. Let _notation_ be _pluralRules_.[[Notation]].
         1. Let _compactDisplay_ be _pluralRules_.[[CompactDisplay]].
-        1. Return PluralRuleSelectRange(_locale_, _type_, _notation_, _compactDisplay_, _xp_.[[PluralCategory]], _yp_.[[PluralCategory]]).
+        1. Return PluralRuleSelectRange(_locale_, _type_, _notation_, _compactDisplay_, _xResult_.[[PluralCategory]], _yResult_.[[PluralCategory]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -366,12 +366,12 @@
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ of _parts_, do
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
+          1. Let _partObj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"value"*, _part_.[[Value]]).
           1. If _part_.[[Unit]] is not ~empty~, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"unit"*, _part_.[[Unit]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
+            1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"unit"*, _part_.[[Unit]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _partObj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -22,11 +22,11 @@
         1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.RelativeTimeFormat.prototype%"*, « [[InitializedRelativeTimeFormat]], [[Locale]], [[LocaleData]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] »).
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.RelativeTimeFormat%, %Intl.RelativeTimeFormat%.[[LocaleData]], _locales_, _options_, « ~coerce-options~ »).
         1. Set _options_ to _optionsResolution_.[[Options]].
-        1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
-        1. Let _locale_ be _r_.[[Locale]].
+        1. Let _resolvedLocale_ be _optionsResolution_.[[ResolvedLocale]].
+        1. Let _locale_ be _resolvedLocale_.[[Locale]].
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
-        1. Set _relativeTimeFormat_.[[LocaleData]] to _r_.[[LocaleData]].
-        1. Set _relativeTimeFormat_.[[NumberingSystem]] to _r_.[[nu]].
+        1. Set _relativeTimeFormat_.[[LocaleData]] to _resolvedLocale_.[[LocaleData]].
+        1. Set _relativeTimeFormat_.[[NumberingSystem]] to _resolvedLocale_.[[nu]].
         1. Let _style_ be ? GetOption(_options_, *"style"*, ~string~, « *"long"*, *"short"*, *"narrow"* », *"long"*).
         1. Set _relativeTimeFormat_.[[Style]] to _style_.
         1. Let _numeric_ be ? GetOption(_options_, *"numeric"*, ~string~, « *"always"*, *"auto"* », *"always"*).
@@ -128,10 +128,10 @@
         1. Perform ? RequireInternalSlot(_relativeTimeFormat_, [[InitializedRelativeTimeFormat]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. For each row of <emu-xref href="#table-relativetimeformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _relativeTimeFormat_'s internal slot whose name is the Internal Slot value of the current row.
-          1. Assert: _v_ is not *undefined*.
-          1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+          1. Let _propertyKey_ be the Property value of the current row.
+          1. Let _value_ be the value of _relativeTimeFormat_'s internal slot whose name is the Internal Slot value of the current row.
+          1. Assert: _value_ is not *undefined*.
+          1. Perform ! CreateDataPropertyOrThrow(_options_, _propertyKey_, _value_).
         1. Return _options_.
       </emu-alg>
 
@@ -276,14 +276,14 @@
             1. Let _result_ be _patterns_.[[&lt;_valueString_>]].
             1. Return a List containing the Record { [[Type]]: *"literal"*, [[Value]]: _result_, [[Unit]]: ~empty~ }.
         1. If _value_ is *-0*<sub>𝔽</sub> or _value_ &lt; *-0*<sub>𝔽</sub>, then
-          1. Let _tl_ be *"past"*.
+          1. Let _tense_ be *"past"*.
         1. Else,
-          1. Let _tl_ be *"future"*.
-        1. Let _po_ be _patterns_.[[&lt;_tl_>]].
-        1. Let _fv_ be PartitionNumberPattern(_relativeTimeFormat_.[[NumberFormat]], ℝ(_value_)).
-        1. Let _pr_ be ResolvePlural(_relativeTimeFormat_.[[PluralRules]], _value_).[[PluralCategory]].
-        1. Let _pattern_ be _po_.[[&lt;_pr_>]].
-        1. Return MakePartsList(_pattern_, _unit_, _fv_).
+          1. Let _tense_ be *"future"*.
+        1. Let _tensePatterns_ be _patterns_.[[&lt;_tense_>]].
+        1. Let _formattedValue_ be PartitionNumberPattern(_relativeTimeFormat_.[[NumberFormat]], ℝ(_value_)).
+        1. Let _pluralCategory_ be ResolvePlural(_relativeTimeFormat_.[[PluralRules]], _value_).[[PluralCategory]].
+        1. Let _pattern_ be _tensePatterns_.[[&lt;_pluralCategory_>]].
+        1. Return MakePartsList(_pattern_, _unit_, _formattedValue_).
       </emu-alg>
     </emu-clause>
 
@@ -366,12 +366,12 @@
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ of _parts_, do
-          1. Let _O_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
-          1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
           1. If _part_.[[Unit]] is not ~empty~, then
-            1. Perform ! CreateDataPropertyOrThrow(_O_, *"unit"*, _part_.[[Unit]]).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _O_).
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"unit"*, _part_.[[Unit]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -23,8 +23,8 @@
         1. Let _segmenter_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.Segmenter.prototype%"*, _internalSlotsList_).
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.Segmenter%, %Intl.Segmenter%.[[LocaleData]], _locales_, _options_).
         1. Set _options_ to _optionsResolution_.[[Options]].
-        1. Let _r_ be _optionsResolution_.[[ResolvedLocale]].
-        1. Set _segmenter_.[[Locale]] to _r_.[[Locale]].
+        1. Let _resolvedLocale_ be _optionsResolution_.[[ResolvedLocale]].
+        1. Set _segmenter_.[[Locale]] to _resolvedLocale_.[[Locale]].
         1. Let _granularity_ be ? GetOption(_options_, *"granularity"*, ~string~, « *"grapheme"*, *"word"*, *"sentence"* », *"grapheme"*).
         1. Set _segmenter_.[[SegmenterGranularity]] to _granularity_.
         1. Return _segmenter_.
@@ -103,10 +103,10 @@
         1. Perform ? RequireInternalSlot(_segmenter_, [[InitializedSegmenter]]).
         1. Let _options_ be OrdinaryObjectCreate(%Object.prototype%).
         1. For each row of <emu-xref href="#table-segmenter-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _segmenter_'s internal slot whose name is the Internal Slot value of the current row.
-          1. Assert: _v_ is not *undefined*.
-          1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+          1. Let _propertyKey_ be the Property value of the current row.
+          1. Let _value_ be the value of _segmenter_'s internal slot whose name is the Internal Slot value of the current row.
+          1. Assert: _value_ is not *undefined*.
+          1. Perform ! CreateDataPropertyOrThrow(_options_, _propertyKey_, _value_).
         1. Return _options_.
       </emu-alg>
 


### PR DESCRIPTION
https://github.com/tc39/ecma262/pull/3789, https://github.com/tc39/ecma262/pull/3837

Things to note:

- I left short names for Intl types alone, e.g. `lf` and `nf` instead of `listFormat` and `numberFormat`. Not a huge fan but matches `ta` instead of `typedArray` in 262. Can be a separate cleanup if needed.
- In some cases we iterate over a table column of properties, which are are used both as a regular property key and for `[[<property>]]` substitution. The default name for this would be `propertyKey` which doesn't work as well for field access IMO so I kept those as `property`.