### PR TITLE
Two editorial fixes

### DIFF
--- a/spec/locale.html
+++ b/spec/locale.html
@@ -282,7 +282,7 @@
         1. Let _loc_ be the *this* value.
         1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
         1. Let _maximal_ be the result of the <a href="https://unicode.org/reports/tr35/#Likely_Subtags">Add Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _maximal_ to _loc_.[[Locale]].
-        1. Return ! Construct(%Intl.Locale%, _maximal_).
+        1. Return ! Construct(%Intl.Locale%, « _maximal_ »).
       </emu-alg>
     </emu-clause>
 
@@ -293,7 +293,7 @@
         1. Let _loc_ be the *this* value.
         1. Perform ? RequireInternalSlot(_loc_, [[InitializedLocale]]).
         1. Let _minimal_ be the result of the <a href="https://unicode.org/reports/tr35/#Likely_Subtags">Remove Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _minimal_ to _loc_.[[Locale]].
-        1. Return ! Construct(%Intl.Locale%, _minimal_).
+        1. Return ! Construct(%Intl.Locale%, « _minimal_ »).
       </emu-alg>
     </emu-clause>
 

--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -60,7 +60,8 @@
           1. Let _tPrefix_ be the substring of _transformExtension_ from 3.
           1. Let _tlang_ be the longest prefix of _tPrefix_ matched by the <code>tlang</code> Unicode locale nonterminal. If there is no such prefix, return *true*.
           1. Let _tlangVariants_ be GetLocaleVariants(_tlang_).
-          1. If _tlangVariants_ contains any duplicate subtags, return *false*.
+          1. If _tlangVariants_ is not *undefined*, then
+            1. If _tlangVariants_ contains any duplicate subtags, return *false*.
         1. Return *true*.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
I ran across these while researching #1056.

- Construct takes an argument list
- GetLocaleVariants can return undefined