### PR TITLE
Editorial: Update Well-Known Intrinsic Objects table to match 262

### DIFF
--- a/spec/conventions.html
+++ b/spec/conventions.html
@@ -35,58 +35,8 @@
         </thead>
         <tr>
           <td>%Intl%</td>
-          <td>`Intl`</td>
+          <td>*"Intl"*</td>
           <td>The `Intl` object (<emu-xref href="#intl-object"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%Intl.Collator%</td>
-          <td>`Intl.Collator`</td>
-          <td>The `Intl.Collator` constructor (<emu-xref href="#sec-intl-collator-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%Intl.DateTimeFormat%</td>
-          <td>`Intl.DateTimeFormat`</td>
-          <td>The `Intl.DateTimeFormat` constructor (<emu-xref href="#sec-intl-datetimeformat-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%Intl.DisplayNames%</td>
-          <td>`Intl.DisplayNames`</td>
-          <td>The `Intl.DisplayNames` constructor (<emu-xref href="#sec-intl-displaynames-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%Intl.DurationFormat%</td>
-          <td>`Intl.DurationFormat`</td>
-          <td>The `Intl.DurationFormat` constructor (<emu-xref href="#sec-intl-durationformat-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%Intl.ListFormat%</td>
-          <td>`Intl.ListFormat`</td>
-          <td>The `Intl.ListFormat` constructor (<emu-xref href="#sec-intl-listformat-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%Intl.Locale%</td>
-          <td>`Intl.Locale`</td>
-          <td>The `Intl.Locale` constructor (<emu-xref href="#sec-intl-locale-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%Intl.NumberFormat%</td>
-          <td>`Intl.NumberFormat`</td>
-          <td>The `Intl.NumberFormat` constructor (<emu-xref href="#sec-intl-numberformat-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%Intl.PluralRules%</td>
-          <td>`Intl.PluralRules`</td>
-          <td>The `Intl.PluralRules` constructor (<emu-xref href="#sec-intl-pluralrules-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%Intl.RelativeTimeFormat%</td>
-          <td>`Intl.RelativeTimeFormat`</td>
-          <td>The `Intl.RelativeTimeFormat` constructor (<emu-xref href="#sec-intl-relativetimeformat-constructor"></emu-xref>)</td>
-        </tr>
-        <tr>
-          <td>%Intl.Segmenter%</td>
-          <td>`Intl.Segmenter`</td>
-          <td>The `Intl.Segmenter` constructor (<emu-xref href="#sec-intl-segmenter-constructor"></emu-xref>)</td>
         </tr>
         <tr>
           <td>%IntlSegmentIteratorPrototype%</td>


### PR DESCRIPTION
See:

- https://github.com/tc39/ecma262/pull/2056
- https://github.com/tc39/ecma262/pull/3881

This is what remains:

<img width="1335" height="336" alt="image" src="https://github.com/user-attachments/assets/8e1f5b88-43ee-4035-8634-77d256beda39" />