### PR TITLE
Editorial: Rename len to length in aliases

### DIFF
--- a/spec/locale-sensitive-functions.html
+++ b/spec/locale-sensitive-functions.html
@@ -219,11 +219,11 @@
 
       <emu-alg>
         1. Let _array_ be ? ToObject(*this* value).
-        1. Let _len_ be ? LengthOfArrayLike(_array_).
+        1. Let _length_ be ? LengthOfArrayLike(_array_).
         1. Let _separator_ be the implementation-defined list-separator String value appropriate for the host environment's current locale (such as *", "*).
         1. Let _result_ be the empty String.
         1. Let _k_ be 0.
-        1. Repeat, while _k_ &lt; _len_,
+        1. Repeat, while _k_ &lt; _length_,
           1. If _k_ > 0, then
             1. Set _result_ to the string-concatenation of _result_ and _separator_.
           1. Let _element_ be ? Get(_array_, ! ToString(𝔽(_k_))).

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -52,9 +52,9 @@
           1. Let _localesObj_ be CreateArrayFromList(« _locales_ »).
         1. Else,
           1. Let _localesObj_ be ? ToObject(_locales_).
-        1. Let _len_ be ? LengthOfArrayLike(_localesObj_).
+        1. Let _length_ be ? LengthOfArrayLike(_localesObj_).
         1. Let _k_ be 0.
-        1. Repeat, while _k_ &lt; _len_,
+        1. Repeat, while _k_ &lt; _length_,
           1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
           1. Let _exists_ be ? HasProperty(_localesObj_, _propertyKey_).
           1. If _exists_ is *true*, then
@@ -164,20 +164,20 @@
         1. Let _k_ be 3.
         1. Repeat, while _k_ &lt; _size_,
           1. Let _e_ be StringIndexOf(_extension_, *"-"*, _k_).
-          1. If _e_ is ~not-found~, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
-          1. Let _subtag_ be the substring of _extension_ from _k_ to _k_ + _len_.
+          1. If _e_ is ~not-found~, let _length_ be _size_ - _k_; else let _length_ be _e_ - _k_.
+          1. Let _subtag_ be the substring of _extension_ from _k_ to _k_ + _length_.
           1. NOTE: A <emu-not-ref>keyword</emu-not-ref> is a sequence of subtags in which the first is a key of length 2 and any subsequent ones (if present) have length in the inclusive interval from 3 to 8, collectively constituting a value along with their medial *"-"* separators. An attribute is a single subtag with length in the inclusive interval from 3 to 8 that precedes all <emu-not-ref>keywords</emu-not-ref>.
-          1. Assert: _len_ ≥ 2.
-          1. If _keyword_ is *undefined* and _len_ ≠ 2, then
+          1. Assert: _length_ ≥ 2.
+          1. If _keyword_ is *undefined* and _length_ ≠ 2, then
             1. If _subtag_ is not an element of _attributes_, append _subtag_ to _attributes_.
-          1. Else if _len_ = 2, then
+          1. Else if _length_ = 2, then
             1. Set _keyword_ to the Record { [[Key]]: _subtag_, [[Value]]: *""* }.
             1. If _keywords_ does not contain an element whose [[Key]] is _keyword_.[[Key]], append _keyword_ to _keywords_.
           1. Else if _keyword_.[[Value]] is the empty String, then
             1. Set _keyword_.[[Value]] to _subtag_.
           1. Else,
             1. Set _keyword_.[[Value]] to the string-concatenation of _keyword_.[[Value]], *"-"*, and _subtag_.
-          1. Set _k_ to _k_ + _len_ + 1.
+          1. Set _k_ to _k_ + _length_ + 1.
         1. Return the Record { [[Attributes]]: _attributes_, [[Keywords]]: _keywords_ }.
       </emu-alg>
     </emu-clause>

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -845,9 +845,9 @@
                 1. Let _digits_ be a List whose elements are the code points specified in the Digits column of the matching row in <emu-xref href="#table-numbering-system-digits"></emu-xref>.
                 1. Assert: The length of _digits_ is 10.
                 1. Let _transliterated_ be the empty String.
-                1. Let _len_ be the length of _formattedString_.
+                1. Let _length_ be the length of _formattedString_.
                 1. Let _position_ be 0.
-                1. Repeat, while _position_ &lt; _len_,
+                1. Repeat, while _position_ &lt; _length_,
                   1. Let _c_ be the code unit at index _position_ within _formattedString_.
                   1. If 0x0030 ≤ _c_ ≤ 0x0039, then
                     1. NOTE: _c_ is an ASCII digit.

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -210,9 +210,9 @@
           1. Perform ? RequireInternalSlot(_segments_, [[SegmentsSegmenter]]).
           1. Let _segmenter_ be _segments_.[[SegmentsSegmenter]].
           1. Let _string_ be _segments_.[[SegmentsString]].
-          1. Let _len_ be the length of _string_.
+          1. Let _length_ be the length of _string_.
           1. Let _n_ be ? ToIntegerOrInfinity(_index_).
-          1. If _n_ &lt; 0 or _n_ ≥ _len_, return *undefined*.
+          1. If _n_ &lt; 0 or _n_ ≥ _length_, return *undefined*.
           1. Let _startIndex_ be FindBoundary(_segmenter_, _string_, _n_, ~before~).
           1. Let _endIndex_ be FindBoundary(_segmenter_, _string_, _n_, ~after~).
           1. Return CreateSegmentDataObject(_segmenter_, _string_, _startIndex_, _endIndex_).
@@ -289,8 +289,8 @@
           1. Let _segmenter_ be _iterator_.[[IteratingSegmenter]].
           1. Let _string_ be _iterator_.[[IteratedString]].
           1. Let _startIndex_ be _iterator_.[[IteratedStringNextSegmentCodeUnitIndex]].
-          1. Let _len_ be the length of _string_.
-          1. If _startIndex_ ≥ _len_, then
+          1. Let _length_ be the length of _string_.
+          1. If _startIndex_ ≥ _length_, then
             1. Return CreateIteratorResultObject(*undefined*, *true*).
           1. Let _endIndex_ be FindBoundary(_segmenter_, _string_, _startIndex_, ~after~).
           1. Set _iterator_.[[IteratedStringNextSegmentCodeUnitIndex]] to _endIndex_.
@@ -355,8 +355,8 @@
         <dd>The Segment Data object describes the segment within _string_ from _segmenter_ that is bounded by the indices _startIndex_ and _endIndex_.</dd>
       </dl>
       <emu-alg>
-        1. Let _len_ be the length of _string_.
-        1. Assert: _endIndex_ ≤ _len_.
+        1. Let _length_ be the length of _string_.
+        1. Assert: _endIndex_ ≤ _length_.
         1. Assert: _startIndex_ &lt; _endIndex_.
         1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _segment_ be the substring of _string_ from _startIndex_ to _endIndex_.
@@ -390,8 +390,8 @@
         <dd>It finds a segmentation boundary between two code units in _string_ in the specified _direction_ from the code unit at index _startIndex_ according to the locale and options of _segmenter_ and returns the immediately following code unit index.</dd>
       </dl>
       <emu-alg>
-        1. Let _len_ be the length of _string_.
-        1. Assert: _startIndex_ &lt; _len_.
+        1. Let _length_ be the length of _string_.
+        1. Assert: _startIndex_ &lt; _length_.
         1. Let _locale_ be _segmenter_.[[Locale]].
         1. Let _granularity_ be _segmenter_.[[SegmenterGranularity]].
         1. If _direction_ is ~before~, then
@@ -401,7 +401,7 @@
         1. Assert: _direction_ is ~after~.
         1. Search _string_ for the first segmentation boundary that follows the code unit at index _startIndex_, using locale _locale_ and text element granularity _granularity_.
         1. If a boundary is found, return the count of code units in _string_ preceding it.
-        1. Return _len_.
+        1. Return _length_.
       </emu-alg>
       <emu-note>Boundary determination is implementation-dependent, but general default algorithms are specified in <a href="https://unicode.org/reports/tr29/">Unicode Standard Annex #29</a>. It is recommended that implementations use locale-sensitive tailorings such as those provided by the Common Locale Data Repository (available at <a href="https://cldr.unicode.org">https://cldr.unicode.org</a>).</emu-note>
     </emu-clause>


### PR DESCRIPTION
Simple `sed -i 's/_len_/_length_/g' spec/*`, missed in #1075.