### PR TITLE
Undo unintentional normative change in CalendarsOfLocale

### DIFF
--- a/spec/locale.html
+++ b/spec/locale.html
@@ -635,8 +635,8 @@
         1. Let _calendarsInUse_ be a List of unique calendar types in common use for date and time formatting in _lookupRegion_, sorted by descending preference of use in _lookupRegion_. The list is empty if no calendar preference data for _lookupRegion_ is available.
         1. For each element _identifier_ of _calendarsInUse_, do
           1. Let _canonical_ be CanonicalizeUValue(*"ca"*, _identifier_).
-          1. If _identifier_ is _canonical_ and _availableCalendars_ contains _identifier_, then
-            1. Append _identifier_ to _list_.
+          1. If _availableCalendars_ contains _canonical_ and _list_ does not contain _canonical_, then
+            1. Append _canonical_ to _list_.
         1. If _list_ is empty, set _list_ to « *"gregory"* ».
         1. Return CreateArrayFromList(_list_).
       </emu-alg>


### PR DESCRIPTION
Regression from #1067. Intl.Locale.p.getCalendars should return only canonical and available calendar IDs, but should not drop non-canonical IDs.

Closes: #1084
