### PR TITLE
Meta: Bump ecmarkup to v24.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN https://tc39.es/ecma402/#sec-copyright-and-software-license",
       "dependencies": {
         "@tc39/ecma262-biblio": "=2.1.3018",
-        "ecmarkup": "^22.0.0"
+        "ecmarkup": "^24.2.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -255,6 +255,51 @@
       "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0.tgz",
       "integrity": "sha512-hu7EI+YxlEWEKrb2himbS13HNaq5mlUePASf99KeQqkiNeqiAZbKqG4w59uDcLZs8JrV3qJqS/NYib5ZMhbfTQ=="
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -292,6 +337,18 @@
       "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.3018.tgz",
       "integrity": "sha512-kWFnmj5NWeMEvZ2unIdKL8aHBqTdlUwQ+J1Eh2hgmJBxxLGvnocwpjPtx6SItOpocteHs5dblmup4hqBnpSadg==",
       "license": "SEE LICENSE IN LICENSE.md"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -338,6 +395,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -348,6 +411,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -360,6 +429,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "license": "MIT",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/chalk": {
@@ -375,6 +454,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clean-css": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
       }
     },
     "node_modules/color-convert": {
@@ -505,6 +596,89 @@
         "node": ">=8"
       }
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
     "node_modules/cssstyle": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.0.tgz",
@@ -582,6 +756,71 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -605,12 +844,13 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-22.0.0.tgz",
-      "integrity": "sha512-DMZYlRH0QEPieu+iqFfCThMdnPmMLySHepZcYEq1I7U4gMJIf3jy5Pwy8cusxmvJ732PeMeqr9b4mhY3dw0dVg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-24.2.0.tgz",
+      "integrity": "sha512-MMgmpm0p/MgjVSun8YDc5Fog7PXk55+cvR+4PjTCpHeeoPbUZjdUq//4YjF7Ek1N5S12HMiGBfDvkgtMBZDs+A==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
+        "clean-css": "^5.3.3",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
@@ -620,19 +860,22 @@
         "grammarkdown": "^3.3.2",
         "highlight.js": "11.0.1",
         "html-escape": "^1.0.2",
+        "html-minifier-terser": "^7.2.0",
         "js-yaml": "^3.13.1",
         "jsdom": "^25.0.1",
         "nwsapi": "2.2.0",
         "parse5": "^6.0.1",
         "prex": "^0.4.7",
-        "promise-debounce": "^1.0.1"
+        "promise-debounce": "^1.0.1",
+        "svgo": "^4.0.1",
+        "terser": "^5.46.1"
       },
       "bin": {
         "ecmarkup": "bin/ecmarkup.js",
         "emu-format": "bin/emu-format.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 24"
       }
     },
     "node_modules/entities": {
@@ -943,6 +1186,27 @@
       "resolved": "https://registry.npmjs.org/html-escape/-/html-escape-1.0.2.tgz",
       "integrity": "sha512-r4cqVc7QAX1/jpPsW9OJNsTTtFhcf+ZBqoA3rWOddMg/y+n6ElKfz+IGKbvV2RTeECDzyrQXa2rpo3IFFrANWg=="
     },
+    "node_modules/html-minifier-terser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "clean-css": "~5.3.2",
+        "commander": "^10.0.0",
+        "entities": "^4.4.0",
+        "param-case": "^3.0.4",
+        "relateurl": "^0.2.7",
+        "terser": "^5.15.1"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -1094,6 +1358,15 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -1108,6 +1381,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1156,17 +1435,65 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "license": "MIT"
     },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "license": "MIT"
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1229,6 +1556,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -1272,6 +1608,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -1282,6 +1627,34 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -1298,6 +1671,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/symbol-tree": {
@@ -1335,6 +1742,30 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/tldts": {
       "version": "6.1.85",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma402/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma402/",
   "dependencies": {
-    "ecmarkup": "^22.0.0",
+    "ecmarkup": "^24.2.0",
     "@tc39/ecma262-biblio": "=2.1.3018"
   }
 }

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -61,12 +61,13 @@
 
       <emu-alg>
         1. Let _dateTimeFormat_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Intl.DateTimeFormat.prototype%"*, « [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[HourCycle]], [[DateStyle]], [[TimeStyle]], [[DateTimeFormat]], [[BoundFormat]] »).
-        1. Let _hour12_ be *undefined*.
-        1. Let _modifyResolutionOptions_ be a new Abstract Closure with parameters (_options_) that captures _hour12_ and performs the following steps when called:
-          1. Set _hour12_ to _options_.[[hour12]].
+        1. Let _specialOptions_ be the Record { [[Hour12]]: *undefined* }.
+        1. Let _modifyResolutionOptions_ be a new Abstract Closure with parameters (_options_) that captures _specialOptions_ and performs the following steps when called:
+          1. Set _specialOptions_.[[Hour12]] to _options_.[[hour12]].
           1. Remove field [[hour12]] from _options_.
-          1. If _hour12_ is not *undefined*, set _options_.[[hc]] to *null*.
+          1. If _specialOptions_.[[Hour12]] is not *undefined*, set _options_.[[hc]] to *null*.
         1. Let _optionsResolution_ be ? ResolveOptions(%Intl.DateTimeFormat%, %Intl.DateTimeFormat%.[[LocaleData]], _locales_, _options_, « ~coerce-options~ », _modifyResolutionOptions_).
+        1. Let _hour12_ be _specialOptions_.[[Hour12]].
         1. Set _options_ to _optionsResolution_.[[Options]].
         1. Let _resolvedLocale_ be _optionsResolution_.[[ResolvedLocale]].
         1. Set _dateTimeFormat_.[[Locale]] to _resolvedLocale_.[[Locale]].
@@ -228,13 +229,13 @@
           [[LocaleData]].[[&lt;_locale_>]].[[hc]] must be « *null*, *"h11"*, *"h12"*, *"h23"*, *"h24"* ».
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_>]].[[hourCycle]] must be one of the String values *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
+          [[LocaleData]].[[&lt;_locale_>]].[[hourCycle]] must be one of the Strings *"h11"*, *"h12"*, *"h23"*, or *"h24"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_>]].[[hourCycle12]] must be one of the String values *"h11"* or *"h12"*.
+          [[LocaleData]].[[&lt;_locale_>]].[[hourCycle12]] must be one of the Strings *"h11"* or *"h12"*.
         </li>
         <li>
-          [[LocaleData]].[[&lt;_locale_>]].[[hourCycle24]] must be one of the String values *"h23"* or *"h24"*.
+          [[LocaleData]].[[&lt;_locale_>]].[[hourCycle24]] must be one of the Strings *"h23"* or *"h24"*.
         </li>
         <li>
           [[LocaleData]].[[&lt;_locale_>]] must have a [[formats]] field. The value of this [[formats]] field must be a Record with a [[&lt;_calendar_>]] field for each calendar value _calendar_. The value of each [[&lt;_calendar_>]] field must be a List of DateTime Format Records. Multiple Records in such a List may use the same subset of the fields as long as the corresponding values differ for at least one field. The following subsets must be available for each locale:
@@ -1096,7 +1097,7 @@
     <emu-clause id="sec-intl.datetimeformat.prototype-%symbol.tostringtag%" oldids="sec-intl.datetimeformat.prototype-@@tostringtag">
       <h1>Intl.DateTimeFormat.prototype [ %Symbol.toStringTag% ]</h1>
 
-      <p>The initial value of the %Symbol.toStringTag% property is the String value *"Intl.DateTimeFormat"*.</p>
+      <p>The initial value of the %Symbol.toStringTag% property is the String *"Intl.DateTimeFormat"*.</p>
 
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
@@ -1112,12 +1113,12 @@
     <p>Intl.DateTimeFormat instances also have several internal slots that are computed by <emu-xref href="#sec-intl-datetimeformat-constructor" title></emu-xref>:</p>
 
     <ul>
-      <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[Calendar]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeCalendarIdentifier">Unicode Calendar Identifier</a> used for formatting.</li>
-      <li>[[NumberingSystem]] is a String value representing the <a href="https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> used for formatting.</li>
-      <li>[[TimeZone]] is a String value used for formatting that is either an available named time zone identifier or an offset time zone identifier.</li>
-      <li>[[HourCycle]] is a String value indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[DateTimeFormat]] has an [[hour]] field.</li>
-      <li>[[DateStyle]], [[TimeStyle]] are each either *undefined*, or a String value with values *"full"*, *"long"*, *"medium"*, or *"short"*.</li>
+      <li>[[Locale]] is a String representing the language tag of the locale whose localization is used for formatting.</li>
+      <li>[[Calendar]] is a String representing the <a href="https://unicode.org/reports/tr35/#UnicodeCalendarIdentifier">Unicode Calendar Identifier</a> used for formatting.</li>
+      <li>[[NumberingSystem]] is a String representing the <a href="https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> used for formatting.</li>
+      <li>[[TimeZone]] is a String used for formatting that is either an available named time zone identifier or an offset time zone identifier.</li>
+      <li>[[HourCycle]] is a String indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[DateTimeFormat]] has an [[hour]] field.</li>
+      <li>[[DateStyle]], [[TimeStyle]] are each either *undefined*, *"full"*, *"long"*, *"medium"*, or *"short"*.</li>
       <li>[[DateTimeFormat]] is a DateTime Format Record.</li>
     </ul>
 
@@ -1385,13 +1386,13 @@
           1. Else if _partType_ is *"dayPeriod"*, then
             1. Assert: _format_ has a field [[dayPeriod]].
             1. Let _fieldFormat_ be _format_.[[dayPeriod]].
-            1. Let _formattedValue_ be a String value representing the day period of _localTime_ in the form given by _fieldFormat_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
+            1. Let _formattedValue_ be an ILD String representing the day period of _localTime_ in the form given by _fieldFormat_.
             1. Append the Record { [[Type]]: _partType_, [[Value]]: _formattedValue_ } to _result_.
           1. Else if _partType_ is *"timeZoneName"*, then
             1. Assert: _format_ has a field [[timeZoneName]].
             1. Let _fieldFormat_ be _format_.[[timeZoneName]].
             1. Let _value_ be _dateTimeFormat_.[[TimeZone]].
-            1. Let _formattedValue_ be a String value representing _value_ in the form given by _fieldFormat_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_. The String value may also depend on the value of the [[InDST]] field of _localTime_ if _fieldFormat_ is *"short"*, *"long"*, *"shortOffset"*, or *"longOffset"*. If the implementation does not have such a localized representation of _fieldFormat_, then use the String value of _value_ itself.
+            1. Let _formattedValue_ be an ILD String representing _value_ in the form given by _fieldFormat_. Its value may depend on the value of the [[InDST]] field of _localTime_ if _fieldFormat_ is *"short"*, *"long"*, *"shortOffset"*, or *"longOffset"*. If the implementation does not have such a localized representation of _fieldFormat_, then use _value_ itself.
             1. Append the Record { [[Type]]: _partType_, [[Value]]: _formattedValue_ } to _result_.
           1. Else if _partType_ matches a Property column of the row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, then
             1. Assert: _format_ has a field [[&lt;_partType_>]].
@@ -1415,11 +1416,11 @@
                 1. Let _ones_ be _codePoints_[_count_ - 1].
                 1. Set _formattedValue_ to CodePointsToString(« _tens_, _ones_ »).
             1. Else if _fieldFormat_ is *"narrow"*, *"short"*, or *"long"*, then
-              1. Let _formattedValue_ be a String value representing _value_ in the form given by _fieldFormat_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _partType_ is *"month"*, then the String value may also depend on whether _format_.[[day]] is present. If the implementation does not have a localized representation of _fieldFormat_, then use the String value of _value_ itself.
+              1. Let _formattedValue_ be an ILD String representing _value_ in the form given by _fieldFormat_. If _partType_ is *"month"*, then its value may depend on whether _format_ has a [[day]] field. If the implementation does not have a localized representation of _fieldFormat_, then use _value_ itself.
             1. Append the Record { [[Type]]: _partType_, [[Value]]: _formattedValue_ } to _result_.
           1. Else if _partType_ is *"ampm"*, then
             1. Let _value_ be _localTime_.[[Hour]].
-            1. If _value_ > 11, let _formattedValue_ be an ILD String value representing *"post meridiem"*; else let _formattedValue_ be an ILD String value representing *"ante meridiem"*.
+            1. If _value_ > 11, let _formattedValue_ be an ILD String representing *"post meridiem"*; else let _formattedValue_ be an ILD String representing *"ante meridiem"*.
             1. Append the Record { [[Type]]: *"dayPeriod"*, [[Value]]: _formattedValue_ } to _result_.
           1. Else if _partType_ is *"relatedYear"*, then
             1. Let _value_ be _localTime_.[[RelatedYear]].
@@ -1427,7 +1428,7 @@
             1. Append the Record { [[Type]]: *"relatedYear"*, [[Value]]: _formattedValue_ } to _result_.
           1. Else if _partType_ is *"yearName"*, then
             1. Let _value_ be _localTime_.[[YearName]].
-            1. Let _formattedValue_ be an ILD String value representing _value_.
+            1. Let _formattedValue_ be an ILD String representing _value_.
             1. Append the Record { [[Type]]: *"yearName"*, [[Value]]: _formattedValue_ } to _result_.
           1. Else,
             1. Let _unknown_ be an ILND String based on _epochNanoseconds_ and _partType_.
@@ -1452,7 +1453,7 @@
         <dd>It interprets _x_ as a time value as specified in ECMA-262, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according to the effective locale and the formatting options of _dateTimeFormat_.</dd>
       </dl>
       <emu-alg>
-        1. Let _x_ be TimeClip(_x_).
+        1. Set _x_ to TimeClip(_x_).
         1. If _x_ is *NaN*, throw a *RangeError* exception.
         1. Let _epochNanoseconds_ be ℤ(ℝ(_x_) × 10<sup>6</sup>).
         1. Let _format_ be _dateTimeFormat_.[[DateTimeFormat]].
@@ -1501,7 +1502,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"type"*, _part_.[[Type]]).
           1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"value"*, _part_.[[Value]]).
           1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _partObj_).
-          1. Increment _n_ by 1.
+          1. Set _n_ to _n_ + 1.
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -1549,8 +1550,8 @@
               1. If _localTime1_.[[Hour]] is less than 12, let _v1_ be *"am"*; else let _v1_ be *"pm"*.
               1. If _localTime2_.[[Hour]] is less than 12, let _v2_ be *"am"*; else let _v2_ be *"pm"*.
             1. Else if _fieldName_ is [[DayPeriod]], then
-              1. Let _v1_ be a String value representing the day period of _localTime1_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
-              1. Let _v2_ be a String value representing the day period of _localTime2_; the String value depends upon the implementation and the effective locale of _dateTimeFormat_.
+              1. Let _v1_ be an ILD String representing the day period of _localTime1_.
+              1. Let _v2_ be an ILD String representing the day period of _localTime2_.
             1. Else if _fieldName_ is [[FractionalSecondDigits]], then
               1. If _format_ has a [[fractionalSecondDigits]] field, then
                 1. Let _fractionalSecondDigits_ be _format_.[[fractionalSecondDigits]].
@@ -1626,7 +1627,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"value"*, _part_.[[Value]]).
           1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"source"*, _part_.[[Source]]).
           1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _partObj_).
-          1. Increment _n_ by 1.
+          1. Set _n_ to _n_ + 1.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/displaynames.html
+++ b/spec/displaynames.html
@@ -181,7 +181,7 @@
       <emu-alg>
         1. Let _displayNames_ be *this* value.
         1. Perform ? RequireInternalSlot(_displayNames_, [[InitializedDisplayNames]]).
-        1. Let _code_ be ? ToString(_code_).
+        1. Set _code_ to ? ToString(_code_).
         1. Set _code_ to ? CanonicalCodeForDisplayNames(_displayNames_.[[Type]], _code_).
         1. Let _fields_ be _displayNames_.[[Fields]].
         1. If _fields_ has a field [[&lt;_code_>]], return _fields_.[[&lt;_code_>]].

--- a/spec/durationformat.html
+++ b/spec/durationformat.html
@@ -318,7 +318,7 @@
         1. Let _record_ be ? ToDurationRecord(_duration_).
         1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
         1. Let _result_ be the empty String.
-        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ of _parts_, do
           1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
         1. Return _result_.
       </emu-alg>
@@ -336,7 +336,7 @@
         1. Let _parts_ be PartitionDurationFormatPattern(_df_, _record_).
         1. Let _result_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
-        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ of _parts_, do
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
@@ -921,18 +921,18 @@
         1. Let _strings_ be a new empty List.
         1. For each element _parts_ of _partitionedPartsList_, do
           1. Let _string_ be the empty String.
-          1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+          1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ of _parts_, do
             1. Set _string_ to the string-concatenation of _string_ and _part_.[[Value]].
           1. Append _string_ to _strings_.
         1. Let _formattedPartsList_ be CreatePartsFromList(_lf_, _strings_).
         1. Let _partitionedPartsIndex_ be 0.
         1. Let _partitionedLength_ be the number of elements in _partitionedPartsList_.
         1. Let _flattenedPartsList_ be a new empty List.
-        1. For each Record { [[Type]], [[Value]] } _listPart_ in _formattedPartsList_, do
+        1. For each Record { [[Type]], [[Value]] } _listPart_ of _formattedPartsList_, do
           1. If _listPart_.[[Type]] is *"element"*, then
             1. Assert: _partitionedPartsIndex_ &lt; _partitionedLength_.
             1. Let _parts_ be _partitionedPartsList_[_partitionedPartsIndex_].
-            1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+            1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ of _parts_, do
               1. Append _part_ to _flattenedPartsList_.
             1. Set _partitionedPartsIndex_ to _partitionedPartsIndex_ + 1.
           1. Else,

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -100,7 +100,7 @@
       <p>When the `supportedValuesOf` method is called with argument _key_ , the following steps are taken:</p>
 
       <emu-alg>
-        1. Let _key_ be ? ToString(_key_).
+        1. Set _key_ to ? ToString(_key_).
         1. If _key_ is *"calendar"*, then
           1. Let _list_ be a new empty List.
           1. For each element _identifier_ of AvailableCalendars(), do

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -295,7 +295,7 @@ Output (List of parts Records):
             1. Let _pattern_ be _listFormat_.[[Templates]][_n_].[[End]].
           1. Let _placeables_ be the Record { [[0]]: _head_, [[1]]: _parts_ }.
           1. Set _parts_ to DeconstructPattern(_pattern_, _placeables_).
-          1. Decrement _i_ by 1.
+          1. Set _i_ to _i_ - 1.
         1. Return _parts_.
       </emu-alg>
 
@@ -340,7 +340,7 @@ Output (List of parts Records):
           1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
           1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _obj_).
-          1. Increment _n_ by 1.
+          1. Set _n_ to _n_ + 1.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/locale.html
+++ b/spec/locale.html
@@ -26,9 +26,9 @@
         1. Let _locale_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Intl.Locale.prototype%"*, _internalSlotsList_).
         1. If _tag_ is not a String and _tag_ is not an Object, throw a *TypeError* exception.
         1. If _tag_ is an Object and _tag_ has an [[InitializedLocale]] internal slot, then
-          1. Let _tag_ be _tag_.[[Locale]].
+          1. Set _tag_ to _tag_.[[Locale]].
         1. Else,
-          1. Let _tag_ be ? ToString(_tag_).
+          1. Set _tag_ to ? ToString(_tag_).
         1. Set _options_ to ? CoerceOptionsToObject(_options_).
         1. If IsWellFormedLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
         1. NOTE: Because <a href="https://unicode.org/reports/tr35/#processing-languageids">LanguageId canonicalization</a> can alter _tag_ in arbitrary ways according to Alias Rules from <a href="https://github.com/unicode-org/cldr/blob/main/common/supplemental/supplementalMetadata.xml"><code>supplementalMetadata.xml</code></a>, it is necessary to perform such canonicalization before applying overrides from _options_.

--- a/spec/negotiation.html
+++ b/spec/negotiation.html
@@ -171,7 +171,7 @@
           1. If _keyword_ is *undefined* and _length_ ≠ 2, then
             1. If _subtag_ is not an element of _attributes_, append _subtag_ to _attributes_.
           1. Else if _length_ = 2, then
-            1. Set _keyword_ to the Record { [[Key]]: _subtag_, [[Value]]: *""* }.
+            1. Set _keyword_ to the Record { [[Key]]: _subtag_, [[Value]]: the empty String }.
             1. If _keywords_ does not contain an element whose [[Key]] is _keyword_.[[Key]], append _keyword_ to _keywords_.
           1. Else if _keyword_.[[Value]] is the empty String, then
             1. Set _keyword_.[[Value]] to _subtag_.
@@ -262,7 +262,7 @@
                 1. Set _supportedKeyword_ to the Record { [[Key]]: _key_, [[Value]]: _value_ }.
             1. Else if _keyLocaleData_ contains *"true"*, then
               1. Set _value_ to *"true"*.
-              1. Set _supportedKeyword_ to the Record { [[Key]]: _key_, [[Value]]: *""* }.
+              1. Set _supportedKeyword_ to the Record { [[Key]]: _key_, [[Value]]: the empty String }.
           1. Assert: _options_ has a field [[&lt;_key_>]].
           1. Let _optionsValue_ be _options_.[[&lt;_key_>]].
           1. Assert: _optionsValue_ is a String, or _optionsValue_ is either *undefined* or *null*.

--- a/spec/numberformat.html
+++ b/spec/numberformat.html
@@ -893,7 +893,7 @@
               1. If _exponent_ &lt; 0, then
                 1. Let _minusSignSymbol_ be the ILND String representing the minus sign.
                 1. Append the Record { [[Type]]: *"exponentMinusSign"*, [[Value]]: _minusSignSymbol_ } to _result_.
-                1. Let _exponent_ be -_exponent_.
+                1. Set _exponent_ to -_exponent_.
               1. Let _exponentResult_ be ToRawFixed(_exponent_, 0, 0, 1, *undefined*).
               1. Append the Record { [[Type]]: *"exponentInteger"*, [[Value]]: _exponentResult_.[[FormattedString]] } to _result_.
             1. Else,
@@ -1271,7 +1271,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"type"*, _part_.[[Type]]).
           1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"value"*, _part_.[[Value]]).
           1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _partObj_).
-          1. Increment _n_ by 1.
+          1. Set _n_ to _n_ + 1.
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -1538,7 +1538,7 @@
           1. Let _x_ = -_x_.
         1. Let _magnitude_ be floor(log10(_x_)).
         1. Let _exponent_ be ComputeExponentForMagnitude(_numberFormat_, _magnitude_).
-        1. Let _x_ be _x_ × 10<sup>-_exponent_</sup>.
+        1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.
         1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_).
         1. If _formatNumberResult_.[[RoundedNumber]] = 0, then
           1. Return _exponent_.
@@ -1922,7 +1922,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"value"*, _part_.[[Value]]).
           1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"source"*, _part_.[[Source]]).
           1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _partObj_).
-          1. Increment _n_ by 1.
+          1. Set _n_ to _n_ + 1.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -172,8 +172,8 @@
       <emu-alg>
         1. Let _relativeTimeFormat_ be the *this* value.
         1. Perform ? RequireInternalSlot(_relativeTimeFormat_, [[InitializedRelativeTimeFormat]]).
-        1. Let _value_ be ? ToNumber(_value_).
-        1. Let _unit_ be ? ToString(_unit_).
+        1. Set _value_ to ? ToNumber(_value_).
+        1. Set _unit_ to ? ToString(_unit_).
         1. Return ? FormatRelativeTime(_relativeTimeFormat_, _value_, _unit_).
       </emu-alg>
     </emu-clause>
@@ -186,8 +186,8 @@
       <emu-alg>
         1. Let _relativeTimeFormat_ be the *this* value.
         1. Perform ? RequireInternalSlot(_relativeTimeFormat_, [[InitializedRelativeTimeFormat]]).
-        1. Let _value_ be ? ToNumber(_value_).
-        1. Let _unit_ be ? ToString(_unit_).
+        1. Set _value_ to ? ToNumber(_value_).
+        1. Set _unit_ to ? ToString(_unit_).
         1. Return ? FormatRelativeTimeToParts(_relativeTimeFormat_, _value_, _unit_).
       </emu-alg>
     </emu-clause>
@@ -263,7 +263,7 @@
 
       <emu-alg>
         1. If _value_ is *NaN*, *+∞*<sub>𝔽</sub>, or *-∞*<sub>𝔽</sub>, throw a *RangeError* exception.
-        1. Let _unit_ be ? SingularRelativeTimeUnit(_unit_).
+        1. Set _unit_ to ? SingularRelativeTimeUnit(_unit_).
         1. Let _fields_ be _relativeTimeFormat_.[[LocaleData]].
         1. Let _patterns_ be _fields_.[[&lt;_unit_>]].
         1. Let _style_ be _relativeTimeFormat_.[[Style]].
@@ -372,7 +372,7 @@
           1. If _part_.[[Unit]] is not ~empty~, then
             1. Perform ! CreateDataPropertyOrThrow(_partObj_, *"unit"*, _part_.[[Unit]]).
           1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(𝔽(_n_)), _partObj_).
-          1. Increment _n_ by 1.
+          1. Set _n_ to _n_ + 1.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/segmenter.html
+++ b/spec/segmenter.html
@@ -139,7 +139,7 @@
       <emu-alg>
         1. Let _segmenter_ be the *this* value.
         1. Perform ? RequireInternalSlot(_segmenter_, [[InitializedSegmenter]]).
-        1. Let _string_ be ? ToString(_string_).
+        1. Set _string_ to ? ToString(_string_).
         1. Return CreateSegmentsObject(_segmenter_, _string_).
       </emu-alg>
     </emu-clause>
@@ -365,7 +365,7 @@
         1. Perform ! CreateDataPropertyOrThrow(_result_, *"input"*, _string_).
         1. Let _granularity_ be _segmenter_.[[SegmenterGranularity]].
         1. If _granularity_ is *"word"*, then
-          1. Let _isWordLike_ be a Boolean value indicating whether the _segment_ in _string_ is "word-like" according to locale _segmenter_.[[Locale]].
+          1. Let _isWordLike_ be a Boolean indicating whether the _segment_ in _string_ is "word-like" according to locale _segmenter_.[[Locale]].
           1. Perform ! CreateDataPropertyOrThrow(_result_, *"isWordLike"*, _isWordLike_).
         1. Return _result_.
       </emu-alg>


### PR DESCRIPTION
This should be done quickly for the localStorage schema migration of https://github.com/tc39/ecmarkup/pull/705 .