### PR TITLE
Normative: Determine getWeekInfo().firstDay using First Day Overrides

### DIFF
--- a/spec/locale.html
+++ b/spec/locale.html
@@ -676,6 +676,36 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-firstdayoverrides" type="implementation-defined abstract operation">
+      <h1>
+        FirstDayOverrides (
+          _loc_: an Intl.Locale,
+        ): an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to *7*<sub>𝔽</sub>
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>The following algorithm refers to Locale data specified in <a href="https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Patterns_Week_Elements">Unicode Technical Standard #35 Part 4 Dates, Week Elements</a> and is an implementation of the <a href="https://www.unicode.org/reports/tr35/tr35-dates.html#first-day-overrides">First Day Overrides</a> algorithm.</dd>
+      </dl>
+      <emu-alg>
+        1. If _loc_.[[FirstDayOfWeek]] is not *undefined*, then
+          1. Let _firstDay_ be WeekdayUValueToNumber(_loc_.[[FirstDayOfWeek]]).
+          1. If _firstDay_ is not *undefined*, return _firstDay_.
+        1. Let _rgExtension_ be CanonicalUnicodeSubdivision(_loc_.[[Locale]], *"rg"*).
+        1. If _rgExtension_ is not *undefined* and week data for region _rgExtension_ are available, return a value for the first day of the week based on region _rgExtension_.
+        1. If _loc_.[[Calendar]] is *"iso8601"*, return *1*<sub>𝔽</sub>.
+        1. If _loc_.[[Calendar]] is a calendar type that specifies the first day of the week, return a value for that weekday.
+        1. Let _regionSubtag_ be GetLocaleRegion(_loc_.[[Locale]]).
+        1. If _regionSubtag_ is not *undefined* and week data for region _regionSubtag_ are available, return a value for the first day of the week based on region _regionSubtag_.
+        1. Let _sdExtension_ be CanonicalUnicodeSubdivision(_loc_.[[Locale]], *"sd"*).
+        1. If _sdExtension_ is not *undefined* and week data for region _sdExtension_ are available, return a value for the first day of the week based on region _sdExtension_.
+        1. Let _maximal_ be the result of the <a href="https://unicode.org/reports/tr35/#Likely_Subtags">Add Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _maximal_ to *undefined*.
+        1. If _maximal_ is *undefined*, let _likelyRegion_ be *undefined*; else let _likelyRegion_ be GetLocaleRegion(_maximal_).
+        1. If _likelyRegion_ is not *undefined* and week data for region _likelyRegion_ are available, return a value for the first day of the week based on region _likelyRegion_.
+        1. If week data for region *"001"* are available, return a value for the first day of the week based on region *"001"*.
+        1. Return *1*<sub>𝔽</sub>.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-hourcyclesoflocale" type="implementation-defined abstract operation">
       <h1>
         HourCyclesOfLocale (
@@ -883,11 +913,9 @@
           1. Let _lookupRegion_ be _region_.
         1. Else,
           1. Let _lookupRegion_ be *"001"*.
-        1. Let _weekInfo_ be a Record whose fields are defined by <emu-xref href="#table-locale-weekinfo-record"></emu-xref>, with values based on region _lookupRegion_.
-        1. Let _firstDayString_ be _loc_.[[FirstDayOfWeek]].
-        1. If _firstDayString_ is not *undefined*, then
-          1. Let _firstDay_ be WeekdayUValueToNumber(_firstDayString_).
-          1. If _firstDay_ is not *undefined*, set _weekInfo_.[[FirstDay]] to _firstDay_.
+        1. Let _weekInfo_ be a Record whose fields are defined by <emu-xref href="#table-locale-weekinfo-record"></emu-xref>.
+        1. Set _weekInfo_.[[Weekend]] to a value based on region _lookupRegion_.
+        1. Set _weekInfo_.[[FirstDay]] to FirstDayOverrides(_loc_).
         1. Return _weekInfo_.
       </emu-alg>
 


### PR DESCRIPTION
UTS-35 specifies an algorithm, called "First Day Overrides" (https://unicode.org/reports/tr35/tr35-dates.html#First_Day_Overrides) that determines what subtags in a locale identifier should influence the determination of the first day of the week, and with what priority.

Apply the algorithm to Intl.Locale.prototype.getWeekInfo().firstDay. Before this change, the RegionPreference algorithm was applied, which ignored the `-u-ca` calendar value.

The RegionPreference algorithm continues to be applied to the determination of the weekend days, which are not affected by the choice of calendar.

Closes: #1055